### PR TITLE
Remove duplicate build info from ruby page

### DIFF
--- a/src/pages/deploy/ruby.md
+++ b/src/pages/deploy/ruby.md
@@ -2,20 +2,6 @@
 title: Ruby Builds
 ---
 
-## Buildpacks
-
-Railway uses [Cloudnative Buildpacks](https://buildpacks.io/) to attempt to
-build and deploy with zero configuration. Currently, we support the following
-languages out of the box
-
-- NodeJS
-- Python
-- Go
-- Ruby
-- Java
-
-If you have a language that you want us to support, please don't hesitate to
-[reach out](https://discord.gg/xAm2w6g) and let us know.
 ### Ruby
 
 The [Ruby buildpack](https://github.com/heroku/heroku-buildpack-ruby) detects if


### PR DESCRIPTION
The page: https://docs.railway.app/deploy/ruby contains the first part of this page: https://docs.railway.app/deploy/builds

Ruby page starts with the same content like the builds page and can be confusing.