### PR TITLE
Fix alignment of content in "Deploy on Railway Examples" table cells

### DIFF
--- a/src/styles/GlobalStyles.ts
+++ b/src/styles/GlobalStyles.ts
@@ -30,4 +30,8 @@ export const GlobalStyles = createGlobalStyle`
   * {
     box-sizing: border-box;
   }
+
+  .docs-content td {
+    vertical-align: middle;
+  }
 `;


### PR DESCRIPTION
This PR fixes the alignment of the contents of the cells in the "Deploy on Railway Examples" table.

I noticed that the "Template" column was misaligned due to the text being pushed down to the bottom of the cell.

### Before

<img width="1266" alt="Screenshot 2023-09-02 at 2 28 55 PM" src="https://github.com/railwayapp/docs/assets/1486634/b76d72b2-8bb7-4818-89ba-03fc6e5ca38d">

### After

<img width="1266" alt="Screenshot 2023-09-02 at 2 29 07 PM" src="https://github.com/railwayapp/docs/assets/1486634/977a07f1-f5ad-45ff-bc3d-8e2d1f0cde98">

The fix contained in this PR does impact all `<td>` elements in the `.docs-content` section (which I believe is just this table, at the moment). It probably doesn't hurt to have `vertical-align: middle` set on all `<td>` elements, but if that is problematic we can investigate alternative solutions to fix the alignment for this particular case.