### PR TITLE
Add compare to heroku file to maturity

### DIFF
--- a/src/docs/maturity/compare-to-heroku.md
+++ b/src/docs/maturity/compare-to-heroku.md
@@ -1,0 +1,70 @@
+---
+title: Railway vs. Heroku
+---
+
+## Summary
+
+Railway is a simple and powerful deployment platform that focuses on giving you and your team a deployment plane that radically increases developer efficiency.
+
+We are alike in the following ways:
+- GitHub repo deployments
+- CLI tooling
+- Built-in databases
+
+We differ in the following:
+- We have an outsized focus on support and developer experience. A highly engaged community and the Railway team stand at the ready to help you scale
+- Resource-based pricing, only pay for what you use.
+- Better developer experience. We offer PR deploys, variable management, rapid builds, and local development flows.
+- And much more...
+
+## Differences
+
+### Builds
+
+In the current era of software development, using Docker adds a large workload to the average developer. We want to offer the developer all the benefits of reproducibility, speed, and ease of use when deploying images without the clunky boilerplate of Docker.
+
+Heroku's buildpacks are decent, but we want to offer the user a better experience. This is why we built Nixpacks.
+
+Nixpax is open source (https://github.com/railwayapp/nixpacks). It detects more languages, builds are faster, and builds are reproducible. (A common frustration of Heroku's Buildpacks).
+
+Those moving from Heroku to Railway will find an easy switch from Heroku's Buildpacks to Railway's Nixpacks.
+
+### Product
+
+Deploying a project on Railway is incredibly easy thanks to Nixpacks and our templating system. We have a [Getting Started guide](/getting-started) that will walk you through the process.
+
+It's possible to go from zero → 3 services in < 30 seconds. Adding new services is trivial and meshing them together means you don't need to deal with headaches based on your infrastructure.
+
+### Pricing
+
+Pay only for what you use—no need to size dynos.
+
+Containers scale vertically up to 8 GB/CPU Cores (on the Hobby Plan) and 32 GB/CPU Cores (on Teams Plans).
+
+Did traffic spike for an hour? Only pay for that hour, no manual scaling intervention required.
+
+For those who prefer to pay upfront. We offer credit-based Developer plans who wish to load their account with credits.
+
+### Develop and Deploy
+
+You can use the CLI to run every service locally, hooking in with your cloud infrastructure.
+
+For example, running `railway run yarn start` in a project with Postgres will automatically inject required enviroment variables such as `DATABASE_URL`.
+
+If your changes look good, you can even run `railway up` from the terminal to trigger a new deployment on demand.
+
+### Lifecycle Management
+
+We offer guardrails to prevent new deployments from knocking your app offline, such as [Healthchecks](/deploy/healthchecks). By providing an endpoint for Railway to hit, we will make a series of requests, checking for a 200 OK response before we switch deploys to the most recent one.
+
+Want to revert a change? Because we image all builds, you can [rollback](/deploy/deployments#rollback) to an earlier working deploy in just one click.
+
+### Support + Community
+
+Railway serves hundreds of thousands of thousands of builders who deploy applications that bring tremendous impact to themselves, their friends, and their customers.
+
+We feel no project, big or small- is never not important. This is our guiding philosophy to our users.
+
+As a result, we make great pains to be very communicative in our support channels, [optimistically gather feedback](https://feedback.railway.app/), provide informative docs, and encourage our community to help each other.
+
+Having an issue with a deployment? [Join over 5k Railway users on our Discord Server!](https://discord.gg/railway) With our dedicated support channels, you can get help from the Railway team and our community of builders.


### PR DESCRIPTION
In relation to #408 

Added the `compare to heroku` page under the `maturity` section in docs.

I haven't removed the file from `reference` yet, because the main website links to it from the continue reading button on https://railway.app/heroku. As the main website isn't open source (as far as I can tell) I thought it would be best to wait until this PR is merged, the main website link to be updated, before deleting the file in `reference`. I hope this makes sense.

Also this "works on my machine" but I had some issues with NPM, so I did this through GitHub on the web haha😅

 Hoping that it looks all good here 🙂 