### PR TITLE
Update To Priority Boarding

### DIFF
--- a/src/docs/reference/priority-boarding.md
+++ b/src/docs/reference/priority-boarding.md
@@ -18,7 +18,7 @@ width={992} height={422} quality={80} />
 Once connected to Discord, you'll need to let Percy, the Railway Discord bot, know that you'd like to be a part of priority boarding. 
 
 In Discord, open up any channel, enter `/beta`, and follow the prompts. 
-Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join priority boarding button.
+Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join Priority Boarding button.
 
 You should now have access to the `#priority-boarding` channel. You should also see that your Account Settings now display a new Priority Boarding status.
 

--- a/src/docs/reference/priority-boarding.md
+++ b/src/docs/reference/priority-boarding.md
@@ -18,7 +18,7 @@ width={992} height={422} quality={80} />
 Once connected to Discord, you'll need to let Percy, the Railway Discord bot, know that you'd like to be a part of priority boarding. 
 
 In Discord, open up any channel, enter `/beta`, and follow the prompts. 
-Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join priority onboarding button.
+Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join priority boarding button.
 
 You should now have access to the `#priority-boarding` channel. You should also see that your Account Settings now display a new Priority Boarding status.
 

--- a/src/docs/reference/priority-boarding.md
+++ b/src/docs/reference/priority-boarding.md
@@ -2,13 +2,13 @@
 title: Priority Boarding
 ---
 
-Priority Boarding is Railway's beta program. The railway team are always working on pushing new beta features out to priority boarding. We also offer a Discord channel dedicated to this, allowing you to submit feedback. 
+Priority Boarding is Railway's beta program. The railway team is always working on pushing new beta features out to priority boarding. We also offer a Discord channel dedicated to this, allowing you to submit feedback. 
 
 To read more about Priority Boarding, check out [Priority Boarding: The Journey to Get There](https://blog.railway.app/p/building-the-beta).
 
 ## Getting Started
 
-Priority Boarding is available to users who have connected their Railway account to Discord. To get started, visit [General Settings](https://railway.app/account), scroll down to Account Settings, and connect your account to the Railway Discord server.
+Priority Boarding is available to users who have connected their Railway account to Discord. To get started, visit [General Settings](https://railway.app/account), scroll down to Account Settings and connect your account to the Railway Discord server.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1666373029/docs/discord-connect_ok03jw.png"
 alt="Screenshot of Account Settings - Priority Boarding"
@@ -17,7 +17,8 @@ width={992} height={422} quality={80} />
 
 Once connected to Discord, you'll need to let Percy, the Railway Discord bot, know that you'd like to be a part of priority boarding. 
 
-In Discord, open up any channel, enter `/beta`, and follow the prompts.
+In Discord, open up any channel, enter `/beta`, and follow the prompts. 
+Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join priority onboarding button.
 
 You should now have access to the `#priority-boarding` channel. You should also see that your Account Settings now display a new Priority Boarding status.
 
@@ -26,6 +27,6 @@ alt="Screenshot of Account Settings - Priority Boarding"
 layout="responsive"
 width={1004} height={468} quality={80} />
 
-From this point forward, you'll have Priority Boarding features automatically enabled for your account. We'll notify you of any new features via the [Changelog](https://railway.app/changelog). We kindly request that you report any issues you encounter in the Discord channel.
+From this point forward, you'll have Priority Boarding features automatically enabled for your account. We'll notify you of any new features via the [Changelog](https://railway.app/changelog). We kindly request that you report any issues you encounter in the [Discord channel](https://discord.com/channels/713503345364697088/921233523719946260).
 
 That's all there is to it! Thanks for helping improve Railway, and we'll see you in Priority Boarding.


### PR DESCRIPTION
I fixed some minor grammar errors

Added QoL like being able to click on "Discord channel" to go to the Discord channel in question 

And added an alternative way to join priority boarding, I notice a lot of users try doing it via `/beta` which is somewhat buggy, and I often see myself or conductors suggest this alternative way if the bot doesn't work