### PR TITLE
Remove the Beta banner for Config as Code

### DIFF
--- a/src/pages/deploy/config-as-code.md
+++ b/src/pages/deploy/config-as-code.md
@@ -2,8 +2,6 @@
 title: Config as Code
 ---
 
-<PriorityBoardingBanner />
-
 Railway supports defining the configuration for a single deployment in a file
 alongside your code. By default, we will look for a `railway.toml` or
 `railway.json` file. Everything in the build and deploy sections of the service


### PR DESCRIPTION
Title is self explanatory. 

Before we GA this feature: we wanna thank all of the brave souls who put their projects on the line to test this feature. We wouldn't have gotten here without you.

