### PR TITLE
document issue with cloudflare proxying and wildcard certs

### DIFF
--- a/src/docs/deploy/exposing-your-app.md
+++ b/src/docs/deploy/exposing-your-app.md
@@ -51,6 +51,8 @@ width={1048} height={842} quality={80} />
 
 In order to use Wildcard Domains, you must add two CNAME records, one for the wildcard domain, and one for the _acme-challenge. The _acme-challenge CNAME is required for Railway to issue the SSL Certificate for your domain.
 
+**NOTE:** If you're using Cloudflare, it is important that the _acme-challenge record has Cloudflare proxying disabled (no orange cloud). 
+
 ## Private Networks
 
 To expose an application on the [private network](https://docs.railway.app/reference/private-networking) you need to


### PR DESCRIPTION
We need `_acme-challenge` DNS records to direct to us directly for proper validation.