### PR TITLE
Clarification on proxyability of subdomains - Cloudflare

### DIFF
--- a/src/pages/deploy/exposing-your-app.md
+++ b/src/pages/deploy/exposing-your-app.md
@@ -57,11 +57,13 @@ alt="Screenshot of Custom Domain"
 layout="responsive"
 width={1205} height={901} quality={80} />
 
-If proxying is not enabled, Cloudflare will not associate the domain with your Railway project with the following error.
+If proxying is not enabled, Cloudflare will not associate the domain with your Railway project with the following error.  
 
 ```
 ERR_TOO_MANY_REDIRECTS
 ```
+
+Also note that if proxying is enabled, you can NOT use a domain deeper than a first level subdomain without Cloudflare's Advanced Certificate Manager. For example, anything falling under \*.yourdomain.com can be proxied through Cloudflare without issue, however if you have a custom domain under \*.subdomain.yourdomain.com, you MUST disable Cloudflare Proxying and set the CNAME record to DNS Only (the grey cloud), unless you have Cloudflare's Advanced Certificate Manager. 
 
 ### Redirecting a Root Domain Workarounds
 


### PR DESCRIPTION
Certain other platforms enable proxying through Cloudflare on all custom domains regardless (as far as I'm aware) how deep the subdomain goes by default for users using Cloudflare as their Cloudflare for SaaS account handles the SSL issuance and Cloudflare applies that certificate, enabling proxying for those subdomains. Railway doesn't seem to be using Cloudflare for SaaS, thus users cannot use any custom domain deeper than a first level subdomain (like *.sub.domain.com) without paying for Cloudflare's Advanced Certificate Manager feature on their accounts. 

This adds clarification on what users should do if they want to use anything deeper than a first level subdomain on their free Cloudflare accounts without paying for Cloudflare's Advanced Certificate Manager feature.