### PR TITLE
Generate a manifest reference in the docs from the json schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "generate": "prisma generate",
     "migrate:dev": "prisma migrate dev",
     "migrate:deploy": "prisma migrate deploy",
-    "migrate:status": "prisma migrate status"
+    "migrate:status": "prisma migrate status",
+    "toml-reference": "node src/scripts/toml-reference.mjs"
   },
   "dependencies": {
     "@nanostores/react": "^0.4.1",

--- a/src/docs/deploy/config-as-code.md
+++ b/src/docs/deploy/config-as-code.md
@@ -66,96 +66,166 @@ width={948} height={419} quality={100} />
 
 Everything in the build and deploy sections of the service settings can be configured. The settings are...
 
+{/* codegen:start do not edit this comment */}
 ### [Builder](/deploy/builds)
 
-Set the builder for the deployment:
+Set the builder for the deployment.
+
 ```toml
 [build]
-builder = "nixpacks"
+builder = "NIXPACKS"
 ```
 
-The available values are:
-- nixpacks
-- dockerfile
+Possible values are:
+- `NIXPACKS`
+- `DOCKERFILE`
 
-Note: Railway will always build with a Dockerfile if it finds one. To build with nixpacks, you can remove or rename the Dockerfile.
-
-### [Build command](/deploy/builds#build-command)
-
-Build command to pass to the Nixpacks builder:
-```toml
-[build]
-buildCommand = "echo building"
-```
+Note: Railway will always build with a Dockerfile if it finds one. To build with nixpacks, you can remove or rename the Dockerfile..
 
 ### [Watch Patterns](/deploy/builds#watch-paths)
 
-Array of patterns used to conditionally trigger deploys:
+Array of patterns used to conditionally trigger a deploys.
+
 ```toml
 [build]
 watchPatterns = ["src/**"]
 ```
 
+### [Build Command](/deploy/builds#build-command)
+
+Build command to pass to the Nixpacks builder.
+
+```toml
+[build]
+buildCommand = "yarn run build"
+```
+
+This field can be set to `null`.
+
 ### [Dockerfile Path](/deploy/dockerfiles)
 
-Location of non-standard Dockerfile path:
+Location of non-standard Dockerfile.
+
 ```toml
 [build]
 dockerfilePath = "Dockerfile.backend"
 ```
 
+This field can be set to `null`.
+
+### Nixpacks Config Path
+
+Location of a non-standard Nixpacks config file.
+
+```toml
+[build]
+nixpacksConfigPath = "nixpacks.toml"
+```
+
+This field can be set to `null`.
+
+### Nixpacks Plan
+
+Full nixpacks plan. See https://nixpacks.com/docs/configuration/file for more info.
+
+```toml
+[build]
+nixpacksPlan = "examples/node"
+```
+
+This field can be set to `null`.
+
+### Nixpacks Version
+
+Version of Nixpacks to use. Must be a valid Nixpacks version. EXPERIMENTAL: USE AT YOUR OWN RISK!.
+
+```toml
+[build]
+nixpacksVersion = "1.13.0"
+```
+
+This field can be set to `null`.
+
 ### [Start Command](/deploy/deployments#start-command)
 
-The command to run when starting the container:
+The command to run when starting the container.
+
 ```toml
 [deploy]
 startCommand = "echo starting"
 ```
 
-### [Replicas](/develop/services#horizontal-scaling-with-replicas)
+This field can be set to `null`.
 
-The number of replicas to run:
+### [Num Replicas](/develop/services#horizontal-scaling-with-replicas)
+
+The number of instances to run for the deployment.
+
 ```toml
 [deploy]
 numReplicas = 2
 ```
 
+This field can be set to `null`.
+
 ### [Healthcheck Path](/deploy/healthchecks)
 
-Path to check after starting your deployment to ensure it is healthy:
+Path to check after starting your deployment to ensure it is healthy.
+
 ```toml
 [deploy]
 healthcheckPath = "/health"
 ```
 
+This field can be set to `null`.
+
 ### [Healthcheck Timeout](/deploy/healthchecks#timeout)
 
-Number of seconds to wait for the healthcheck path to become healthy:
+Number of seconds to wait for the healthcheck path to become healthy.
+
 ```toml
 [deploy]
 healthcheckTimeout = 300
 ```
 
+This field can be set to `null`.
+
 ### [Restart Policy Type](/deploy/deployments#configurable-restart-policy)
 
-How to handle the deployment crashing:
+How to handle the deployment crashing.
+
 ```toml
 [deploy]
-restartPolicyType = "never"
+restartPolicyType = "ON_FAILURE"
 ```
 
-The available values are:
-- never
-- on_failure
-- always
+Possible values are:
+- `ON_FAILURE`
+- `ALWAYS`
+- `NEVER`
 
 ### Restart Policy Max Retries
 
-The number of times to restart if the restart type is `on_failure`:
 ```toml
 [deploy]
 restartPolicyMaxRetries = 5
 ```
+
+This field can be set to `null`.
+
+### Cron Schedule
+
+Cron schedule to run the deployment on.
+
+```toml
+[deploy]
+cronSchedule = "0 0 * * *"
+```
+
+This field can be set to `null`.
+
+
+{/* codegen:end do not edit this comment */}
 
 ## Custom Config File
 
@@ -231,165 +301,3 @@ If you include it in your `railway.json` file, many editors (e.g. VSCode) will p
   "$schema": "https://railway.app/railway.schema.json"
 }
 ```
-
-
-## Manifest Reference
-
-{/* codegen:start do not edit this comment */}
-### builder
-
-Set the builder for the deployment.
-
-```toml
-[build]
-builder = "NIXPACKS"
-```
-
-Possible values are:
-- `NIXPACKS`
-- `DOCKERFILE`
-- `HEROKU`
-- `PAKETO`
-
-### watchPatterns
-
-```toml
-[build]
-watchPatterns = ["src/**"]
-```
-
-### buildCommand
-
-Build command to pass to the Nixpacks builder.
-
-```toml
-[build]
-buildCommand = "yarn run build"
-```
-
-This field can be set to `null`.
-
-### dockerfilePath
-
-Location of non-standard Dockerfile.
-
-```toml
-[build]
-dockerfilePath = "Dockerfile.backend"
-```
-
-This field can be set to `null`.
-
-### nixpacksConfigPath
-
-Location of a non-standard Nixpacks config file.
-
-```toml
-[build]
-nixpacksConfigPath = "nixpacks.toml"
-```
-
-This field can be set to `null`.
-
-### nixpacksPlan
-
-Full nixpacks plan. See https://nixpacks.com/docs/configuration/file for more info.
-
-```toml
-[build]
-nixpacksPlan = "examples/node"
-```
-
-This field can be set to `null`.
-
-### nixpacksVersion
-
-Version of Nixpacks to use. Must be a valid Nixpacks version. EXPERIMENTAL: USE AT YOUR OWN RISK!.
-
-```toml
-[build]
-nixpacksVersion = "1.13.0"
-```
-
-This field can be set to `null`.
-
-### startCommand
-
-The command to run when starting the container.
-
-```toml
-[deploy]
-startCommand = "echo starting"
-```
-
-This field can be set to `null`.
-
-### numReplicas
-
-The number of instances to run for the deployment.
-
-```toml
-[deploy]
-numReplicas = 2
-```
-
-This field can be set to `null`.
-
-### healthcheckPath
-
-Path to check after starting your deployment to ensure it is healthy.
-
-```toml
-[deploy]
-healthcheckPath = "/health"
-```
-
-This field can be set to `null`.
-
-### healthcheckTimeout
-
-Number of seconds to wait for the healthcheck path to become healthy.
-
-```toml
-[deploy]
-healthcheckTimeout = 300
-```
-
-This field can be set to `null`.
-
-### restartPolicyType
-
-How to handle the deployment crashing.
-
-```toml
-[deploy]
-restartPolicyType = "ON_FAILURE"
-```
-
-Possible values are:
-- `ON_FAILURE`
-- `ALWAYS`
-- `NEVER`
-
-### restartPolicyMaxRetries
-
-```toml
-[deploy]
-restartPolicyMaxRetries = 5
-```
-
-This field can be set to `null`.
-
-### cronSchedule
-
-Cron schedule to run the deployment on.
-
-```toml
-[deploy]
-cronSchedule = "0 0 * * *"
-```
-
-This field can be set to `null`.
-
-
-{/* codegen:end do not edit this comment */}

--- a/src/docs/deploy/config-as-code.md
+++ b/src/docs/deploy/config-as-code.md
@@ -213,7 +213,7 @@ restartPolicyMaxRetries = 5
 
 This field can be set to `null`.
 
-### Cron Schedule
+### [Cron Schedule](/reference/cron-jobs)
 
 Cron schedule to run the deployment on.
 

--- a/src/docs/deploy/config-as-code.md
+++ b/src/docs/deploy/config-as-code.md
@@ -231,3 +231,165 @@ If you include it in your `railway.json` file, many editors (e.g. VSCode) will p
   "$schema": "https://railway.app/railway.schema.json"
 }
 ```
