### PR TITLE
Feedback + Doppler + Plan Update

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -92,6 +92,7 @@ export const sidebarContent: ISidebarContent = [
         "gcp",
         "azure",
         "digital ocean",
+        "doppler",
       ]),
       makePage("Config as Code", "deploy", ["CaC", "IaC", "service", "config"]),
     ],

--- a/src/pages/databases/mysql.md
+++ b/src/pages/databases/mysql.md
@@ -23,3 +23,7 @@ like.
 ## Image
 
 The MySQL database service uses the [mysql:8](https://hub.docker.com/_/mysql) docker image.
+
+## Changing Variables
+
+At the moment it is not possible to change the variables for the MySQL database service. 

--- a/src/pages/deploy/exposing-your-app.md
+++ b/src/pages/deploy/exposing-your-app.md
@@ -63,25 +63,21 @@ If proxying is not enabled, Cloudflare will not associate the domain with your R
 ERR_TOO_MANY_REDIRECTS
 ```
 
-### Redirecting a Root Domain from Google Domains
+### Redirecting a Root Domain Workarounds
 
-Some domain registrars don't fully support CNAME records like Google Domains. As a result - when you add an `@` record for a CNAME, Google Domains won't link it to the Railway service.
+Some domain registrars don't fully support CNAME records. As a result - when you add an `@` record for a CNAME, the domain registrar will create an invalid `A` record.
 
-**Workaround 1 - Root Domain Forwarding**
+Registrars that are known to not fully support CNAME records for the root domain include:
+- Freenom
+- GoDaddy
+- Ionos
 
-In Google Domains, you can create a record to forward your domain root to the Railway service. You can do this by creating a CNAME in the Custom Records section pointing to www to `yourapp.yourrailwayproject.com`
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1631917785/docs/gd-redirect_vhit07.png"
-alt="Screenshot of Custom Domain"
-layout="responsive"
-width={1116} height={411} quality={80} />
-
-Then, under the Synthetic Records section, you can configure a Subdomain forward - enter `@` in the subdomain and then `www.yourdomain.com` under the Destination URL entry.
-
-Keep in mind, if Google's domain forwarding service is down, so is access to your service via that domain.
-
-**Workaround 2 - Cloudflare Proxy**
+**Workaround 1 - Cloudflare Proxy**
 
 You may also configure Cloudflare proxying for your domain to redirect your domain.
 
 After a custom domain is added to the Railway service follow [the instructions listed on Cloudflare's documentation to configure the proxy.](https://support.cloudflare.com/hc/en-us/articles/205893698-Configure-Cloudflare-and-Heroku-over-HTTPS)
+
+**Workaround 2 - Changing your Domain's Nameservers**
+
+You can also change your domain's nameservers to point to Cloudflare's nameservers. This will allow you to use a CNAME record for the root domain. Follow the instructions listed on Cloudflare's documentation to [change your nameservers.](https://developers.cloudflare.com/dns/zone-setups/full-setup/setup/)

--- a/src/pages/deploy/integrations.md
+++ b/src/pages/deploy/integrations.md
@@ -63,3 +63,10 @@ Railway uses GitHub to source account or organizational repos provided the Railw
 ### Railway Deployment Checks
 
 GitHub Commits have a status check to indicate the status of the Railway build. This applies for both PRs and all commits that auto deploy to Railway.
+
+## Secrets Management
+
+It's common for developers to store secrets in environment variables. However, this can be a security risk if you accidentally commit your secrets to a public repository. To avoid this, you can use a secrets management tool to store your secrets in a secure location. Railway supports Doppler as a secrets management tool. You can use Doppler to manage your Railway environment variables using the Railway Integration that Doppler provides.
+### Doppler 
+
+You can get instructions on how to use Doppler with Railway on the [Doppler Docs](https://docs.doppler.com/docs/railway).

--- a/src/pages/reference/plans.md
+++ b/src/pages/reference/plans.md
@@ -14,7 +14,7 @@ Starter plans also have an execution limit, users get 500 execution hours per mo
 
 If you have one service, it will deplete the 500-hour reserve at a normal rate. If you have two services, the timer will also deplete at a normal rate.
 
-Once you have run out of hours for that month, your deployment will be suspended until the next month, were you have to manually restart it.
+Once you have run out of hours for that month, your deployment will be suspended until the next month, where you have to manually restart it.
 
 **Tier Offering**
 
@@ -27,6 +27,9 @@ Once you have run out of hours for that month, your deployment will be suspended
 - Project deploys are stood down if credit limit OR execution hour limit is reached
 - Plugin connection strings are changed then hidden when usage is reached _(your data is not deleted)_
 - Need to redeploy projects after the new monthly credit is applied to your account
+- Max 5 members per project
+- Max 3 concurrent deploys per user
+-- If another deploy is attempted, Railway will remove the oldest deploy. This is intended as an anti-spam measure. If you need more concurrent deploys, please upgrade to the Developer plan.
 
 ## Developer Plan Offering
 

--- a/src/pages/reference/plans.md
+++ b/src/pages/reference/plans.md
@@ -124,3 +124,5 @@ With that current arrangement, their app will stay up for ~21 days.
 Successful and crashed deployments will continue to consume execution hours unless they are manually removed.
 
 This is because a crashed deployment continues to occupy deployment space, even if it doesn't use any compute resources.
+
+In order to save on execution hours, you will need to remove all running deploys and databases. Railway doesn't automatically sleep your applications.

--- a/yarn.lock
+++ b/yarn.lock
@@ -1913,9 +1913,9 @@ camelize@^1.0.0:
   integrity sha1-FkpUg+Yw+kMh5a8HAg5TGDGyYJs=
 
 caniuse-lite@^1.0.30001196, caniuse-lite@^1.0.30001202, caniuse-lite@^1.0.30001208, caniuse-lite@^1.0.30001219, caniuse-lite@^1.0.30001228:
-  version "1.0.30001312"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001312.tgz"
-  integrity sha512-Wiz1Psk2MEK0pX3rUzWaunLTZzqS2JYZFzNKqAiJGiuxIjRPLgV6+VDPOg6lQOUxmDwhTlh198JsTTi8Hzw6aQ==
+  version "1.0.30001447"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001447.tgz"
+  integrity sha512-bdKU1BQDPeEXe9A39xJnGtY0uRq/z5osrnXUw0TcK+EYno45Y+U7QU9HhHEyzvMDffpYadFXi3idnSNkcwLkTw==
 
 ccount@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
## What's In This PR

- Adds a reference and a tag to Doppler's Railway integration
- Fixes an outdated workaround to Google Domain's synthetic records
- Adds reference to the Deploy limit for Free Plans
- Adds a sentence on how Railway doesn't sleep workloads.

Small amount of content, but necessary. Thanks to our anonymous feedback submitters. 