### PR TITLE
Update public-networking.md custom domain section

### DIFF
--- a/src/docs/guides/public-networking.md
+++ b/src/docs/guides/public-networking.md
@@ -83,6 +83,7 @@ Note that changes to DNS settings may take up to 72 hours to propagate worldwide
 
 **Important Considerations**
 - Freenom domains are not allowed and not supported.
+- The Trial Plan is limited to 1 custom domain. It is therefore not possible to use both `yourdomain.com` and `www.yourdomain.com` as these are considered two distinct custom domains.
 - The [Hobby Plan](/reference/pricing#plans) is limited to 2 custom domains per service.
 - The [Pro Plan]() is limited to 10 domains per service by default.  This limit can be increased for Pro users on request, simply reach out to us at [team@railway.app](mailto:team@railway.app) or via [private thread](/reference/support#private-threads).
 


### PR DESCRIPTION
Adding a line to Important Considerations to explain that Trial plan users only have one custom domain available.  
It currently isn't clear that www and root domains are considered unique in Railway.  
There are [several posts in the Discussions](https://help.railway.app/search?q=www+redirect) and [Discord](https://discord.com/channels/713503345364697088/1100135019726508164) asking about this so I'm trying to clarify directly in the docs.