### PR TITLE
Update templates.md

### DIFF
--- a/src/docs/reference/templates.md
+++ b/src/docs/reference/templates.md
@@ -126,7 +126,6 @@ If your published template is deployed into other users' projects, you are immed
 #### Important things to note
 
 - Your template must be published to the marketplace to be eligible for kickback.
-- For Hobby users with a $5 discount, only usage in excess of the discount is counted in the kickback.
 - Platform fees are not included in the kickback, but usage fees of the platform are included. Examples of platform fees are:
 
   - Cost of Subscription Plan ($5 for Hobby, $20 for Pro)


### PR DESCRIPTION
The hobby tier no longer has a $5 discount; it is $5/month with included usage. Line removed looks like it was added when there was the $5 discount awhile ago. 

It may be worth re-visiting logic in the billing system to make sure it's updated too.