### PR TITLE
domain limit clarifications

### DIFF
--- a/src/docs/guides/public-networking.md
+++ b/src/docs/guides/public-networking.md
@@ -83,8 +83,8 @@ Note that changes to DNS settings may take up to 72 hours to propagate worldwide
 
 **Important Considerations**
 - Freenom domains are not allowed and not supported.
-- The [Hobby Plan](/reference/pricing#plans) is limited to 2 custom domains.
-- The [Pro Plan]() is limited to 10 domains by default.  This limit can be increased for Pro users on request, simply reach out to us at [team@railway.app](mailto:team@railway.app) or via [private thread](/reference/support#private-threads).
+- The [Hobby Plan](/reference/pricing#plans) is limited to 2 custom domains per service.
+- The [Pro Plan]() is limited to 10 domains per service by default.  This limit can be increased for Pro users on request, simply reach out to us at [team@railway.app](mailto:team@railway.app) or via [private thread](/reference/support#private-threads).
 
 ## Wildcard Domains
 

--- a/src/docs/reference/public-networking.md
+++ b/src/docs/reference/public-networking.md
@@ -38,9 +38,9 @@ If your application requires higher limits, please don't hesitate to reach out t
 
 ## Custom Domain Count Limits
 
-The [Hobby plan](/reference/pricing#plans) is limited to 2 custom domains.
+The [Hobby plan](/reference/pricing#plans) is limited to 2 custom domains per service.
 
-The [Pro Plan](/reference/pricing#plans) is limited to 10 domains by default but can be increased for Pro users on request, by reaching out to us at [team@railway.app](mailto:team@railway.app) or via [private thread](/reference/support#private-threads).
+The [Pro Plan](/reference/pricing#plans) is limited to 10 domains per service by default but can be increased for Pro users on request, by reaching out to us at [team@railway.app](mailto:team@railway.app) or via [private thread](/reference/support#private-threads).
 
 ## FAQ
 


### PR DESCRIPTION
clarify that these limits are per service and not per workspace or per project.