### PR TITLE
Add missing information

### DIFF
--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -7,6 +7,7 @@ import javascript from "react-syntax-highlighter/dist/cjs/languages/prism/javasc
 import json from "react-syntax-highlighter/dist/cjs/languages/prism/json";
 import toml from "react-syntax-highlighter/dist/cjs/languages/prism/toml";
 import typescript from "react-syntax-highlighter/dist/cjs/languages/prism/typescript";
+import go from "react-syntax-highlighter/dist/cjs/languages/prism/go";
 
 import "twin.macro";
 import { useCopy } from "../../hooks/useCopy";
@@ -23,6 +24,7 @@ SyntaxHighlighter.registerLanguage("toml", toml);
 SyntaxHighlighter.registerLanguage("json", json);
 SyntaxHighlighter.registerLanguage("graphql", graphql);
 SyntaxHighlighter.registerLanguage("typescript", typescript);
+SyntaxHighlighter.registerLanguage("go", go);
 
 export type SupportedLanguage =
   | "javascript"
@@ -30,7 +32,8 @@ export type SupportedLanguage =
   | "json"
   | "toml"
   | "graphql"
-  | "typescript";
+  | "typescript"
+  | "go";
 
 export interface Props {
   language?: string;

--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -34,7 +34,7 @@ layout="intrinsic"
 width={1080} height={950}
 quality={100} />
 
-This error occurs when Railway is unable to communicate with your application, making your request fail with a status code of 502 (Bad Gateway).
+This error occurs when Railway cannot communicate with your application, causing your request to fail with a 502 (Bad Gateway) status code.
 
 For Railway to communicate with your application, your web server should be available at host `0.0.0.0` and listen on the port specified by the `PORT` environment variable, which Railway automatically injects into your application.
 

--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -24,41 +24,42 @@ When deploying to Railway, you may encounter some errors that prevent your
 application from working as expected. These are descriptions and solutions to errors that
 users commonly encounter.
 
-## Application Error: This application failed to respond
+## Application failed to respond
 
-After deploying your application, you encounter this screen when accessing
-your application's domain:
+After deploying your application or making changes, you might encounter this screen when accessing your application's domain:
+
 <Image src="https://res.cloudinary.com/railway/image/upload/v1722017042/docs/application-error_wgrwro_i4tjkl.png"
 alt="Screenshot of application failed to respond error"
+layout="intrinsic"
 width={1080} height={950}
 quality={100} />
 
-This error occurs when Railway is unable to connect to your application, making your request fail with status code 502 (Bad Gateway).
+This error occurs when Railway is unable to communicate with your application, making your request fail with a status code of 502 (Bad Gateway).
 
-Railway needs to know how to communicate with your application. When you
-deploy and expose a web application on Railway, we expect your web server
-to be available at host `0.0.0.0` and a port that we provide in the form
-of a `PORT` variable. The `PORT` variable is automatically injected by
-Railway into your application's environment.
+For Railway to communicate with your application, your web server should be available at host `0.0.0.0` and listen on the port specified by the `PORT` environment variable, which Railway automatically injects into your application.
 
-Thus, your web server must listen on host `0.0.0.0` and the port that
-Railway provides in the `PORT` environment variable.
+Separately, you need to set the correct [target port](/guides/public-networking#target-ports) for your public domain.
+
+Without these configurations, Railway cannot establish a connection to your running application.
 
 ### Solution
 
 To fix this, start your application's server using:
-* Host = `0.0.0.0`,
-* Port = Value of the `PORT` environment variable provided by Railway.
 
-<Banner variant="info">
-Alternatively, you can set a custom `PORT` service variable in your
-Railway environment to tell Railway that your application is available
-at the port you specified. For more information, check out
-[Defining Variables](/develop/variables#defining-variables).
-**This approach is not recommended**.
-</Banner>
+- Host = `0.0.0.0`
+- Port = Value of the `PORT` environment variable provided by Railway.
 
-Below are some solution examples for common languages and frameworks.
+Next, ensure that the target port for your public domain is set to the port your application is now listening on.
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1726092089/docs/target_ports_eiqgw0.png"
+alt="Screenshot of application failed to respond error"
+layout="intrinsic"
+width={700} height={634}
+quality={100} />
+
+<span style={{'font-size': "0.9em"}}>Screenshot showing that the domain was previously configured with port 3000, and the correct 8080 port.</span>
+
+**Below are some solution examples for common languages and frameworks.**
 
 #### Node / Express
 

--- a/src/docs/guides/healthchecks-and-restarts.md
+++ b/src/docs/guides/healthchecks-and-restarts.md
@@ -4,7 +4,7 @@ title: Configure Healthchecks and Restart Policy
 
 Railway provides controls for ensuring deployed services remain healthy.
 
-## Configure Healthcheck Endpoint
+## Configure Healthcheck Path
 
 A Healthcheck can be used to guarantee zero-downtime deployments of your web services by ensuring the new version is live and able to handle requests.
 
@@ -12,13 +12,17 @@ To configure a healthcheck -
 1. Ensure your webserver has an endpoint (e.g. `/health`) that will return an HTTP status code of 200 when the application is live and ready
 2. Under your service settings, input your health endpoint.  Railway will wait for this endpoint to serve a `200` status code before switching traffic to your new endpoint
 
-Note that Railway does not monitor the healthcheck endpoint after the deployment has gone live.
+**Note:** Railway does not monitor the healthcheck endpoint after the deployment has gone live.
+
+## Configure Healthcheck Port
+
+Railway will inject a `PORT` environment variable that your application should listen on. This variable's value is also used for performing health checks on your application.
+
+If your application doesn't listen on the `PORT` variable, possibly due to using [target ports](/guides/public-networking#target-ports), you can manually set a `PORT` variable to inform Railway of the port to use for health checks.
 
 ### Healthcheck Timeout
 
-The default timeout on healthchecks is 300 seconds (5 minutes) - if your application fails
-to serve a `200` status code during this allotted time, the deploy will be marked
-as failed.
+The default timeout on healthchecks is by default 300 seconds (5 minutes) - if your application fails to serve a `200` status code during this allotted time, the deploy will be marked as failed.
 
 <Image 
 src="https://res.cloudinary.com/railway/image/upload/v1664564544/docs/healthcheck-timeout_lozkiv.png"
@@ -26,7 +30,7 @@ alt="Screenshot of Healthchecks Timeouts"
 layout="intrinsic"
 width={1188} height={348} quality={80} />
 
-To increase the timeout, change the number of seconds on the service settings page.
+To increase the timeout, change the number of seconds on the service settings page, or with a `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` service variable.
 
 ### Services with Attached Volumes
 
@@ -41,6 +45,8 @@ If you are looking for a quick way to setup continuous monitoring of your servic
 ## Restart Policy
 
 The restart policy dictates what action Railway should take if a deployed service stops or otherwise becomes unhealthy, e.g. exits with a non-zero exit code.
+
+**Note:** For services with multiple replicas, a restart will only affect the replica that crashed, while the other replica(s) continue handling the workload until the restarted replica is back online.
 
 To configure a restart policy, go to the Service settings, set a restart policy of `Never`, `Always`, or `On-Failure` with an optional maximum number of restarts.
 

--- a/src/docs/guides/public-networking.md
+++ b/src/docs/guides/public-networking.md
@@ -157,7 +157,7 @@ Generally, direct CNAME records at the root or apex level are incompatible with 
 The type of record to create is entirely dependent on your DNS provider.  Here are some examples -
 
 - <a href="https://developers.cloudflare.com/dns/zone-setups/partial-setup" target="_blank">Cloudflare CNAME</a> - Simply set up a CNAME record for your root domain in Cloudflare, and they take care of the rest under the hood.  Refer to <a href="https://support.cloudflare.com/hc/en-us/articles/205893698-Configure-Cloudflare-and-Heroku-over-HTTPS" target="_blank">this guide</a> for more detailed instructions.
-- <a href="https://support.dnsimple.com/articles/domain-apex-heroku/" target="_blank">DNSimple ALIAS</a> - Set up an ALIAS in DNSimple for your root domain.
+- <a href="https://support.dnsimple.com/articles/domain-apex-heroku/" target="_blank">DNSimple ALIAS</a> - Set up an dynamic ALIAS in DNSimple for your root domain.
 - <a href="https://www.namecheap.com/support/knowledgebase/article.aspx/9646/2237/how-to-create-a-cname-record-for-your-domain/" target="_blank">Namecheap CNAME</a> - Set up an CNAME in Namecheap for your root domain.
 
 In contrast there are many nameservers that don't support CNAME flattening or dynamic ALIAS records -
@@ -166,6 +166,7 @@ In contrast there are many nameservers that don't support CNAME flattening or dy
 - <a href="https://support.hostinger.com/en/articles/1696789-how-to-change-nameservers-at-hostinger" target="_blank">Hostinger</a>
 - <a href="https://www.godaddy.com/en-ca/help/edit-my-domain-nameservers-664" target="_blank">GoDaddy</a>
 - <a href="https://www.namesilo.com/support/v2/articles/domain-manager/dns-manager" target="_blank">NameSilo</a>
+- <a href="https://dns.he.net/" target="_blank">Hurricane Electric</a>
 
 **Workaround - Changing your Domain's Nameservers**
 

--- a/src/docs/guides/public-networking.md
+++ b/src/docs/guides/public-networking.md
@@ -119,6 +119,30 @@ If you have a wildcard domain on Cloudflare, you must:
     layout="responsive"
     width={855} height={342} quality={80} />
 
+## Target Ports
+
+Target Ports, or Magic Ports, correlate a single domain to a specific internal port that the application listens on, enabling you to expose multiple HTTP ports through the use of multiple domains.
+
+Example -
+
+`https://example.com/` → `:8080`
+
+`https://management.example.com/` → `:9000`
+
+When you first generate a Railway-provided domain, if your application listens on a single port, Railway's magic automatically detects and sets it as the domain's target port. If your app listens on multiple ports, you're provided with a list to choose from.
+
+When you add a custom domain, you're given a list of ports to choose from, and the selected port will handle all traffic routed to the domain. You can also specify a custom port if needed.
+
+These target ports inform Railway which public domain corresponds to each internal port, ensuring that traffic from a specific domain is correctly routed to your application.
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1726092043/docs/target_ports_custom_domain_qhgd5p.png"
+alt="Screenshot of target port selection on a custom domain"
+layout="intrinsic"
+width={700} height={582}
+quality={100} />
+
+You can change the automatically detected or manually set port at any time by clicking the edit icon next to the domain.
+
 ## Adding a custom domain
 
 When adding a root or apex domain to your Railway service, you must ensure that you add the appropriate DNS record to the domain within your DNS provider.  At this time, Railway supports <a href="https://developers.cloudflare.com/dns/cname-flattening/" target="_blank">CNAME Flattening</a> and ALIAS records.
@@ -141,6 +165,7 @@ In contrast there are many nameservers that don't support CNAME flattening or dy
 - <a href="https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/domain-register-other-dns-service.html" target="_blank">AWS Route 53</a>
 - <a href="https://support.hostinger.com/en/articles/1696789-how-to-change-nameservers-at-hostinger" target="_blank">Hostinger</a>
 - <a href="https://www.godaddy.com/en-ca/help/edit-my-domain-nameservers-664" target="_blank">GoDaddy</a>
+- <a href="https://www.namesilo.com/support/v2/articles/domain-manager/dns-manager" target="_blank">NameSilo</a>
 
 **Workaround - Changing your Domain's Nameservers**
 

--- a/src/docs/tutorials/set-up-a-tailscale-subnet-router.md
+++ b/src/docs/tutorials/set-up-a-tailscale-subnet-router.md
@@ -182,6 +182,8 @@ width={602} height={526} quality={100} />
 
 - Click **Save**.
 
+- Ensure that the **Use Tailscale subnets** option is enabled in your Tailscale client's Settings or Preferences menu.
+
 **That is it for all the configurations needed, you can now call any service via its private domain and port just as if you were another service within the private network!**
 
 ## 5. Connecting to a service on the private network (Bonus)


### PR DESCRIPTION
- Updates common errors with info about target ports, since that comes into play with the 502 error now.
- Add info about needing a `PORT` variable for health checks when target ports are in use.
- Add a note about how the restart mechanism works for services with multiple replicas.
- Document target ports.
- Support Go syntax highlighting for code blocks.
- Add two more nameserver providers that don't support root-level CNAMEs.
- Add a note about enabling subnets in the tailscale client settings.