+
+
+## Manifest Reference
+
+{/* codegen:start do not edit this comment */}
+### builder
+
+Set the builder for the deployment.
+
+```toml
+[build]
+builder = "NIXPACKS"
+```
+
+Possible values are:
+- `NIXPACKS`
+- `DOCKERFILE`
+- `HEROKU`
+- `PAKETO`
+
+### watchPatterns
+
+```toml
+[build]
+watchPatterns = ["src/**"]
+```
+
+### buildCommand
+
+Build command to pass to the Nixpacks builder.
+
+```toml
+[build]
+buildCommand = "yarn run build"
+```
+
+This field can be set to `null`.
+
+### dockerfilePath
+
+Location of non-standard Dockerfile.
+
+```toml
+[build]
+dockerfilePath = "Dockerfile.backend"
+```
+
+This field can be set to `null`.
+
+### nixpacksConfigPath
+
+Location of a non-standard Nixpacks config file.
+
+```toml
+[build]
+nixpacksConfigPath = "nixpacks.toml"
+```
+
+This field can be set to `null`.
+
+### nixpacksPlan
+
+Full nixpacks plan. See https://nixpacks.com/docs/configuration/file for more info.
+
+```toml
+[build]
+nixpacksPlan = "examples/node"
+```
+
+This field can be set to `null`.
+
+### nixpacksVersion
+
+Version of Nixpacks to use. Must be a valid Nixpacks version. EXPERIMENTAL: USE AT YOUR OWN RISK!.
+
+```toml
+[build]
+nixpacksVersion = "1.13.0"
+```
+
+This field can be set to `null`.
+
+### startCommand
+
+The command to run when starting the container.
+
+```toml
+[deploy]
+startCommand = "echo starting"
+```
+
+This field can be set to `null`.
+
+### numReplicas
+
+The number of instances to run for the deployment.
+
+```toml
+[deploy]
+numReplicas = 2
+```
+
+This field can be set to `null`.
+
+### healthcheckPath
+
+Path to check after starting your deployment to ensure it is healthy.
+
+```toml
+[deploy]
+healthcheckPath = "/health"
+```
+
+This field can be set to `null`.
+
+### healthcheckTimeout
+
+Number of seconds to wait for the healthcheck path to become healthy.
+
+```toml
+[deploy]
+healthcheckTimeout = 300
+```
+
+This field can be set to `null`.
+
+### restartPolicyType
+
+How to handle the deployment crashing.
+
+```toml
+[deploy]
+restartPolicyType = "ON_FAILURE"
+```
+
+Possible values are:
+- `ON_FAILURE`
+- `ALWAYS`
+- `NEVER`
+
+### restartPolicyMaxRetries
+
+```toml
+[deploy]
+restartPolicyMaxRetries = 5
+```
+
+This field can be set to `null`.
+
+### cronSchedule
+
+Cron schedule to run the deployment on.
+
+```toml
+[deploy]
+cronSchedule = "0 0 * * *"
+```
+
+This field can be set to `null`.
+
+
+{/* codegen:end do not edit this comment */}

