### PR TITLE
feat: upgrade node version to LTS version 18

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=18.17.0"
   },
   "babelMacros": {
     "twin": {


### PR DESCRIPTION
# Description 

This PR aim to address part 1 of this GithHub issue: https://github.com/railwayapp/docs/issues/537 which is how the app uses an end of life node version from over a year ago. This also allows for upgrade to Next 14 from 13 later on as 14 only allows for node >18.x.

## Manual QA - Screenshots
App during manual QA was running on the specified node version locally ✅ 
<img width="858" alt="Screenshot 2024-08-16 at 10 31 35 PM" src="https://github.com/user-attachments/assets/69a49f16-a9eb-41eb-8666-2d2a8c9c494e">


App, pages, and links, etc. appear to be working well! ✅ 
<img width="1704" alt="Screenshot 2024-08-16 at 10 31 52 PM" src="https://github.com/user-attachments/assets/824ae60f-0325-40cd-82e6-cf42c9c30974">

<img width="1709" alt="Screenshot 2024-08-16 at 10 32 10 PM" src="https://github.com/user-attachments/assets/23bdb6ad-32c0-44bb-bf7d-21917b38145d">

<img width="1704" alt="Screenshot 2024-08-16 at 10 32 24 PM" src="https://github.com/user-attachments/assets/d42b2572-c501-48ba-b019-29e44367bd28">
