### PR TITLE
Clear search results if query is empty

### DIFF
--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -112,9 +112,10 @@ export const useDebouncedSearch = <
     }
   }, [query]);
 
-  // Perform search
+  // Perform search and clear search results if query is empty
   useEffect(() => {
     if (query === "") {
+      setResults(null);
       return;
     }
     search();


### PR DESCRIPTION
Like this [issue](https://github.com/railwayapp/docs/issues/266) describes, search results were not being removed when the input text is empty.

I fixed that.