### PR TITLE
Add Missing CLI Options for Link Command in Railway CLI

### DIFF
--- a/src/docs/reference/cli-api.md
+++ b/src/docs/reference/cli-api.md
@@ -195,7 +195,9 @@ Arguments:
   [PROJECT_ID]  Project ID to link to
 
 Options:
-      --environment <ENVIRONMENT>  Environment to link to
+  -e, --environment <ENVIRONMENT>  Environment to link to
+  -p, --project-id <PROJECT-ID>    Project ID to link to
+  -s, --service <SERVICE>          The service to link to
       --json                       Output in JSON format
   -h, --help                       Print help
   -V, --version                    Print version


### PR DESCRIPTION
This PR adds a few missing options that were absent from the [Link](https://docs.railway.app/reference/cli-api#link) documentation, but are available when running the CLI in the terminal.