### PR TITLE
Redirect /reference/pricing -> /reference/pricing/plans

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -89,7 +89,12 @@ const redirects = [
       destination: "/tutorials/getting-started",
       permanent: true,
     },
+    {
+      source: "/reference/pricing",
+      destination: "/reference/pricing/plans",
+      permanent: true,
+    },
   ];
-  
+
   module.exports = redirects;
-  
+


### PR DESCRIPTION
#476 split the pricing docs up and /reference/pricing is no longer valid. We still link here in some places, so it's best to keep the redirect to a valid "nearest page" under pricing.