### PR TITLE
dockerfile info correction + add replica variable

### DIFF
--- a/src/docs/deploy/dockerfiles.md
+++ b/src/docs/deploy/dockerfiles.md
@@ -28,11 +28,18 @@ RAILWAY_DOCKERFILE_PATH = Dockerfile.origin
 If you need to use the environment variables that Railway injects at build time,
 you must specify them in the Dockerfile with
 
-```
+```dockerfile
 ARG EnvironmentVariable
 ```
 
-Be sure to declare your environment variables at the start of the `Dockerfile`.
+Be sure to declare your environment variables in the stage they are required in.
+
+```dockerfile
+FROM node
+
+ARG RAILWAY_ENVIRONMENT
+ENV RAILWAY_ENVIRONMENT=$RAILWAY_ENVIRONMENT
+```
 
 ### Docker Compose
 

--- a/src/docs/develop/variables.md
+++ b/src/docs/develop/variables.md
@@ -56,6 +56,7 @@ builds and deployments.
 | `RAILWAY_GIT_COMMIT_MESSAGE`      | The message of the commit that triggered the deployment. Example: `Fixed a few bugs`                                                                                                                 |
 | `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` | The timeout length (in seconds) of healthchecks. Example: `300`                                                                                                                                      |
 | `RAILWAY_ENVIRONMENT`             | The railway environment for the deployment. Example: `production`                                                                                                                                    |
+| `RAILWAY_REPLICA_ID`             | The railway replica ID for the deployment. Example: `2`                                                                                                                                    |
 
 ## User-Provided Configuration Variables
 


### PR DESCRIPTION
Corrects info and adds an example in the environment variables section of the dockerfiles page
Adds the replica id variable to the variables page