### PR TITLE
add copy button to code block components

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@prisma/client": "2.23.0",
     "@radix-ui/react-scroll-area": "^0.0.11",
     "@tailwindcss/typography": "^0.4.0",
+    "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.4",
     "fathom-client": "^3.1.0",
     "fuse.js": "^6.4.6",

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -8,6 +8,9 @@ import { useTheme } from "../../styles/theme";
 import { normalize } from "./normalize";
 import tw from "twin.macro";
 import { useIsMounted } from "../../hooks/useIsMounted";
+import { Icon } from "../Icon";
+import { CheckCircle, Copy } from "react-feather";
+import { useCopy } from "../../hooks/useCopy";
 
 SyntaxHighlighter.registerLanguage("javascript", javascript);
 SyntaxHighlighter.registerLanguage("js", javascript);
@@ -50,16 +53,17 @@ export const CodeBlock: React.FC<Props> = ({
   language,
 }) => {
   const isMounted = useIsMounted();
+  const [copied, copy] = useCopy();
 
   const { colorMode } = useTheme();
   const theme = colorMode === "light" ? lightCodeTheme : darkCodeTheme;
 
   const params = useMemo(() => getParams(className) as any, [className]);
 
-  const lang = useMemo(() => language ?? params.language ?? "shell", [
-    language,
-    params,
-  ]);
+  const lang = useMemo(
+    () => language ?? params.language ?? "shell",
+    [language, params],
+  );
 
   const [content] = useMemo(
     () =>
@@ -80,14 +84,25 @@ export const CodeBlock: React.FC<Props> = ({
   }
 
   return (
-    <Container>
+    <div tw="relative" className="group">
       <SyntaxHighlighter language={lang} style={theme}>
         {content}
       </SyntaxHighlighter>
-    </Container>
+      <div tw="absolute top-0 right-0 mr-1 mt-1 text-gray-300 hover:text-gray-400 hidden group-hover:flex">
+        {copied ? (
+          <div tw="p-1">
+            <Icon icon={CheckCircle} size="sm" />
+          </div>
+        ) : (
+          <button
+            tw="focus:ring-0 hover:bg-gray-200 p-1 rounded-md"
+            type="button"
+            onClick={() => copy(content)}
+          >
+            <Icon icon={Copy} size="sm" />
+          </button>
+        )}
+      </div>
+    </div>
   );
 };
-
-const Container = tw.div`
-  
-`;

--- a/src/hooks/useCopy.ts
+++ b/src/hooks/useCopy.ts
@@ -1,0 +1,23 @@
+import { useRef, useState } from "react";
+import copy from "copy-to-clipboard";
+
+export const useCopy = (): [boolean, (text: string) => void] => {
+  const [showCopied, setShowCopied] = useState(false);
+  const timeoutRef = useRef<any>(null);
+
+  const copyText = (text: string) => {
+    copy(text);
+    setShowCopied(true);
+
+    if (timeoutRef.current != null) {
+      clearTimeout(timeoutRef.current);
+    }
+
+    timeoutRef.current = setTimeout(() => {
+      setShowCopied(false);
+      timeoutRef.current = null;
+    }, 1500);
+  };
+
+  return [showCopied, copyText];
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2160,6 +2160,13 @@ convert-source-map@1.7.0, convert-source-map@^1.7.0:
   dependencies:
     safe-buffer "~5.1.1"
 
+copy-to-clipboard@^3.3.1:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/copy-to-clipboard/-/copy-to-clipboard-3.3.1.tgz#115aa1a9998ffab6196f93076ad6da3b913662ae"
+  integrity sha512-i13qo6kIHTTpCm8/Wup+0b1mVWETvu2kIMzKoK8FpkLkFxlt0znUAHcMzox+T8sPlqtZXq3CulEjQHsYiGFJUw==
+  dependencies:
+    toggle-selection "^1.0.6"
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -4852,6 +4859,11 @@ to-regex-range@^5.0.1:
   integrity sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
   dependencies:
     is-number "^7.0.0"
+
+toggle-selection@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/toggle-selection/-/toggle-selection-1.0.6.tgz#6e45b1263f2017fa0acc7d89d78b15b8bf77da32"
+  integrity sha1-bkWxJj8gF/oKzH2J14sVuL932jI=
 
 toidentifier@1.0.0:
   version "1.0.0"


### PR DESCRIPTION
I was using the docs yesterday and noticed I had to manually copy the commands which wasn't really fun. This PR adds a copy button which only shows up on hover allowing the user to copy the entire command in one click.