### PR TITLE
Fix typo in "Is Railway serverless?"

### DIFF
--- a/src/docs/maturity/philosophy.md
+++ b/src/docs/maturity/philosophy.md
@@ -81,4 +81,4 @@ No, Railway is a deployment platform that works with your existing code. We don'
 
 ### Is Railway serverless?
 
-No, services on Railway are deployed in stateful Docker containers. They are old deployments are removed on every new deploy.
+No, services on Railway are deployed in stateful Docker containers. The old deployments are removed on every new deploy.


### PR DESCRIPTION
This PR fixes a small typo I found under the "Is Railway serverless?" heading in the "Philosophy" section.