### PR TITLE
feat(content): Explain how to fix common errors

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,7 @@ const nextConfig = withContentlayer({
       "railway.app",
       "res.cloudinary.com",
       "devicons.railway.app",
+      "i.imgur.com",
     ],
   },
   async redirects() {

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -122,6 +122,23 @@ export const sidebarContent: ISidebarContent = [
     ],
   },
   {
+    title: "Troubleshoot",
+    pages: [
+      makePage("Fixing Common Errors", "troubleshoot", [
+        "error",
+        "errors",
+        "railway error",
+        "railway errors",
+        "application error",
+        "failed to respond",
+        "application failed to respond",
+        "503",
+        "service unavailable",
+        "503 service unavailable",
+      ]),
+    ],
+  },
+  {
     title: "Reference",
     pages: [
       makePage("Pricing", "reference", ["pricing"]),

--- a/src/docs/troubleshoot/fixing-common-errors.md
+++ b/src/docs/troubleshoot/fixing-common-errors.md
@@ -1,0 +1,102 @@
+---
+title: Fixing Common Errors
+---
+
+{/**
+This page holds descriptions and solutions to common errors users may face
+when deploying to Railway.
+
+When adding a new error/section, please keep in mind that content on this
+page should be as detailed as possible, and link out to relevant docs when
+necessary. We want to be consistent and complete. When in doubt, try to
+stick to this formula:
+
+    - Error as section title (`## Some Error`)
+        - A description of the error. Explain to users what error this is (add
+          a screenshot if applicable), why this happens, and what causes it.
+        - How to solve the error (`## Solution`). Solutions may have sections
+          underneath it for language/framework/stack-specific solutions, e.g.:
+            - Python
+            - Go
+            - ...
+*/}
+
+When deploying to Railway, you may encounter some errors that prevent your
+application from working. These are descriptions and solutions to errors that
+users commonly encounter.
+
+## Application Error: This application failed to respond
+
+After deploying your application, you encounter this screen when accessing
+your application's domain:
+
+<Image src="https://i.imgur.com/4WDZHHE.png"
+alt="Screenshot of application failed to respond error"
+width={729} height={675}
+quality={80} />
+
+This error occurs when Railway is unable to connect to your application.
+
+Railway needs to know how to communicate with your application. When you
+deploy and expose a web application on Railway, we expect your web server
+to be available at host `0.0.0.0` and a port that we provide in the form
+of a `PORT` variable. The `PORT` variable is automatically injected by
+Railway into your application's environment.
+
+Thus, your web server must listen on host `0.0.0.0` and the port that
+Railway provides in the `PORT` environment variable.
+
+### Solution
+
+To fix this, start your application's server using:
+
+* Host = `0.0.0.0`,
+* Port = Value of the `PORT` environment variable provided by Railway.
+
+<Banner variant="info">
+Alternatively, you can set a custom `PORT` service variable in your
+Railway environment to tell Railway that your application is available
+at the port you specified. For more information, check out
+[Defining Variables](/develop/variables#defining-variables).
+**This approach is not recommended**.
+</Banner>
+
+#### Node/Express
+
+Make your application listen on `0.0.0.0` and `PORT`:
+
+```javascript
+// Use PORT provided in environment or default to 3000
+var port = process.env.PORT || 3000;
+
+// Listen on `port` and 0.0.0.0
+app.listen(port, '0.0.0.0', function () {
+  // ...
+});
+```
+
+#### Python/Gunicorn
+
+`gunicorn` listens on `0.0.0.0` and the `PORT` environment variable by default.
+There is no additional configuration necessary.
+
+If you are running into this error on `gunicorn`, try creating a
+[Procfile](/deploy/builds#procfiles) in your project's root directory and set
+the host and port explicitly:
+
+* **Django**
+    ```sh
+    # Procfile
+    web: python manage.py migrate && \
+         python manage.py collectstatic --noinput && \
+         gunicorn --bind=0.0.0.0:$PORT $YOUR_APP.wsgi
+    ```
+
+* **Flask**
+    ```sh
+    # Procfile
+    web: gunicorn --bind=0.0.0.0:$PORT $YOUR_APP:app
+    ```
+
+For more information about Procfiles, check out
+[Builds -> Procfiles](/deploy/builds#procfiles).


### PR DESCRIPTION
This PR:
* Creates a new "Troubleshoot" section in the Railway docs
* Add a "Fixing Common Errors" section underneath it
* Add instructions for how to fix "Application Error: This application failed to respond" (i.e. wrong host/port)

## Motivation

In the Discord community, there are a lot of help requests on post-deployment issues. They're commonly user errors unrelated to Railway, and a subset of them are Railway errors unrelated to the platform - for those issues, the problem & solution is always the same.

I believe that a section dedicated to troubleshooting will streamline how Railway provides support. It eases the burden of community helpers & the Railway team by allowing them to link out to highly-specific help sections in the docs without "manually" responding individually to each help request.

More generally, this new section will hold content for troubleshooting common errors users may encounter. Apart from the newly-added page ("Fixing Common Errors"), we can add tech-specific pages into this section that explains common specific gotchas (such as logs not appearing in Python because they're buffered & not flushed to stdout):

```
Troubleshoot
  |> Fixing Common Errors
  |> Python
  |> Node
  |> ...
```

## Rendered Changes

![rw-troubleshoot-fixing-common-errors](https://user-images.githubusercontent.com/24421625/229022229-e5ce8a6b-1381-4742-a2aa-75347e6c7335.png)
