### PR TITLE
Update Healthcheck documentation

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -95,6 +95,7 @@ export const sidebarContent: ISidebarContent = [
       makePage("Metrics", "diagnose", ["metrics", "logs"]),
       makePage("Webhooks", "diagnose", ["webhooks", "notifcations"]),
       makePage("Project Usage", "diagnose", ["usage", "pricing"]),
+      makePage("Healthchecks", "diagnose", ["health", "healthcheck"])
     ],
   },
   {

--- a/src/pages/develop/variables.md
+++ b/src/pages/develop/variables.md
@@ -43,6 +43,7 @@ builds and deployments.
 | `RAILWAY_GIT_REPO_NAME`      | The name of the repository that triggered the deployment. Example: `myproject` |
 | `RAILWAY_GIT_REPO_OWNER`     | The name of the repository owner that triggered the deployment. Example: `mycompany` |
 | `RAILWAY_GIT_COMMIT_MESSAGE` | The message of the commit that triggered the deployment. Example: `Fixed a few bugs` |
+| `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` | The timeout length (in seconds) of healthchecks. Example: `300` |
 
 ## Templated Variables
 

--- a/src/pages/diagnose/healthchecks.md
+++ b/src/pages/diagnose/healthchecks.md
@@ -1,0 +1,18 @@
+---
+title: Healthchecks
+---
+
+Healthchecks can be used to guarantee zero-downtime deployments of your application by ensuring the new version is live and able to handle requests.
+
+
+<NextImage 
+src="https://res.cloudinary.com/railway/image/upload/v1636427657/docs/healthchecks_xov2f5.png"
+alt="Screenshot of Healthchecks"
+layout="intrinsic"
+width={967} height={694} quality={80} />
+
+First, make sure your webserver has an endpoint (e.g. `/health`) that will return a response with HTTP status code 200 when your application is live and ready. If your application needs to do some initialization on startup (running database migrations, populating cache, etc.), it's a good idea to return a non-200 status code from your endpoint until the initialization completes. 
+
+Under Deployments → Settings, input your health endpoint. Railway will wait for this endpoint to serve a 200 status code before switching traffic to your new deployment.
+
+The default timeout on healthchecks is 120 seconds - if your application fails to serve a 200 status code during this allotted time, the deploy will be marked as failed and removed. To increase the timeout, specify the `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` variable on your deployment. 

--- a/src/pages/diagnose/webhooks.md
+++ b/src/pages/diagnose/webhooks.md
@@ -57,17 +57,3 @@ Slack supports integrating directly with webhooks.
 2. Get a hooks.slack.com address for your channel (Tutorial [here](https://api.slack.com/messaging/webhooks#create_a_webhook))
 3. Open up Railway, navigate to your project. Under Deployments -> Settings -> Webhooks, paste your URL
 4. Click the checkmark to save
-
-## Project Healthchecks
-
-<NextImage 
-src="https://res.cloudinary.com/railway/image/upload/v1636427657/docs/healthchecks_xov2f5.png"
-alt="Screenshot of Healthchecks"
-layout="intrinsic"
-width={967} height={694} quality={80} />
-
-Guarantee the new version of your application is live and able to handle requests by configuring a project healthcheck.
-
-Under Deployments → Settings, once the input has a endpoint provided, Railway will ping this endpoint after a new image has been deployed but before Railway upgrades the deployment to the static url.
-
-If the healthcheck succeeds, everything proceeds as normal. If it fails after the allotted retries, we fail the deploy and tear down the container that was spun up and retains the previous deployment. A user can remove a previously configured healthcheck by setting it to null in the UI.


### PR DESCRIPTION
Moves Healthchecks to its own page under Diagnose, and updates the copy to include `RAILWAY_HEALTHCHECK_TIMEOUT_SEC`. Also allows healthchecks to show up in CMD+K

Changes:

![image](https://user-images.githubusercontent.com/16275602/145451750-30916ec5-1445-4811-8667-ea5c70115542.png)

![image](https://user-images.githubusercontent.com/16275602/145451810-df88d03d-6587-46a9-afb5-40ede21aeac2.png)
