### PR TITLE
Add service flag to 'up' section

### DIFF
--- a/src/pages/reference/cli-api.md
+++ b/src/pages/reference/cli-api.md
@@ -199,6 +199,7 @@ railway up [path]
 
 - `-d`, `--detach`: Detach from cloud build/deploy logs
 - `-e`, `--environment`: Specify the environment to use
+- `-s`, `--service`: Specify the service to use (e.g., `--service my-service`)
 
 ## Variables
 


### PR DESCRIPTION
Was looking for a way to specify a service for `railway up` and had to go digging in the cli code to find the `--service` flag added in https://github.com/railwayapp/cli/pull/208/

Cheers 😄 