### PR TITLE
Add an additional caveat for the private networking, not available during build

### DIFF
--- a/src/docs/reference/private-networking.md
+++ b/src/docs/reference/private-networking.md
@@ -46,6 +46,7 @@ Requests to replica DNS service address will be round robin'd between all replic
 
 During the feature development process we found a few caveats that you should be aware of:
 
+- Private networking is not available during the build phase.
 - Railway databases are not accessible via the private network, we are moving towards a system where DBs are services with volumes attached.
 - You will need to establish a wireguard tunnel to external services if you wish to vendor requests in your application.
 - You will need to bind to a IPv6 port to receive traffic on the private network.


### PR DESCRIPTION
I've seen a few people ask this, and a #feedback post on this, so until it's supported, It would be good to have this caveat in the docs