### PR TITLE
Optimize Usage guide: Add "Use Private Networking"

### DIFF
--- a/src/docs/guides/optimize-usage.md
+++ b/src/docs/guides/optimize-usage.md
@@ -34,6 +34,24 @@ Multiple emails will be sent as your usage approaches your hard limit:
 
 Find more information about Usage Limits in the [reference page](/reference/usage-limits).
 
+## Use Private Networking
+
+Using [Private Networking](/guides/private-networking) when communicating with other services (such as databases) within your Railway project will help you avoid unnecessary Network Egress costs.
+
+### With databases
+
+Communicate with your Railway database over private networking by using the `DATABASE_PRIVATE_URL` environment variable, instead of `DATABASE_PUBLIC_URL`:
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1715870608/docs/privnet-db_iujd9g.png" alt="Database Private URL" layout="responsive" width={664} height={452} />
+
+### With other services
+
+If your Railway services need to communicate with each other, you can find the service's private URL in the service settings:
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1715870638/docs/privnet-services_iyqsgd.png" alt="Private Network URL" layout="responsive" width={758} height={573} />
+
+Learn more about Railway's Private Networking [here](/guides/private-networking).
+
 ## Enabling App Sleeping
 
 Enabling App Sleep on a service tells Railway to stop a service when it is inactive, effectively reducing the overall cost to run it.

--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -32,17 +32,7 @@ If you are supporting a commercial application, we highly recommend you to upgra
 
 ### How do I prevent spending more than I want to?
 
-**Usage Limits**
-
-You can set [Usage Limits](/reference/usage-limits) to prevent unexpected costs. We recommend doing this if you'd like to cap your maximum bill every month.
-
-**Private Networking**
-
-Using [Private Networking](/guides/private-networking) when communicating with other services (such as databases) within your Railway project will help you avoid unnecessary Network Egress costs.
-
-**App Sleeping**
-
-Turning on [App Sleeping](/reference/app-sleeping) (aka "Serverless") may reduce the resource usage cost of a service. With App Sleeping enabled, Railway will pause your app if no traffic detected over a 10 minute period. When traffic is detected, your app will automatically resume.
+Check out our [guide on optimizing usage](/guides/optimize-usage).
 
 ### Why is my resource usage higher than expected?
 


### PR DESCRIPTION
This adds a "Use Private Networking" to https://docs.railway.app/guides/optimize-usage, and links to it from "How do I prevent spending more than I want to?" section of the pricing FAQ.