### PR TITLE
Use Dockerfile to build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM node:alpine
+
+# Create app directory
+WORKDIR /usr/src/app
+
+COPY package.json yarn.lock ./
+
+# Install deps
+RUN yarn
+
+# Bundle app source
+COPY . .
+
+# Build
+RUN yarn build
+
+# Start
+CMD [ "yarn", "start" ]


### PR DESCRIPTION
Builds are not currently working because the default nodejs buildpack does not respect yarn lock files. This PR updates the docs to use a Dockerfile which does respsect yarn.lock.