### PR TITLE
fix typo `Github` to `GitHub`

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -64,7 +64,7 @@ export const sidebarContent: ISidebarContent = [
         pages: [
           makePage("Start Command", "guides"),
           makePage("Deployment Actions", "guides"),
-          makePage("Github Autodeploys", "guides"),
+          makePage("GitHub Autodeploys", "guides"),
           makePage("Optimize Performance", "guides"),
           makePage("Healthchecks and Restarts", "guides"),
           makePage("Monorepo", "guides"),

--- a/src/docs/guides/create.md
+++ b/src/docs/guides/create.md
@@ -12,7 +12,7 @@ You can either create a template from scratch or base it off of an existing proj
 
 The <a href="https://railway.app/button" target="_blank">Railway button page</a>. allows you to create templates to offer a 1-click deploy on Railway experience.
 
-Services within a template can be deployed from any public Github repository, or directly from a Docker image in Docker Hub or Github Container Registry.
+Services within a template can be deployed from any public GitHub repository, or directly from a Docker image in Docker Hub or GitHub Container Registry.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1656470421/docs/template-editor_khw8n6.png"
 alt="Template Editor"
@@ -69,9 +69,9 @@ When a template is deployed, all functions are executed and the result replaces 
 The current template variable functions are:
 
 - `secret(length?: number, alphabet?: string)`: Generates a random secret (32 chars by default).  You can generate random Hex or Base64 secrets by passing the appropriate alphabet.
-    
-    - Base64: `secret(32, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/')`
-    - Hex: `secret(32, '0123456789ABCDEF')`
+
+  - Base64: `secret(32, 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789+/')`
+  - Hex: `secret(32, '0123456789ABCDEF')`
 
 - `randomInt(min?: number, max?: number)`: Generates a random integer between min and max (defaults to 0 and 100)
 
@@ -86,4 +86,3 @@ You can see all of your templates on your <a href="https://railway.app/account/t
  width={3100}
  quality={80}
 />
-

--- a/src/docs/guides/deployments.md
+++ b/src/docs/guides/deployments.md
@@ -7,10 +7,11 @@ Let's configure your deployments!
 Now that you understand how to tailor your builds if necessary, let's get into the various ways you can control how your services are deployed and run.  Like builds, when you deploy a service, Railway will apply some defaults that can easily be overridden when necessary.
 
 #### Deployment Concepts
+
 |||
 |-|-|
 | **Deployment Controls** | Deployments are attempts to build and run your code.  Railway provides controls for changing the default run behavior, and for acting on existing deployments, for example rolling back to a previous deployment or restarting a service.                                                                                    |
-| **Auto Deploys**          | If you have deployed from your Github repo, we will automatically build and deploy your code when you push a change to the connected branch.                                                                                                                    |
+| **Auto Deploys**          | If you have deployed from your GitHub repo, we will automatically build and deploy your code when you push a change to the connected branch.                                                                                                                    |
 | **Regional Deployments** | By default, services are deployed to the `us-west1` region in Oregon, US.  To optimize performance for your users in other parts of the world, we offer regional deployments. |
 | **Scaling** | Scaling your application has never been so easy.  Vertical auto-scaling is performed without any configuration on your part.  Horizontal scaling is made possible with replicas. |
 | **Healthchecks** | Healthchecks can be configured on your services to control when a new deployment is deemed healthy and ready for connections.                                                                                                            |

--- a/src/docs/guides/github-autodeploys.md
+++ b/src/docs/guides/github-autodeploys.md
@@ -1,5 +1,5 @@
 ---
-title: Controlling Github Autodeploys
+title: Controlling GitHub Autodeploys
 ---
 
 [Services that are linked to a GitHub repo](/guides/services#deploying-from-a-github-repo) automatically deploy when new commits are detected in the connected branch.
@@ -26,13 +26,12 @@ To disable automatic deployment, simply choose `Disable Trigger` from your Servi
   required for this feature to work.
 </Banner>
 
-
 To ensure Railway waits for your GitHub Actions to run successfully before triggering a new deployment, you should enable Check Suites.
 
 #### Requirements
 
-- You must have a Github workflow defined in your repository.  
-- The Github workflow must contain a directive to run on push: 
+- You must have a GitHub workflow defined in your repository.  
+- The GitHub workflow must contain a directive to run on push:
 
     ```plaintext
     on:
@@ -40,6 +39,7 @@ To ensure Railway waits for your GitHub Actions to run successfully before trigg
         branches:
           - main
     ```
+
 ### Enabling Check Suites
 
 If your workflow satisfies the requirements above, you will see the `Check Suites` flag in service settings.
@@ -48,8 +48,8 @@ If your workflow satisfies the requirements above, you will see the `Check Suite
 
 Toggle this on to ensure Railway waits for your GitHub Actions to run successfully before triggering a new deployment.
 
-When enabled, deployments will be moved to a `WAITING` state while your workflows are running. 
+When enabled, deployments will be moved to a `WAITING` state while your workflows are running.
 
-If any workflow fails, the deployments will be `SKIPPED`. 
+If any workflow fails, the deployments will be `SKIPPED`.
 
 When all workflows are successful, deployments will proceed as usual.

--- a/src/docs/guides/services.md
+++ b/src/docs/guides/services.md
@@ -33,9 +33,9 @@ alt="Screenshot of how to connect a service to a GitHub repo or Docker image"
 layout="responsive"
 width={709} height={190} quality={80} />
 
-### Deploying from a Github Repo
+### Deploying from a GitHub Repo
 
-Define a GitHub repository as your service source by selecting `Connect Repo` and choosing the repository you'd like to deploy. 
+Define a GitHub repository as your service source by selecting `Connect Repo` and choosing the repository you'd like to deploy.
 
 When a new commit is pushed to the linked branch, Railway will automatically build and deploy the new code.
 
@@ -45,18 +45,20 @@ alt="Screenshot of a GitHub deployment trigger"
 layout="responsive"
 width={708} height={245} quality={80} />
 
-You must link your Railway account to Github, to enable Railway to connect to your Github repositories.  <a href="https://github.com/apps/railway-app/installations/new" target="_blank">You can configure the Railway App in Github by clicking this link.</a>
+You must link your Railway account to GitHub, to enable Railway to connect to your GitHub repositories.  <a href="https://github.com/apps/railway-app/installations/new" target="_blank">You can configure the Railway App in GitHub by clicking this link.</a>
 
 ### Deploying from a Docker Image
 
 To deploy from a docker image, specify the path of the image when prompted in the creation flow.
 
-Railway can deploy images from <a href="https://hub.docker.com/" target="_blank">Docker Hub</a> or <a href="https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry" target="_blank">GitHub Container Registry</a>.  Example paths - 
+Railway can deploy images from <a href="https://hub.docker.com/" target="_blank">Docker Hub</a> or <a href="https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-container-registry" target="_blank">GitHub Container Registry</a>.  Example paths -
 
 Docker Hub:
+
 - `bitnami/redis`
 
 GitHub Container Registry:
+
 - `ghcr.io/railwayapp-templates/postgres-ssl:latest`
 
 ## Deploying from a local directory
@@ -68,11 +70,9 @@ GitHub Container Registry:
 3. Link to your Railway project using the `railway link` CLI command.
 4. Deploy the directory using `railway up`.  The CLI will prompt you to choose a service target, be sure to choose the empty service you created.
 
-
 ## Deploying a Monorepo
 
 For information on how to deploy a Monorepo click [here](/guides/monorepo).
-
 
 ## Monitoring
 

--- a/src/docs/reference/accounts.md
+++ b/src/docs/reference/accounts.md
@@ -4,7 +4,7 @@ title: Accounts
 
 Railway Accounts are how a user interacts with the Railway platform.
 
-Users are only allowed one account per person. This is enforced through email, Github, and payment method verification.
+Users are only allowed one account per person. This is enforced through email, GitHub, and payment method verification.
 
 ## Account Settings
 

--- a/src/docs/reference/production-readiness-checklist.md
+++ b/src/docs/reference/production-readiness-checklist.md
@@ -21,9 +21,9 @@ Ensuring your application is performant and reliable under changing conditions l
 **&check; Serve your application from the right region**
 
 - Deploying your application as close to your users as possible minimizes the number of network hops, reducing latency and improving performance.
-    
+
     Railway offers multiple [deployment regions](/reference/deployment-regions) around the globe.
-    
+
     You may also consider implementing a CDN to cache server responses on an edge network.
 
 **&check; Use private networking between services**
@@ -67,7 +67,7 @@ Observability and monitoring refers to tracking the health and performance of yo
 - Ensure you are alerted if the [deployment status](/reference/deployments#deployment-states) of your services change.
 
     Enable email notifications in you Account Settings to receive these alerts via email.
-    
+
     Setup [webhooks](/reference/deployments#deployment-states) to have the alerts sent to another system, like Slack or Discord.
 
 *What's next for observability features in Railway?  We have a ton of ideas, but we would love to hear yours in our <a href="https://community.railway.app/feature-request/better-logging-support-1e6f5676" target="_blank">community forums</a>.*
@@ -82,7 +82,7 @@ Quality assurance involves following practices to ensure changes to your applica
 
 - Common practice is to run a suite of tests, scans, or other automated jobs against your code before it is merged into production.  You may want to configure your deployments to wait until those jobs have completed successfully before triggering a build.
 
-  Enable [check suites](/guides/github-autodeploys#check-suites) to have Railway wait for your Github workflows to complete successfuly before triggering a deployment.
+  Enable [check suites](/guides/github-autodeploys#check-suites) to have Railway wait for your GitHub workflows to complete successfuly before triggering a deployment.
 
 **&check; Use environments**
 
@@ -100,7 +100,7 @@ Quality assurance involves following practices to ensure changes to your applica
 
 **&check; Understand the deployment rollback feature**
 
-- Introducing breaking changes to your application code is sometimes unavoidable, and it can be a headache reverting to previous commits. 
+- Introducing breaking changes to your application code is sometimes unavoidable, and it can be a headache reverting to previous commits.
 
     Be sure to check out the [deployment rollback feature](/guides/deployment-actions#rollback), in case you need to rollback to a previous deployment.
 
@@ -143,7 +143,7 @@ Being prepared for major and unexpected issues helps minimize downtime and data 
 - Data is critical to preserve in many applications.  You should ensure you have a backup strategy in place for your data.
 
     Implement a [cron service](/guides/cron-jobs) to dump and store your data backups.
-    
+
     If you use Postgres, check out one of our popular templates - <a href="https://railway.app/template/I4zGrH" target="_blank">PostgreSQL S3 Backups</a>.
 
     *We are exploring ways to implement a native solution for backing up your data.  If you have any thoughts, we would love to hear from you in our <a href="https://community.railway.app/feature-request/native-database-backups-for-popular-data-8ec06824" target="_blank">community forums</a>.*

--- a/src/docs/reference/services.md
+++ b/src/docs/reference/services.md
@@ -4,7 +4,7 @@ title: Services
 
 A Railway service is a deployment target.  Under the hood, services are containers deployed from an image.
 
-Each service keeps a log of [deployment attempts](/reference/deployments) and [performance metrics](/reference/metrics). 
+Each service keeps a log of [deployment attempts](/reference/deployments) and [performance metrics](/reference/metrics).
 
 [Variables](/reference/variables), source references (e.g. GitHub repository URI), and relevant [start and build commands](/reference/build-and-start-commands) are also stored in the service, among other configuration.
 
@@ -20,15 +20,15 @@ Services that are run until completion, on a defined schedule, also called Cron 
 
 ## Service Source
 
-A service source can be any of the following - Docker Image, Github or Local repository.
+A service source can be any of the following - Docker Image, GitHub or Local repository.
 
 If a [Dockerfile](/reference/dockerfiles) is found within the source repository, Railway will automatically use it to build an image for the service.
 
 #### Docker Image
 
-Services can be deployed directly from a Docker image from Docker Hub or Github Container Registry.
+Services can be deployed directly from a Docker image from Docker Hub or GitHub Container Registry.
 
-#### Github Repository
+#### GitHub Repository
 
 Services can be connected to a GitHub repo and automatically deployed on each commit.
 


### PR DESCRIPTION
## Why

Typo: Ref: [GitHub Docs](https://docs.github.com/en)