### PR TITLE
Mention serverless in Docs

### DIFF
--- a/src/docs/reference/app-sleeping.md
+++ b/src/docs/reference/app-sleeping.md
@@ -2,7 +2,7 @@
 title: App Sleeping
 ---
 
-App Sleeping allows you to increase the efficiency of resource utilization on Railway and may reduce the usage cost of a [service](/reference/services), by ensuring it is running only when necessary.
+App Sleeping (aka "Serverless") allows you to increase the efficiency of resource utilization on Railway and may reduce the usage cost of a [service](/reference/services), by ensuring it is running only when necessary.
 
 ## How it Works
 


### PR DESCRIPTION
Making it a bit more clear that we support this. 

Seeing a few places on the web where it's said we don't

https://www.reddit.com/r/nextjs/comments/1bgej9q/cost_comparison_vercel_planetscale_vs/?rdt=59162
