### PR TITLE
Added Porkbun to registrar list in exposing-your-app.md

### DIFF
--- a/src/docs/deploy/exposing-your-app.md
+++ b/src/docs/deploy/exposing-your-app.md
@@ -107,6 +107,7 @@ Registrars that are known to not fully support CNAME records for the root domain
 - Freenom
 - GoDaddy
 - Ionos
+- Porkbun
 
 **Workaround 1 - Cloudflare Proxy**
 


### PR DESCRIPTION
Porkbun is another registrar that doesn't fully support CNAME records which requires you to go through Cloudflare. 