### PR TITLE
feat(search): Add hotkey nav, tweak UI slightly for better clarity between results

### DIFF
--- a/src/components/Search/Results.tsx
+++ b/src/components/Search/Results.tsx
@@ -68,7 +68,7 @@ const Results: React.FC<Props> = ({ closeModal, results }) => {
     }
     closeModal();
     router.push(selectedResult.slug);
-  }, [selectedResult]);
+  }, [closeModal, router, selectedResult]);
 
   useEffect(() => {
     const unsubscribe = tinykeys(window, {
@@ -77,7 +77,7 @@ const Results: React.FC<Props> = ({ closeModal, results }) => {
       Enter: () => onEnter(),
     });
     return () => unsubscribe();
-  }, [onArrowKeyDown]);
+  }, [onArrowKeyDown, onArrowKeyUp, onEnter]);
 
   return (
     <div css={tw`p-2 m-2`}>

--- a/src/components/Search/Results.tsx
+++ b/src/components/Search/Results.tsx
@@ -3,8 +3,8 @@ import { Search } from "@/types";
 import { Markup } from "interweave";
 import { useRouter } from "next/router";
 import React, { useCallback, useEffect, useState } from "react";
-import tw from "twin.macro";
 import tinykeys from "tinykeys";
+import tw from "twin.macro";
 
 interface Props {
   closeModal: () => void;
@@ -41,6 +41,7 @@ const Results: React.FC<Props> = ({ closeModal, results }) => {
       // End of results; nothing to go down from.
       return;
     }
+
     setSelectedResult(prev => {
       // On key down, go to the next item.
       const next = prev ? resultsFlat[prev.idx + 1] : resultsFlat[0];
@@ -51,8 +52,8 @@ const Results: React.FC<Props> = ({ closeModal, results }) => {
   const onArrowKeyUp = useCallback(() => {
     setSelectedResult(prev => {
       if (prev === null || prev.idx === 0) {
-        // Start of results. Going up from here is the search input, so we
-        // null out `selectedResult` to set the focus back to the input.
+        // Start of results. Going up from here is the search input, so it's
+        // a no-op.
         return null;
       }
       // On key up, go to the previous item.
@@ -77,8 +78,6 @@ const Results: React.FC<Props> = ({ closeModal, results }) => {
     });
     return () => unsubscribe();
   }, [onArrowKeyDown]);
-
-  console.log("selected", selectedResult);
 
   return (
     <div css={tw`p-2 m-2`}>


### PR DESCRIPTION
This adds back hotkey-based nav in the search UI:
* Arrow keys (`^`, `v`) to navigate through results
* `Enter` to browse to selected result
* Hover to select result

UI tweaks:
* Make results stand out more by adding borders
* Clip text overflow for long sections, e.g.
    ![ss 2023-04-28 at 3 10 19 AM](https://user-images.githubusercontent.com/24421625/234967295-2ace6417-7b89-4b34-aa42-675ffef11065.png)

## Demo

https://user-images.githubusercontent.com/24421625/234967059-addad8db-8ccd-4e27-9f9f-abbdfa12a38d.mov

Resolves #247
Resolves LOG-351