### PR TITLE
docs: add explanation on how to specify nixpacks options within railway.toml

### DIFF
--- a/src/docs/deploy/config-as-code.md
+++ b/src/docs/deploy/config-as-code.md
@@ -135,6 +135,13 @@ nixpacksPlan = "examples/node"
 
 This field can be set to `null`.
 
+You can also define specific options as follow.
+
+```toml
+[build.nixpacksPlan.phases.setup]
+nixPkgs = ["...", "zlib"]
+```
+
 ### Nixpacks Version
 
 Version of Nixpacks to use. Must be a valid Nixpacks version. EXPERIMENTAL: USE AT YOUR OWN RISK!.


### PR DESCRIPTION
After seeing [this message](https://discord.com/channels/713503345364697088/1157550938140180510/1157554477721735199) I wondered how to do that with the `toml` file.

I checked some json -> toml converter and found it. I deployed my change successfully using this syntax