### PR TITLE
Additional Install Method for Windows

### DIFF
--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -38,7 +38,7 @@ Set-ExecutionPolicy RemoteSigned -scope CurrentUser
 This installs Scoop, adds a bucket, and installs the CLI. Run it in PowerShell.
 
 ```ps1
-iwr -useb get.scoop.sh | iex; scoop bucket add cone https://github.com/Milo123459/cone; scoop install cone/railway
+iwr -useb get.scoop.sh | iex; scoop bucket add cone https://github.com/railwayapp/scoop-railway; scoop install scoop-railway/railway
 ```
 
 You can also download the [prebuilt binary directly](https://github.com/railwayapp/cli/releases/latest) or [build from source](https://github.com/railwayapp/cli#from-source).

--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -25,9 +25,9 @@ sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/insta
 
 **Windows (via Scoop)**
 
-*This should be used incase the npm method doesn't work for you.*
+Use this method if you prefer to interact with Railway using a native Windows binary.
 
-**Note:** you might need to run this command in an administrative PowerShell instance to make Scoop work.
+This commnd below requires an administrative powershell instance.
 
 ```ps1
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser

--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -27,7 +27,7 @@ sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/insta
 
 Use this method if you prefer to interact with Railway using a native Windows binary.
 
-This commnd below requires an administrative powershell instance.
+This command below requires an administrative powershell instance.
 
 ```ps1
 Set-ExecutionPolicy RemoteSigned -scope CurrentUser

--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -41,6 +41,8 @@ This installs Scoop, adds a bucket, and installs the CLI. Run it in PowerShell.
 iwr -useb get.scoop.sh | iex; scoop bucket add cone https://github.com/railwayapp/scoop-railway; scoop install scoop-railway/railway
 ```
 
+For additional documentation on Scoop, see [here](https://scoop-docs.vercel.app/)
+
 You can also download the [prebuilt binary directly](https://github.com/railwayapp/cli/releases/latest) or [build from source](https://github.com/railwayapp/cli#from-source).
 
 ## Login

--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -7,7 +7,7 @@ needing to worry about environment variables or configuration.
 
 ## Install
 
-Install with [Brew](https://brew.sh) or [NPM](https://www.npmjs.com/package/@railway/cli).
+Install with [Brew](https://brew.sh), [NPM](https://www.npmjs.com/package/@railway/cli) or [Scoop](https://scoop.sh).
 
 **Homebrew**
 
@@ -21,6 +21,24 @@ npm i -g @railway/cli
 **Shell Script**
 ```bash
 sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/install.sh)"
+```
+
+**Windows (via Scoop)**
+
+*This should be used incase the npm method doesn't work for you.*
+
+**Note:** you might need to run this command in an administrative PowerShell instance to make Scoop work.
+
+```ps1
+Set-ExecutionPolicy RemoteSigned -scope CurrentUser
+```
+
+**One-liner to install**
+
+This installs Scoop, adds a bucket, and installs the CLI. Run it in PowerShell.
+
+```ps1
+iwr -useb get.scoop.sh | iex; scoop bucket add cone https://github.com/Milo123459/cone; scoop install cone/railway
 ```
 
 You can also download the [prebuilt binary directly](https://github.com/railwayapp/cli/releases/latest) or [build from source](https://github.com/railwayapp/cli#from-source).


### PR DESCRIPTION
9/10 times the NPM way to install the CLI on windows doesn't work, so this adds a workaround I created