### PR TITLE
refactor to a semantic typesense search

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "migrate:status": "prisma migrate status"
   },
   "dependencies": {
+    "@babel/runtime": "^7.21.0",
     "@nanostores/react": "^0.4.1",
     "@next/env": "^13.2.1",
     "@prisma/client": "4.10.1",
@@ -24,7 +25,6 @@
     "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.4",
     "fathom-client": "^3.1.0",
-    "fuse.js": "^6.4.6",
     "nanostores": "^0.7.4",
     "next": "13.2.1",
     "next-contentlayer": "^0.3.0",
@@ -43,6 +43,7 @@
     "theme-custom-properties": "^1.0.0",
     "tinykeys": "1.4.0",
     "twin.macro": "^3.1.0",
+    "typesense": "^1.5.3",
     "uuid": "^9.0.0"
   },
   "devDependencies": {

--- a/src/layouts/Page.tsx
+++ b/src/layouts/Page.tsx
@@ -1,6 +1,5 @@
 import { useStore } from "@nanostores/react";
-import Fuse from "fuse.js";
-import React, { PropsWithChildren, useEffect, useMemo } from "react";
+import React, { PropsWithChildren, useEffect } from "react";
 import tinykeys from "tinykeys";
 import "twin.macro";
 import { Modal } from "../components/Modal";
@@ -8,7 +7,6 @@ import { MobileNav, Nav } from "../components/Nav";
 import { SearchModal } from "../components/Search";
 import { Props as SEOProps, SEO } from "../components/SEO";
 import { Sidebar } from "../components/Sidebar";
-import { sidebarContent } from "../data/sidebar";
 import { Background } from "../pages";
 import { searchStore } from "../store";
 
@@ -29,16 +27,6 @@ export const Page: React.FC<PropsWithChildren<Props>> = props => {
 
     return () => unsubscribe();
   }, [isSearchOpen]);
-
-  const fuse = useMemo(() => {
-    const pages = sidebarContent.map(section => section.pages).flat();
-    const fuse = new Fuse(pages, {
-      keys: ["title", "tags", "category"],
-      includeScore: true,
-    });
-
-    return fuse;
-  }, [sidebarContent]);
 
   return (
     <>
@@ -65,7 +53,7 @@ export const Page: React.FC<PropsWithChildren<Props>> = props => {
         isOpen={isSearchOpen}
         onClose={() => searchStore.set(false)}
       >
-        <SearchModal fuse={fuse} closeModal={() => searchStore.set(false)} />
+        <SearchModal closeModal={() => searchStore.set(false)} />
       </Modal>
     </>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -84,7 +84,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.2.tgz#dacafadfc6d7654c3051a66d6fe55b6cb2f2a0b3"
   integrity sha512-URpaIJQwEkEC2T9Kn+Ai6Xe/02iNaVCuT/PtoRz3GPVJVDpPd7mLo+VddTbhCRU9TXqW5mSrQfXZyi8kDKOVpQ==
 
-"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.3.1":
+"@babel/runtime@^7.12.5", "@babel/runtime@^7.13.10", "@babel/runtime@^7.16.3", "@babel/runtime@^7.21.0", "@babel/runtime@^7.3.1":
   version "7.21.0"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.21.0.tgz#5b55c9d394e5fcf304909a8b00c07dc217b56673"
   integrity sha512-xwII0//EObnq89Ji5AKYQaRYiW/nZ3llSv29d49IuxPhKbtJoLP+9QUUZ4nVragQVtaVGeZrpB+ZtG/Pdy/POw==
@@ -2217,6 +2217,13 @@ autoprefixer@^10.2.5:
     picocolors "^1.0.0"
     postcss-value-parser "^4.2.0"
 
+axios@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
+
 babel-plugin-macros@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz#9ef6dc74deb934b4db344dc973ee851d148c50c1"
@@ -2835,6 +2842,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+follow-redirects@^1.14.8:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.2.tgz#b460864144ba63f2681096f274c4e57026da2c13"
+  integrity sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==
+
 format@^0.2.0:
   version "0.2.2"
   resolved "https://registry.yarnpkg.com/format/-/format-0.2.2.tgz#d6170107e9efdc4ed30c9dc39016df942b5cb58b"
@@ -2866,11 +2878,6 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
-
-fuse.js@^6.4.6:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/fuse.js/-/fuse.js-6.6.2.tgz#fe463fed4b98c0226ac3da2856a415576dc9a111"
-  integrity sha512-cJaJkxCCxC8qIIcPBF9yGxY0W/tVZS3uEISDxhYIdtk8OL93pe+6Zj7LjCqVV4dzbqcriOZ+kQ/NE4RXZHsIGA==
 
 get-caller-file@^2.0.5:
   version "2.0.5"
@@ -3330,6 +3337,11 @@ lodash@^4.17.11:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
+
+loglevel@^1.8.0:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.8.1.tgz#5c621f83d5b48c54ae93b6156353f555963377b4"
+  integrity sha512-tCRIJM51SHjAayKwC+QAg8hT8vg6z7GSgLJKGvzuPb1Wc+hLzqtuVLxp6/HzSPOozuK+8ErAhy7U/sVzw8Dgfg==
 
 long@^4.0.0:
   version "4.0.0"
@@ -5040,6 +5052,14 @@ typescript@^4.2.4:
   version "4.9.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
   integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
+typesense@^1.5.3:
+  version "1.5.3"
+  resolved "https://registry.yarnpkg.com/typesense/-/typesense-1.5.3.tgz#85aa8fcd6904ca5532bde5df0e83a38621de2026"
+  integrity sha512-eLHBP6AHex04tT+q/a7Uc+dFjIuoKTRpvlsNJwVTyedh4n0qnJxbfoLJBCxzhhZn5eITjEK0oWvVZ5byc3E+Ww==
+  dependencies:
+    axios "^0.26.0"
+    loglevel "^1.8.0"
 
 unified@^10.0.0, unified@^10.1.2:
   version "10.1.2"


### PR DESCRIPTION
- Removes fuse.js in favor of typesense, a flexible semantic search engine
- Typesense instance is currently hosted @ [docs-search-index.fly.dev](docs-search-index.fly.dev)