### PR TITLE
changed the bucket for installation via scoop to reference cone inste…

### DIFF
--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -30,7 +30,7 @@ sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/insta
 Use this method if you prefer to interact with Railway using a native Windows binary.
 
 ```ps1
-scoop bucket add cone https://github.com/railwayapp/scoop-railway; scoop install scoop-railway/railway
+scoop bucket add cone https://github.com/railwayapp/scoop-railway; scoop install cone/railway
 ```
 
 For additional documentation on Scoop, see [here](https://scoop-docs.vercel.app/).

--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -30,7 +30,7 @@ sh -c "$(curl -sSL https://raw.githubusercontent.com/railwayapp/cli/master/insta
 Use this method if you prefer to interact with Railway using a native Windows binary.
 
 ```ps1
-scoop bucket add cone https://github.com/railwayapp/scoop-railway; scoop install cone/railway
+scoop bucket add railway https://github.com/railwayapp/scoop-railway; scoop install railway/railway
 ```
 
 For additional documentation on Scoop, see [here](https://scoop-docs.vercel.app/).


### PR DESCRIPTION
…ad of scoop-railway

For Windows, installing the CLI via scoop results in an error, since the railway app is added to the bucket `cone` in the docs, but the subsequent install bucket is called `scoop-railway`. Since this bucket doesn't exist, it throws an error.

Changing the install bucket to reference `cone` as that's where the repo is pointed at