### PR TITLE
feat(content): Refresh Develop -> CLI content

### DIFF
--- a/src/docs/develop/cli.md
+++ b/src/docs/develop/cli.md
@@ -7,84 +7,122 @@ alt="GIF of the CLI in Action"
 layout="intrinsic"
 width={800} height={468} quality={100} />
 
-The Railway command line interface (CLI) connects your code to your Railway project from the command line.
+The Railway Command Line Interface (CLI) lets you interact with your
+Railway project from the command line, allowing you to:
 
-The Railway CLI allows you to
+- Create new Railway projects from the Terminal
+- Link a local project directory to an existing Railway project
+- Run services locally using environment variables from your Railway project
+- And more!
 
-- Create new Railway projects from the terminal
-- Link to an existing Railway project
-- Pull down environment variables to run a service locally
-- Open an interactive shell to a database within a project
+## Installation
 
-## Install
+The Railway CLI can be installed via:
 
-Install with [Brew](https://brew.sh), [NPM](https://www.npmjs.com/package/@railway/cli), Shell Script, or [Scoop](https://scoop.sh).
+- [Homebrew](https://brew.sh) for macOS
+- [npm](https://www.npmjs.com/package/@railway/cli) for macOS, Linux, and Windows
+- [Scoop](https://scoop.sh) for Windows as a native `.exe` binary
+- Direct Shell Script
+- Downloading pre-built binaries
+- Building from source
 
-### NPM (Linux, macOS, Windows)
+### Homebrew (macOS)
 
-```bash
-npm i -g @railway/cli
-```
-
-You need to have => 16.x version of [Node.js](https://nodejs.org/en/) installed.
-
-### Shell Script (Linux, macOS, Windows: Git Bash)
-
-```bash
-curl -fsSL cli.new | sh
-```
-
-### Homebrew (Linux, macOS)
+In a Terminal, enter the following command:
 
 ```bash
 brew install railway
 ```
 
+### npm (macOS, Linux, Windows)
+
+In a Terminal, enter the following command:
+
+```bash
+npm i -g @railway/cli
+```
+
+This requires version =>16 of [Node.js](https://nodejs.org/en/).
+
+### Shell Script (macOS, Linux, Windows)
+
+In a Terminal, enter the following command:
+
+```bash
+bash <(curl -fsSL cli.new)
+```
+
+On Windows, you should use [Windows Subsystem for Linux](https://learn.microsoft.com/en-us/windows/wsl/install)
+with a Bash shell.
+
 ### Scoop (Windows)
 
-Use this method if you prefer to interact with Railway using a native Windows binary. In a PowerShell terminal enter the following command:
+In a PowerShell terminal, enter the following command:
 
 ```ps1
 scoop install railway
 ```
 
-For additional documentation on Scoop, see [here](https://scoop.sh/).
+This installs a native Windows binary (`.exe`). To learn more about Scoop,
+see [https://scoop.sh/](https://scoop.sh/).
 
-### Source
+### Pre-built Binaries
 
-You can also download the [prebuilt binary directly](https://github.com/railwayapp/cli/releases/latest) or [build from source](https://github.com/railwayapp/cli#from-source).
+We publish [pre-built binaries](https://github.com/railwayapp/cli/releases/latest)
+on our [GitHub repository](https://github.com/railwayapp/cli) that you can
+download and use directly.
+
+### From Source
+
+The Railway CLI is an open source project on [GitHub](https://github.com/railwayapp/cli).
+You can build a binary [from source](https://github.com/railwayapp/cli#from-source)
+if you wish.
 
 ## Authentication
 
-### Interactive Login
-
-Login to your Railway account. This command opens a browser tab which authenticates into an existing Railway session.
+Before you can use the Railway CLI, you must authenticate the CLI to your Railway account:
 
 ```bash
 railway login
 ```
 
-If there are any issues with browser-based login you can use the `--browserless` flag to authenticate.
+This command opens a new tab in your default browser to the [https://railway.app](https://railway.app)
+authentication page. Follow the instructions to complete the authentication process.
 
-This will print a URL and a pairing code to the terminal which you can use to authenticate (useful for SSH sessions).
+### Manual Login
 
+You can also authenticate manually using a Pairing Code. This can be useful if
+you're authenticating the CLI inside an environment without a browser (e.g. SSH
+sessions).
+
+Use the `--browserless` flag to authenticate manually:
+
+```bash
+railway login --browserless
+```
+
+This will print a URL and a Pairing Code to the Terminal, which you can use to
+authenticate your CLI session. Follow the instructions to complete the authentication
+process.
 
 ### Project Tokens
 
-You can use Project Tokens to authenticate in cases where user input/interaction is not possible, such as in CI/CD pipelines.
+You can use [Project Tokens](/deploy/integrations#project-tokens) to authenticate
+in cases where user input/interaction is not possible, such as in CI/CD pipelines.
 
-Project tokens allow the CLI to access all the environment variables associated
+Project Tokens allow the CLI to access all the environment variables associated
 with a specific project and environment. Use the token by setting the
 `RAILWAY_TOKEN` environment variable and then running `railway <command>`.
 
 ```bash
 RAILWAY_TOKEN=XXXX railway run
 ```
+
 ## Usage
 
 ### Link to a Project
 
-Associate a project and environment with your current directory
+To associate a project and environment with your current directory:
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1631917786/docs/railway-link_juslvt.png"
 alt="Screenshot of Railway"
@@ -95,8 +133,9 @@ width={389} height={116} quality={80} />
 # Link to a project
 railway link
 ```
-Prompts you to select a team, project, and environment to associate with your current directory. Any future commands will be run against this project and environment.
 
+This prompts you to select a team, project, and environment to associate with
+your current directory. Any future commands will be run against this project and environment.
 
 ### Create a Project
 
@@ -106,8 +145,7 @@ Create a new project directly from the command line.
 # Create a new project
 railway init
 ```
-Prompts you to name your project and select a team to create the project in.
-
+This prompts you to name your project and select a team to create the project in.
 
 ### Local Development
 
@@ -136,7 +174,8 @@ railway shell
 
 ### Environments
 
-Projects might have multiple environments, but by default the CLI links to the `production` environment. You can change the linked environment with the `environment` command.
+Projects might have multiple environments, but by default the CLI links to the `production` environment.
+You can change the linked environment with the `environment` command.
 
 ```bash
 # Change the linked environment
@@ -180,31 +219,31 @@ Our CLI is open source. Contribute to the development of the Railway CLI by open
 
 ## CLI v3 Changes
 
-The Railway CLI recently underwent a rewrite to improve the user experience and make it easier to maintain. The biggest change is that the new v3 CLI will use the new [Public API](/reference/public-api/) rather than undocumented routes.
+The Railway CLI recently underwent a rewrite to improve the user and developer experience.
+The biggest change is that the new v3 CLI will use the new [Public API](/reference/public-api/).
 
 The new CLI is written in Rust and is currently available via all release channels.
 
 ### What's New?
 
-- The new CLI is written in Rust and is much faster than the previous version
-- The new CLI has interactive search for services + projects to link to
-- The new CLI now displays information about your data in cleaner, more readable tables
-- The new CLI has additional flags such as `--json` to output data in JSON format for scripting
+- Written in Rust; much faster than previous versions
+- Interactive search for services + projects when linking
+- Tabular displays for cleaner data visualization
 - New commands:
+    - `railway service` for linking to a project's service
+    - `railway domain` for generating a service domain
 
-  - `railway service` helper command to link to a project's service
-  - `railway add` now allows you to provision multiple database types at once
-  - `railway domain` now will generate a service domain
-  - `railway logs` now opens a direct websocket connection to the logs API and will stream logs in real time
+### What's Improved?
 
-- Added the `--json` flag to output data in JSON format for scripting
-- CLI commands now allow you to explicitly specify the project and environment you want to use via flags.
+- Commands now allow you to specify the project and environment via flags
+- Additional flags such as `--json` to output data in JSON format for scripting
+- `railway add` now allows you to provision multiple database types at once
+- `railway logs` now opens a direct websocket connection to the logs API and will stream logs in real time
 
-### Deprecations
+### What's Deprecated?
 
-- Undocumented commands such as `railway protect` and `railway shell` will be removed. We are re-thinking how we want to handle these features and will be adding them back in the future
+- `railway build` has been removed
+- `railway protect` has been removed
 - `railway variables add` will no longer give you the option to add a secret. We are re-thinking how we want to handle the secret flow within the CLI now since the addition of [Shared Variables](/develop/variables#shared-variables)
-- `railway down` will be sunset as we are looking into better ways to handle deployments and scaling
-- `railway version` is being removed in favor of using `-V` or `--version` flags.
-- `railway build` is being removed in favor of using `railway variables` to output a local .env file (also the name was confusing)
+- `railway version` has been removed, in favor of using `-V` or `--version` flags
 - `railway init` will no longer allow you to deploy a new Project with a Template. We have since re-worked the flow and realized that the Template deploy flow is best served in the dashboard


### PR DESCRIPTION
This PR does a slight refresh of https://docs.railway.app/develop/cli to re-organize information in a reader-friendlier way, and also fixes the following issues:
- `...Open an interactive shell to a database within a project...` False, we don't support this (it's a shell with environment variables, not a shell to a database)
- `...Homebrew (Linux, macOS)...` Homebrew is not available on Linux
- CLIv3
  - `railway shell` is not removed
  - `railway down` is not removed
