### PR TITLE
Update outdated timeout on healthchecks

### DIFF
--- a/src/pages/diagnose/healthchecks.md
+++ b/src/pages/diagnose/healthchecks.md
@@ -14,7 +14,7 @@ First, make sure your webserver has an endpoint (e.g. `/health`) that will retur
 
 Under Service → Settings, input your health endpoint. Railway will wait for this endpoint to serve a 200 status code before switching traffic to your new deployment.
 
-The default timeout on healthchecks is 120 seconds - if your application fails to serve a 200 status code during this allotted time, the deploy will be marked as failed and removed. To increase the timeout, specify the `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` variable on your deployment.
+The default timeout on healthchecks is 300 seconds - if your application fails to serve a 200 status code during this allotted time, the deploy will be marked as failed and removed. To increase the timeout, specify the `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` variable on your deployment.
 
 ## Debugging
 


### PR DESCRIPTION
The docs seem to reference an outdated value that is much higher now which is also depicted in the second image.