### PR TITLE
Private networking works on App sleep

### DIFF
--- a/src/docs/reference/app-sleeping.md
+++ b/src/docs/reference/app-sleeping.md
@@ -21,7 +21,6 @@ The first request made to a slept service wakes it. It may take a small amount o
 ## Caveats
 
 - There will be a small delay in the response time of the first request sent to a slept service (commonly known as "cold boot times")
-- [Private Networking](/reference/private-networking) does not currently work with App Sleeping
 - For Railway to put a service to sleep, a service must not send _outbound_ traffic for at least 10 minutes. Outbound traffic can include telemetry, NTP, etc. Inbound traffic is excluded from considering when to sleep a service.
 - Enabling App Sleeping will apply the setting across all [Replicas](/reference/scaling#horizontal-scaling-with-replicas)
 - Slept services still consume a slot on our infrastructure, enabling App Sleeping de-prioritizes your workload and in remote cases, may require a rebuild to re-live the service.


### PR DESCRIPTION
With our new runtime which has been the default for months, private networking and app sleep work together
