### PR TITLE
Document the railway environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ npm run dev
 yarn dev
 ```
 
-Open [http://localhost:3000](http://localhost:3000) to see the result.
+Open [http://localhost:3001](http://localhost:3001) to see the result.

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --port ${PORT-3001}",
     "build": "next build",
-    "start": "next start --port ${PORT-3000}",
+    "start": "next start --port ${PORT-3001}",
     "clean": "rm -rf .next",
     "tsc": "tsc -p ."
   },

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -49,6 +49,7 @@ export const sidebarContent: ISidebarContent = [
         "procfile",
         "deploy",
       ]),
+      makePage("Environment Variables", "deployment", ["environment", "variables"]),
       makePage("Serverless", "deployment", ["vercel", "netlify"]),
       makePage("Self Hosted Server", "deployment", [
         "aws",

--- a/src/pages/deployment/environment-variables.md
+++ b/src/pages/deployment/environment-variables.md
@@ -7,7 +7,6 @@ builds and deployments.
 
 | Name                         | Description |
 |------------------------------|-------------|
-| `RAILWAY_DEPLOYMENT_URL`     | The domain specific to the current deployment, of the form `c56c8f2a83d2.up.railway.app` (not available during builds) |
 | `RAILWAY_STATIC_URL`         | The public domain, of the form `example.up.railway.app` |
 | `RAILWAY_GIT_COMMIT_SHA`     | The git [SHA](https://docs.github.com/en/github/getting-started-with-github/github-glossary#commit) of the commit that triggered the deployment. Example: d0beb8f5c55b36df7d674d55965a23b8d54ad69b |
 | `RAILWAY_GIT_AUTHOR`         | The user of the commit that triggered the deployment. Example `gschier` |

--- a/src/pages/deployment/environment-variables.md
+++ b/src/pages/deployment/environment-variables.md
@@ -8,7 +8,7 @@ builds and deployments.
 | Name                         | Description |
 |------------------------------|-------------|
 | `RAILWAY_STATIC_URL`         | The public domain, of the form `example.up.railway.app` |
-| `RAILWAY_GIT_COMMIT_SHA`     | The git [SHA](https://docs.github.com/en/github/getting-started-with-github/github-glossary#commit) of the commit that triggered the deployment. Example: d0beb8f5c55b36df7d674d55965a23b8d54ad69b |
+| `RAILWAY_GIT_COMMIT_SHA`     | The git [SHA](https://docs.github.com/en/github/getting-started-with-github/github-glossary#commit) of the commit that triggered the deployment. Example: `d0beb8f5c55b36df7d674d55965a23b8d54ad69b` |
 | `RAILWAY_GIT_AUTHOR`         | The user of the commit that triggered the deployment. Example `gschier` |
 | `RAILWAY_GIT_BRANCH`         | The branch that triggered the deployment. Example `main` |
 | `RAILWAY_GIT_REPO_NAME`      | The name of the repository that triggered the deployment. Example `myproject` |

--- a/src/pages/deployment/environment-variables.md
+++ b/src/pages/deployment/environment-variables.md
@@ -7,8 +7,8 @@ builds and deployments.
 
 | Name                         | Description |
 |------------------------------|-------------|
-| `RAILWAY_DEPLOYMENT_DOMAIN`  | The domain specific to the current deployment, of the form `c56c8f2a83d2.up.railway.app` (not available during builds) |
-| `RAILWAY_STATIC_DOMAIN`      | The public domain, of the form `example.up.railway.app` |
+| `RAILWAY_DEPLOYMENT_URL`     | The domain specific to the current deployment, of the form `c56c8f2a83d2.up.railway.app` (not available during builds) |
+| `RAILWAY_STATIC_URL`         | The public domain, of the form `example.up.railway.app` |
 | `RAILWAY_GIT_COMMIT_SHA`     | The git [SHA](https://docs.github.com/en/github/getting-started-with-github/github-glossary#commit) of the commit that triggered the deployment. Example: d0beb8f5c55b36df7d674d55965a23b8d54ad69b |
 | `RAILWAY_GIT_AUTHOR`         | The user of the commit that triggered the deployment. Example `gschier` |
 | `RAILWAY_GIT_BRANCH`         | The branch that triggered the deployment. Example `main` |

--- a/src/pages/deployment/environment-variables.md
+++ b/src/pages/deployment/environment-variables.md
@@ -1,0 +1,17 @@
+---
+title: Environment Variables
+---
+
+Railway provides the following additional system environment variables to all 
+builds and deployments.
+
+| Name                         | Description |
+|------------------------------|-------------|
+| `RAILWAY_DEPLOYMENT_DOMAIN`  | The domain specific to the current deployment, of the form `c56c8f2a83d2.up.railway.app` (not available during builds) |
+| `RAILWAY_STATIC_DOMAIN`      | The public domain, of the form `example.up.railway.app` |
+| `RAILWAY_GIT_COMMIT_SHA`     | The git [SHA](https://docs.github.com/en/github/getting-started-with-github/github-glossary#commit) of the commit that triggered the deployment. Example: d0beb8f5c55b36df7d674d55965a23b8d54ad69b |
+| `RAILWAY_GIT_AUTHOR`         | The user of the commit that triggered the deployment. Example `gschier` |
+| `RAILWAY_GIT_BRANCH`         | The branch that triggered the deployment. Example `main` |
+| `RAILWAY_GIT_REPO_NAME`      | The name of the repository that triggered the deployment. Example `myproject` |
+| `RAILWAY_GIT_REPO_OWNER`     | The name of the repository that triggered the deployment. Example `mycompany` |
+| `RAILWAY_GIT_COMMIT_MESSAGE` | The message of the commit that triggered the deployment. Example `Fixed a few bugs` |


### PR DESCRIPTION
This PR adds a new Deployments > Environment Variables doc to explain the environment variables that Railway provides to builds/deploys.

This PR _also_ changes the default port from `3000` to `3001` to prevent conflicting with other dev services.

<img width="1547" alt="image" src="https://user-images.githubusercontent.com/587576/116471638-c2304180-a829-11eb-84db-c15b0a7fba8b.png">


