### PR TITLE
(1204): Clarified Python Project Procfile Requirements

### DIFF
--- a/src/pages/deployment/builds.md
+++ b/src/pages/deployment/builds.md
@@ -48,7 +48,11 @@ The [Python buildpack](https://github.com/heroku/heroku-buildpack-python)
 detects if your build is Python by looking for a `requirements.txt` file. If
 found, dependencies will be installed using `pip`.
 
-Please include a [Procfile](/deployment/builds#procfile) in the root folder of your repository. If no [Procfile](/deployment/builds#procfile) is found, your deploy might fail to start. 
+Please include a [Procfile](/deployment/builds#procfile) in the root folder of your repository. If no [Procfile](/deployment/builds#procfile) is found, your deploy might fail to start with the following error.
+
+```
+ERROR: failed to launch: determine start command: when there is no default process a command is required
+```
 
 The default Python version is `3.6`.
 

--- a/src/pages/deployment/builds.md
+++ b/src/pages/deployment/builds.md
@@ -48,6 +48,8 @@ The [Python buildpack](https://github.com/heroku/heroku-buildpack-python)
 detects if your build is Python by looking for a `requirements.txt` file. If
 found, dependencies will be installed using `pip`.
 
+Please include a [Procfile](/deployment/builds#procfile) in the root folder of your repository. If no [Procfile](/deployment/builds#procfile) is found, your deploy might fail to start. 
+
 The default Python version is `3.6`.
 
 You can customize the Python version by adding a `runtime.txt` file to the root of your project.
@@ -92,8 +94,7 @@ process1: command
 process2: command
 ```
 
-When Railway deploys your build, all process will be started by running their
-respective command.
+When Railway deploys your build, all processes listed in the file will be started by running their respective command.
 
 _Note: some buildpacks specify a default start command_
 

--- a/src/pages/deployment/builds.md
+++ b/src/pages/deployment/builds.md
@@ -94,11 +94,10 @@ the deployment starts.
 A Procfile is in the format of
 
 ```
-process1: command
-process2: command
+process: command
 ```
 
-When Railway deploys your build, all processes listed in the file will be started by running their respective command.
+When Railway deploys your build, the process listed in the file will be started by running the respective command. Note: Railway can only execute one process per Procfile.
 
 _Note: some buildpacks specify a default start command_
 


### PR DESCRIPTION
_Say that 5 times, 5 times as fast_

Thanks to Discord user: andreawthaderp#3031 for catching this issue. Added copy to clarify the Python Procfile requirements.

Comments from the Author
- Might be good to call out that we look for `web:` in the file but I will spend some time thinking about the bigger picture of docs before including that.