### PR TITLE
update brew docs

### DIFF
--- a/src/docs/develop/cli.md
+++ b/src/docs/develop/cli.md
@@ -39,7 +39,6 @@ curl -fsSL cli.new | sh
 ```bash
 brew install railway
 ```
-*Note: This will install 2.x.x, we are working on restoring installs on Brew.*
 
 ### Scoop (Windows)
 


### PR DESCRIPTION
remove 2.x.x warning