### PR TITLE
Bumps the GH Action to use Node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,12 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Use Node 16
-        uses: actions/setup-node@v3
+      - name: Use Node 18
+        uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 18.x
           cache: "yarn"
 
       - name: Install packages


### PR DESCRIPTION
*We really should move over our community contributions to Railway CI but it's fine as is.*

Because Node 16 LTS is nearing EOL, a customer kindly has bumped our Docs version up.