### PR TITLE
Teams Direct Line of Support

### DIFF
--- a/src/pages/reference/teams.md
+++ b/src/pages/reference/teams.md
@@ -12,7 +12,7 @@ Team plans cost $20 per seat, for more information see our [pricing page](https:
 
 Organizations can create a team by heading to the [Create Team](https://railway.app/new/team) page and entering in the required information.
 
-After the team is created, you will be prompted to enter your billing information.
+After the team creation, you will be prompted to enter the team's billing information.
 
 ## Managing Teams
 
@@ -29,3 +29,10 @@ There are two scopes for Team members
 ## Transferring Projects to Teams
 
 In the Dashboard you can click and drag projects into the team. Just click and hold the handle icon on the project on the dashboard, you will see a drag interface appear and then you can let go of the mouse click in the desired team. 
+
+## Direct Line of Support
+
+Railway creates a Discord channel for your company to speak with the development team. This is a direct line  of communication with the team for your team to share feedback, ask questions, and raise concerns with the product.
+
+With a valid payment method attached to the team, a private Discord channel on the [Railway Community Server](https://discord.gg/railway) is made. Provided you or your team members have their [Discord accounts linked](https://railway.app/discord-link) we automatically invite you to the channel. You can attach your account at any time to be invited. 
+


### PR DESCRIPTION
Added a section with the docs that explains how our automatic support onboarding behaves. Will be referenced within the product for the teams page on team creation.