--- a/src/scripts/toml-reference.mjs
+++ b/src/scripts/toml-reference.mjs
@@ -1,0 +1,117 @@
+import fs from "fs/promises";
+
+const startComment = "{/* codegen:start do not edit this comment */}";
+const endComment = "{/* codegen:end do not edit this comment */}";
+
+async function main() {
+  const path = "./src/docs/deploy/config-as-code.md";
+  let content = await fs.readFile(path, "utf-8");
+  const startIndex = content.indexOf(startComment);
+  const endIndex = content.indexOf(endComment);
+
+  if (startIndex === -1 || endIndex === -1) {
+    throw new Error("Could not find start or end comment");
+  }
+
+  const response = await fetch(
+    "https://backboard.railway.app/railway.schema.json",
+  );
+  if (!response.ok) {
+    throw new Error("Could not fetch JSON schema");
+  }
+
+  const jsonSchema = await response.json();
+  let newContent = "";
+
+  const { build, deploy } = jsonSchema.properties;
+
+  newContent += generateDocsForProperties("build", build.properties);
+
+  newContent += generateDocsForProperties("deploy", deploy.properties);
+
+  content = [
+    content.substring(0, startIndex + startComment.length),
+    newContent,
+    content.substring(endIndex),
+  ].join("\n");
+
+  await fs.writeFile(path, content);
+}
+
+function generateDocsForProperties(section, properties) {
+  let content = "";
+
+  for (const [key, value] of Object.entries(properties)) {
+    const { nullable, value: unwrappedValue } = unwrap(value);
+    const propertyPath = `${section}.${key}`;
+    content += `### ${key}\n\n`;
+    if (unwrappedValue.description) {
+      content += `${unwrappedValue.description}.\n\n`;
+    }
+
+    const example = examples[propertyPath] ?? value.enum?.[0];
+
+    if (example) {
+      content += `\`\`\`toml
+[${section}]
+${key} = ${
+        typeof example === "string" ? `"${example}"` : JSON.stringify(example)
+      }
+\`\`\`
+
+`;
+    } else {
+      console.warn(`No example for ${propertyPath}`);
+    }
+
+    if (unwrappedValue.enum) {
+      content += `Possible values are:\n${value.enum
+        .map(v => `- \`${v}\``)
+        .join("\n")}\n\n`;
+    }
+
+    if (nullable) {
+      content += `This field can be set to \`null\`.\n\n`;
+    }
+  }
+
+  return content;
+}
+
+function unwrap(value) {
+  let nullable = false;
+  if (!value.anyOf) return { value, nullable };
+  if (value.anyOf.length === 2) {
+    nullable = value.anyOf.find(v => v.type === "null");
+    if (nullable) {
+      value = value.anyOf.find(v => v.type !== "null");
+    }
+  }
+  if (value.anyOf.length === 2) {
+    const not = value.anyOf.find(v => v.not);
+    if (not) {
+      value = value.anyOf.find(v => !v.not);
+    }
+  }
+  return { value, nullable };
+}
+
+// Although json-schema supports examples, we build the schema from zod and it doesn't support examples.
+// So a solution is to have them here.
+const examples = {
+  "build.watchPatterns": ["src/**"],
+  "build.buildCommand": "yarn run build",
+  "build.dockerfilePath": "Dockerfile.backend",
+  "build.nixpacksConfigPath": "nixpacks.toml",
+  "build.nixpacksPlan": "examples/node",
+  "build.nixpacksVersion": "1.13.0",
+  "deploy.startCommand": "echo starting",
+  "deploy.numReplicas": 2,
+  "deploy.healthcheckPath": "/health",
+  "deploy.healthcheckTimeout": 300,
+  "deploy.restartPolicyMaxRetries": 5,
+  "deploy.restartPolicyType": "ON_FAILURE",
+  "deploy.cronSchedule": "0 0 * * *",
+};
+
+main().catch(console.error);

--- a/src/scripts/toml-reference.mjs
+++ b/src/scripts/toml-reference.mjs
@@ -150,6 +150,7 @@ const links = {
   "deploy.healthcheckPath": "/deploy/healthchecks",
   "deploy.healthcheckTimeout": "/deploy/healthchecks#timeout",
   "deploy.restartPolicyType": "/deploy/deployments#configurable-restart-policy",
+  "deploy.cronSchedule": "/reference/cron-jobs",
 };
 
 const ignoredEnumValues = ["HEROKU", "PAKETO"];


### PR DESCRIPTION
This PR aims to semi-automate the process of generating docs for the manifest schema.

Note: the script is in JS because I didn't see an easy way to run a `.ts` file with `ts-node` in this project since adding `type: module` in package.json would break the next.js build process.

The generted for this PR preview can be seen [here](https://railway-docs-docs-pr-331.up.railway.app/deploy/config-as-code#configurable-settings).