### PR TITLE
Fix curl URL

### DIFF
--- a/src/pages/develop/cli.md
+++ b/src/pages/develop/cli.md
@@ -24,7 +24,7 @@ npm i -g @railway/cli
 ### Shell Script
 
 ```bash
-curl -fsSL https://railway-develop.app/install.sh | sh
+curl -fsSL https://railway.app/install.sh | sh
 ```
 
 ### Scoop


### PR DESCRIPTION
`railway-develop.app/install.sh` (from #109) gives `ECONNREFUSED`, but `railway.app` seems to work.