### PR TITLE
fix(search): Use ubuntu-latest in Build Search Index action

### DIFF
--- a/.github/workflows/build-search-index.yml
+++ b/.github/workflows/build-search-index.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build-index:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
       - name: Scrape and index docs


### PR DESCRIPTION
`1804` is deprecated: https://github.com/actions/runner-images/issues/6002.