### PR TITLE
Version info for Node and Python

### DIFF
--- a/src/pages/deployment/builds.md
+++ b/src/pages/deployment/builds.md
@@ -32,6 +32,16 @@ If no [Procfile](/deployment/builds#procfile) is found,
 a [web process](/deployment/builds#web-process) will be started with `npm start`
 .
 
+You can customize the node version using the [engines field](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines) of your `package.json`. For example
+
+```json
+{
+  "engines": {
+    "node": ">=0.10.3 <15"
+  }
+}
+```
+
 ### Python
 
 The [Python buildpack](https://github.com/heroku/heroku-buildpack-python)
@@ -39,6 +49,13 @@ detects if your build is Python by looking for a `requirements.txt` file. If
 found, dependencies will be installed using `pip`.
 
 The default Python version is `3.6`.
+
+You can customize the Python version by adding a `runtime.txt` file to the root of your project.
+The contents of the file should include the version. For example,
+
+```
+python-3.5.2
+```
 
 ### Go
 


### PR DESCRIPTION
Docs taken from

https://devcenter.heroku.com/articles/python-runtimes

and

https://docs.npmjs.com/cli/v7/configuring-npm/package-json#engines