### PR TITLE
Document RAILWAY_ENVIRONMENT environment variable

### DIFF
--- a/src/pages/develop/variables.md
+++ b/src/pages/develop/variables.md
@@ -45,6 +45,7 @@ builds and deployments.
 | `RAILWAY_GIT_REPO_OWNER`          | The name of the repository owner that triggered the deployment. Example: `mycompany`                                                                                                                 |
 | `RAILWAY_GIT_COMMIT_MESSAGE`      | The message of the commit that triggered the deployment. Example: `Fixed a few bugs`                                                                                                                 |
 | `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` | The timeout length (in seconds) of healthchecks. Example: `300`                                                                                                                                      |
+| `RAILWAY_ENVIRONMENT`             | The railway environment for the deployment. Example: `production`                                                                                                                                    |
 
 ## Templated Variables
 


### PR DESCRIPTION
I'm running postgres backups from multiple environments in my railway project and was getting some naming collisions and needed a way to differentiate the `dev` backups from `production`, etc. I noticed this `RAILWAY_ENVIRONMENT` was provided but not documented. If this isn't meant to be public or used feel free to 🚮.