### PR TITLE
Prepare for search indexing

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,4 @@
 module.exports = {
-  siteUrl: "https://docs.railway.app/",
+  siteUrl: process.env.RAILWAY_STATIC_URL ?? "https://docs.railway.app/",
   generateRobotsTxt: true,
 };

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,7 @@
+const RAILWAY_STATIC_URL = process.env.RAILWAY_STATIC_URL;
 module.exports = {
-  siteUrl: process.env.RAILWAY_STATIC_URL ?? "https://docs.railway.app/",
+  siteUrl: RAILWAY_STATIC_URL
+    ? `https://${RAILWAY_STATIC_URL}`
+    : "https://docs.railway.app/",
   generateRobotsTxt: true,
 };

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@prisma/client": "4.10.1",
     "@radix-ui/react-scroll-area": "^1.0.2",
     "@tailwindcss/typography": "^0.5.9",
+    "classnames": "^2.3.2",
     "contentlayer": "^0.3.0",
     "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.4",

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import tw from "twin.macro";
 import { sidebarContent } from "../data/sidebar";
 import { Link } from "./Link";
 import { Logo } from "./Logo";
+import { ISidebarSection } from "@/types";
 import { ScrollArea } from "./ScrollArea";
 import { Search } from "./Search";
 import { ThemeSwitcher } from "./ThemeSwitcher";
@@ -57,12 +58,20 @@ const SidebarContent: React.FC = () => {
   const isCurrentPage = (pageSlug: string) =>
     (prefixedSlug ?? pathname) === pageSlug;
 
+  const isCurrentSection = (section: ISidebarSection) =>
+    section.pages.some(p => isCurrentPage(p.slug));
+
   return (
     <>
       {sidebarContent.map((section, i) => (
         <React.Fragment key={i}>
           {section.title != null && (
-            <h5 tw="px-4 my-2 text-foreground text-sm font-bold">
+            <h5
+              tw="px-4 my-2 text-foreground text-sm font-bold"
+              className={classNames(
+                isCurrentSection(section) && "current-section",
+              )}
+            >
               {section.title}
             </h5>
           )}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -1,3 +1,4 @@
+import classNames from "classnames";
 import { useRouter } from "next/router";
 import React, { useMemo } from "react";
 import tw from "twin.macro";
@@ -53,6 +54,9 @@ const SidebarContent: React.FC = () => {
     [slug],
   );
 
+  const isCurrentPage = (pageSlug: string) =>
+    (prefixedSlug ?? pathname) === pageSlug;
+
   return (
     <>
       {sidebarContent.map((section, i) => (
@@ -68,12 +72,13 @@ const SidebarContent: React.FC = () => {
               <li key={page.slug}>
                 <Link
                   href={page.slug}
+                  className={classNames(isCurrentPage(page.slug) && `current`)}
                   css={[
                     tw`text-gray-700 text-sm`,
                     tw`block px-4 py-2`,
                     tw`hover:bg-gray-100 hover:text-foreground`,
                     tw`focus:outline-none focus:bg-pink-100`,
-                    (prefixedSlug ?? pathname) === page.slug &&
+                    isCurrentPage(page.slug) &&
                       tw`bg-pink-100 text-pink-900 hover:bg-pink-100 border-r-2 border-pink-500`,
                   ]}
                 >

--- a/src/layouts/DocsLayout.tsx
+++ b/src/layouts/DocsLayout.tsx
@@ -74,9 +74,10 @@ export const DocsLayout: React.FC<PropsWithChildren<Props>> = ({
       />
       <div tw="max-w-full">
         <div tw="flex-auto prose dark:prose-invert">
-          <h1>{frontMatter.title}</h1>
-
-          <div className="docs-content">{children}</div>
+          <div className="docs-content">
+            <h1>{frontMatter.title}</h1>
+            {children}
+          </div>
         </div>
 
         <Feedback topic={frontMatter.title} />

--- a/yarn.lock
+++ b/yarn.lock
@@ -2401,6 +2401,11 @@ chownr@^1.1.1:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-1.1.4.tgz#6fc9d7b42d32a583596337666e7d08084da2cc6b"
   integrity sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==
 
+classnames@^2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/classnames/-/classnames-2.3.2.tgz#351d813bf0137fcc6a76a16b88208d2560a0d924"
+  integrity sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==
+
 client-only@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/client-only/-/client-only-0.0.1.tgz#38bba5d403c41ab150bff64a95c85013cf73bca1"


### PR DESCRIPTION
This PR prepares the docs for indexing by:
* Adding structure around docs content (`div.docs-content` now holds all page _content_ incld. title)
* Placing a `current-section` class on the active sidebar topic, for indexer to know about the full document hierarchy
* Enabling dynamic URLs in sitemap gen based on `RAILWAY_STATIC_URL` (for PR environments where it's not always `docs.railway.app`)

This is strictly an internal change with no material (content/ui/etc.) impact.