### PR TITLE
Fix incorrect line in variables.md

### DIFF
--- a/src/pages/develop/variables.md
+++ b/src/pages/develop/variables.md
@@ -53,8 +53,6 @@ Variables can reference other variables using the `${{ MY_VAR }}` templating
 syntax. This can help reduce duplication if you need the same value in more than
 one variable, or need to present a plugin-provided variable differently.
 
-**Note:** The above `RAILWAY_*` variables aren't yet supported in templates
-
 ### Construct "Meta" Variables
 
 If you find yourself needing the same value in more than one place, you can


### PR DESCRIPTION
Remove line stating `RAILWAY_` vars cannot be used in templates, since they now actually work in templates.