### PR TITLE
fix: correct GitHub auto deploy link on getting started page

### DIFF
--- a/src/pages/getting-started.md
+++ b/src/pages/getting-started.md
@@ -162,7 +162,7 @@ width={800} height={498} quality={100} />
 This will create a [deployment](deploy/railway-up) using the current project and
 environment. Click the returned link to see the build and deploy logs.
 
-For projects based off of a GitHub repo like a starter, [auto deploys](deploy/github-triggers) are automatically enabled. Commits on the main branch trigger a redeploy. You can also enable ephemeral deploy environments for PRs made in GitHub Repos.
+For projects based off of a GitHub repo like a starter, [auto deploys](deploy/deployments#deploy-triggers) are automatically enabled. Commits on the main branch trigger a redeploy. You can also enable ephemeral deploy environments for PRs made in GitHub Repos.
 
 After your deployment completes, you can see your new deployment live at the deployment's URL. If you added To-Dos while developing locally, you should see them on your deployment live. In a proper project, you would enable multiple environments to isolate your production environment.
 


### PR DESCRIPTION
Resolves railwayapp/docs#126.  Attempts to fix an issue introduced in cfdca78
where the GitHub auto deploy leads to a 404.

This seems like the correct place to link to, however
there is no exact equivalent page.