### PR TITLE
Add "Build Search Index" job to GH Actions

### DIFF
--- a/.github/workflows/build-search-index.yml
+++ b/.github/workflows/build-search-index.yml
@@ -1,0 +1,24 @@
+name: Build Search Index
+
+on:
+  workflow_dispatch:
+    # Manually hit button. Ideally this should be triggered automatically,
+    # after a build/deploy step, but it's not worth it to make a custom build
+    # right now.
+
+jobs:
+  build-index:
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@master
+      - name: Scrape and index docs
+        env:
+          HOST_URL: ${{ secrets.MEILISEARCH_HOST_URL }}
+          API_KEY: ${{ secrets.MEILISEARCH_WRITE_API_KEY }}
+          CONFIG_FILE_PATH: ${{ github.workspace }}/meilisearch-docs-scraper.config.json
+        run: |
+          docker run -t --rm \
+            -e MEILISEARCH_HOST_URL=$HOST_URL \
+            -e MEILISEARCH_API_KEY=$API_KEY \
+            -v $CONFIG_FILE_PATH:/docs-scraper/config.json \
+            getmeili/docs-scraper:latest pipenv run ./docs_scraper config.json

--- a/meilisearch-docs-scraper.config.json
+++ b/meilisearch-docs-scraper.config.json
@@ -1,0 +1,34 @@
+{
+  "index_uid": "docs_railway_app_production",
+  "stop_urls": [
+    "https://docs.railway.app/",
+    "https://docs.railway.app/getting-started"
+  ],
+  "sitemap_urls": [
+    "https://docs.railway.app/sitemap.xml"
+  ],
+  "js_render": false,
+  "scrape_start_urls": false,
+  "selectors": {
+    "lvl0": {
+      "selector": ".sidebar .current-section",
+      "global": true,
+      "default": "Railway Documentation"
+    },
+    "lvl1": ".docs-content h1",
+    "lvl2": ".docs-content h2",
+    "lvl3": ".docs-content h3",
+    "lvl4": ".docs-content h4",
+    "text": ".docs-content p, .docs-content li, .docs-content a"
+  },
+  "strip_chars": " .,;:#",
+  "custom_settings": {
+    "synonyms": {
+      "postgres": ["postgresql"],
+      "postgresql": ["postgres"],
+      "api": ["graphql", "gql"],
+      "graphql": ["gql", "api"],
+      "gql": ["graphql", "api"]
+    }
+  }
+}


### PR DESCRIPTION
This creates a manually-triggerable GHA job that uses [meilisearch/docs-scraper](https://github.com/meilisearch/docs-scraper) to scrape+index `docs.railway.app`. The index is shipped to a meilisearch cloud instance for now.