### PR TITLE
Fix the color flashing on first page draw on code blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@tailwindcss/typography": "^0.5.9",
     "classnames": "^2.3.2",
     "contentlayer": "^0.3.4",
+    "cookies-next": "^4.2.1",
     "copy-to-clipboard": "^3.3.1",
     "dayjs": "^1.10.4",
     "fathom-client": "^3.1.0",

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -39,11 +39,17 @@ export interface Props {
   language?: string;
   className?: string;
   children?: any;
+  colorModeSSR?: string | null;
 }
 
 const getParams = (
   className = "",
-): { language?: string; for?: string; always?: boolean } => {
+): {
+  language?: string;
+  languageFull?: string;
+  for?: string;
+  always?: boolean;
+} => {
   const [language, params = ""] = className.split(":");
 
   const splitParams = params
@@ -59,6 +65,7 @@ const getParams = (
 
   return {
     language: language.split("language-")[1],
+    languageFull: language || "language-plaintext",
     ...splitParams,
   };
 };
@@ -67,11 +74,9 @@ export const CodeBlock: React.FC<Props> = ({
   children,
   className = children.props ? children.props.className : "",
   language,
+  colorModeSSR,
 }) => {
   const [copied, copy] = useCopy();
-
-  const { colorMode } = useTheme();
-  const theme = colorMode === "light" ? lightCodeTheme : darkCodeTheme;
 
   const params = useMemo(() => getParams(className), [className]);
 
@@ -96,9 +101,17 @@ export const CodeBlock: React.FC<Props> = ({
 
   const isMounted = useIsMounted();
 
+  const colorMode = !isMounted ? colorModeSSR || "light" : useTheme().colorMode;
+
+  const theme = colorMode === "light" ? lightCodeTheme : darkCodeTheme;
+
   return (
     <div tw="relative" className="group">
-      <SyntaxHighlighter language={lang} style={theme} key={isMounted ? "mounted" : "unmounted"}>
+      <SyntaxHighlighter
+        language={lang}
+        style={theme}
+        data-colorMode={colorMode}
+      >
         {content}
       </SyntaxHighlighter>
       <div tw="absolute top-0 right-0 mr-1 mt-1 text-gray-300 hover:text-gray-400 hidden group-hover:flex">

--- a/src/components/CodeBlock/index.tsx
+++ b/src/components/CodeBlock/index.tsx
@@ -46,7 +46,6 @@ const getParams = (
   className = "",
 ): {
   language?: string;
-  languageFull?: string;
   for?: string;
   always?: boolean;
 } => {
@@ -65,7 +64,6 @@ const getParams = (
 
   return {
     language: language.split("language-")[1],
-    languageFull: language || "language-plaintext",
     ...splitParams,
   };
 };

--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,8 +1,11 @@
 import tw, { styled } from "twin.macro";
 import { useTheme } from "../styles/theme";
+import { useIsMounted } from "@/hooks/useIsMounted";
 
 export const XIcon = () => {
   const { colorMode } = useTheme();
+
+  const isMounted = useIsMounted();
 
   return (
     <svg
@@ -19,6 +22,7 @@ export const XIcon = () => {
         strokeLinejoin: "round",
         strokeMiterlimit: 2,
       }}
+      key={isMounted ? "mounted" : "unmounted"}
     >
       <path
         d="M178.57,127.15L290.27,0L263.81,0L166.78,110.38L89.34,0L0,0L117.13,166.93L0,300.25L26.46,300.25L128.86,183.66L210.66,300.25L300,300.25M36.01,19.54L76.66,19.54L263.79,281.67L223.13,281.67"

--- a/src/components/InlineCode.tsx
+++ b/src/components/InlineCode.tsx
@@ -13,22 +13,26 @@ type CodeTheme = {
   };
 };
 
-export const InlineCode: React.FC<PropsWithChildren> = ({ children }) => {
-  const { colorMode } = useTheme();
-  const theme = (
-    colorMode == "light" ? lightCodeTheme : darkCodeTheme
-  ) as CodeTheme;
+export interface Props {
+  children?: any;
+  colorModeSSR?: string | null;
+}
 
+export const InlineCode: React.FC<Props> = ({ children, colorModeSSR }) => {
   const isMounted = useIsMounted();
+
+  const colorMode = !isMounted ? colorModeSSR || "light" : useTheme().colorMode;
+
+  const theme = colorMode === "light" ? lightCodeTheme : darkCodeTheme;
 
   return (
     <code
       css={tw`px-2 py-1 rounded font-mono whitespace-nowrap before:content-[''] after:content-['']`}
       style={{
-        backgroundColor: theme['pre[class*="language-"]'].background,
+        backgroundColor: String(theme['pre[class*="language-"]'].background),
         color: theme['code[class*="language-"]'].color,
       }}
-      key={isMounted ? "mounted" : "unmounted"}
+      data-colorMode={colorMode}
     >
       {children}
     </code>

--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -38,7 +38,7 @@ This error occurs when Railway cannot communicate with your application, causing
 
 For Railway to communicate with your application, your web server should be available at host `0.0.0.0` and listen on the port specified by the `PORT` environment variable, which Railway automatically injects into your application.
 
-Separately, you need to set the correct [target port](/guides/public-networking#target-ports) for your public domain.
+Additionally, if you're using [target ports](/guides/public-networking#target-ports) for your public domain, have your target port set to the correct value.
 
 Without these configurations, Railway cannot establish a connection to your running application.
 
@@ -49,7 +49,7 @@ To fix this, start your application's server using:
 - Host = `0.0.0.0`
 - Port = Value of the `PORT` environment variable provided by Railway.
 
-Next, ensure that the target port for your public domain is set to the port your application is now listening on.
+Next, if you're using [target ports](/guides/public-networking#target-ports), ensure that the target port for your public domain matches the port your application is now listening on.
 
 This setting can be found within your [service settings](/overview/the-basics#service-settings).
 

--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -113,7 +113,7 @@ There is no additional configuration necessary.
 uvicorn main:app --host 0.0.0.0 --port $PORT
 ```
 
-#### Go / `net/http`
+#### Go / net/http
 
 This example is for `net/http` in the Go standard library, but you can also apply this to other frameworks:
 ```go

--- a/src/docs/guides/healthchecks-and-restarts.md
+++ b/src/docs/guides/healthchecks-and-restarts.md
@@ -46,9 +46,17 @@ To increase the timeout, change the number of seconds on the service settings pa
 
 To prevent data corruption, we prevent multiple deployments from being active and mounted to the same service. This means that there will be a small amount of downtime when re-deploying a service that has a volume attached, even if there is a healthcheck endpoint configured.
 
+### Healthcheck Hostname
+
+Railway uses the hostname `healthcheck.railway.app` when performing healthchecks on your service. This is the domain from which the healthcheck requests will originate.
+
+For applications that restrict incoming traffic based on the hostname, you'll need to add `healthcheck.railway.app` to your list of allowed hosts. This ensures that your application will accept healthcheck requests from Railway.
+
+If your application does not permit requests from that hostname, you may encounter errors during the healthcheck process, such as "failed with service unavailable" or "failed with status 400".
+
 ### Continuous Healthchecks
 
-The healthcheck endpoint is currently ***not intended for continuous monitoring*** as it is only called at the start of the deployment, to ensure it is healthy prior to routing traffic to it.
+The healthcheck endpoint is currently ***not used for continuous monitoring*** as it is only called at the start of the deployment, to ensure it is healthy prior to routing traffic to it.
 
 If you are looking for a quick way to setup continuous monitoring of your service(s), check out the <a href="https://railway.app/template/p6dsil" target="_blank">Uptime Kuma template</a> in our template marketplace.
 

--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -80,6 +80,41 @@ When you cancel your subscription, if you're on Hobby, Pro, or Enterprise, your 
 
 If you are on the Hobby plan and using prepaid credits as your payment method, your subscription will be canceled immediately and any credit balance you may have will be forfeited.
 
+### How do I switch between Hobby plan billing models?
+
+At this time, we do not directly support switching between Hobby plan billing models, such as switching from a prepaid credit-based plan to an auto-renewing subscription, or vice versa.
+
+You can, however, cancel your current plan and sign back up with the desired billing model.
+
+**Note:** Cancelling your subscription does not immediately stop your [services](/overview/the-basics#services). The outcome depends on your previous plan -
+
+- For subscription-based plans: Services will continue until the end of your current billing period.
+- For prepaid credits-based plans: Services will run until you exhaust your remaining credits.
+
+**To switch between billing models, you first need to cancel your current plan** -
+
+- Head over to the <a href="https://railway.app/account/billing" target="_blank">billing page</a> of your account.
+- Click on **Manage Subscription**.
+- Click on **Cancel Plan**.
+
+**Sign back up for Railway using the prepaid credits model** -
+
+- Head over to the <a href="https://railway.app/account/upgrade" target="_blank">upgrade page</a>.
+- Scroll to the bottom and select **Looking for a prepaid subscription**.
+- Enter your billing information.
+- Enter the amount of credits you'd like to add to your account. (Minimum of $10)
+- Click on **Purchase Credits**.
+
+You are now on the prepaid credits model. Be sure to always keep a balance in your account to keep your services running.
+
+**Sign back up for Railway using the auto-renewing subscription model** -
+
+- Head over to the <a href="https://railway.app/account/upgrade" target="_blank">upgrade page</a>.
+- Enter your billing information.
+- Click on **Subscribe to Hobby Plan**.
+
+You are now on the auto-renewing subscription model.
+
 ### What happens if the payment fails for my subscription?
 
 If your subscription payment fails, we retry the payment method on file over several days. We also inform you of the payment failure, in case your payment method needs to be updated.

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -3,17 +3,18 @@ import { Collapse } from "@/components/Collapse";
 import { CodeBlock } from "@/components/CodeBlock";
 import Layout from "@/mdxLayouts/index";
 import { allPages, Page } from "contentlayer/generated";
-import { GetStaticPaths, GetStaticProps } from "next";
 import { useMDXComponent } from "next-contentlayer/hooks";
 import Link from "next/link";
 import { Image } from "@/components/Image";
 import { InlineCode } from "@/components/InlineCode";
 import { H2, H3, H4 } from "@/components/Header";
 import { Anchor } from "@/components/Anchor";
+import { GetServerSidePropsContext } from "next";
+import { getCookie } from "cookies-next";
+import { Props as CodeBlockProps } from "@/components/CodeBlock";
+import { Props as InlineCodeProps } from "@/components/InlineCode";
 
 const components: Record<string, React.ElementType> = {
-  pre: CodeBlock,
-  code: InlineCode,
   Collapse,
   Image,
   Banner,
@@ -25,8 +26,25 @@ const components: Record<string, React.ElementType> = {
   h4: H4,
 };
 
-export default function PostPage({ page }: { page: Page }) {
+export default function PostPage({
+  page,
+  colorModeSSR,
+}: {
+  page: Page;
+  colorModeSSR: string | null;
+}) {
   const MDXContent = useMDXComponent(page.body.code);
+
+  // Create a new components object with the extra props
+  const componentsWithProps = {
+    ...components,
+    pre: (props: CodeBlockProps) => (
+      <CodeBlock {...props} colorModeSSR={colorModeSSR} />
+    ),
+    code: (props: InlineCodeProps) => (
+      <InlineCode {...props} colorModeSSR={colorModeSSR} />
+    ),
+  };
 
   return (
     <Layout
@@ -34,29 +52,30 @@ export default function PostPage({ page }: { page: Page }) {
         title: page.title,
       }}
     >
-      <MDXContent components={components} />
+      <MDXContent components={componentsWithProps} />
     </Layout>
   );
 }
 
-export const getStaticProps: GetStaticProps = async ({ params }) => {
-  const page = allPages.find(
-    page =>
-      page._raw.flattenedPath ===
-      (params?.slug as string[] | undefined)?.join("/"),
-  );
+export const getServerSideProps = async (
+  context: GetServerSidePropsContext,
+) => {
+  const { slug } = context.params as { slug: string[] };
+  const page = allPages.find(p => p.url === `/${slug.join("/")}`);
+  const themeCookie = getCookie("theme", { req: context.req }) as
+    | string
+    | undefined;
+
+  if (!page) {
+    return {
+      notFound: true,
+    };
+  }
 
   return {
     props: {
       page,
+      colorModeSSR: themeCookie ?? null,
     },
-  };
-};
-
-export const getStaticPaths: GetStaticPaths = async () => {
-  const paths = allPages.map(page => page.url);
-  return {
-    paths,
-    fallback: false,
   };
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -133,7 +133,7 @@ const Home: NextPage = () => {
             </ButtonLink>
           </div>
         </div>
-        <div tw="mt-16 grid grid-cols-1 md:grid-cols-3 gap-4">
+        <div tw="mt-16 grid grid-cols-1 md:grid-cols-3 gap-x-4 gap-y-5">
           <OverviewSecondaryLink href="https://discord.gg/railway">
             <DiscordIcon tw="w-8 h-8" />
             <div>Join our Discord Server </div>
@@ -182,4 +182,5 @@ const OverviewLinkText = styled.div`
 
 const OverviewSecondaryLink = styled(Link)`
   ${tw`flex items-center text-gray-600 gap-2 hover:text-pink-700`}
+  ${tw`justify-center text-center`}
 `;

--- a/src/styles/theme.tsx
+++ b/src/styles/theme.tsx
@@ -7,12 +7,14 @@ import React, {
   createContext,
   PropsWithChildren,
   useContext,
+  useEffect,
   useMemo,
 } from "react";
 import { transformThemeToCustomProperties } from "theme-custom-properties";
 import { GlobalStyles as TwinGlobalStyles } from "twin.macro";
 import { ColorMode, colorThemes, defaultColorMode } from "./colors";
 import { GlobalStyles } from "./GlobalStyles";
+import { setCookie } from "cookies-next";
 
 const themes = {
   light: { colors: colorThemes.light },
@@ -46,9 +48,14 @@ export const WrappedThemeProvider: React.FC<PropsWithChildren> = ({
   const themeState: ThemeState = {
     colorMode,
     setColorMode: value => {
+      setCookie("theme", value, { maxAge: 60 * 60 * 24 * 365 * 100 });
       setTheme(value);
     },
   };
+
+  useEffect(() => {
+    setCookie("theme", colorMode, { maxAge: 60 * 60 * 24 * 365 * 100 });
+  }, [colorMode]);
 
   return (
     <ThemeContext.Provider value={themeState}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -2910,6 +2910,11 @@
   dependencies:
     "@types/estree" "*"
 
+"@types/cookie@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@types/cookie/-/cookie-0.6.0.tgz#eac397f28bf1d6ae0ae081363eca2f425bedf0d5"
+  integrity sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==
+
 "@types/debug@^4.0.0":
   version "4.1.7"
   resolved "https://registry.npmjs.org/@types/debug/-/debug-4.1.7.tgz"
@@ -3760,6 +3765,19 @@ convert-source-map@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz"
   integrity sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==
+
+cookie@^0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.6.0.tgz#2798b04b071b0ecbff0dbb62a505a8efa4e19051"
+  integrity sha512-U71cyTamuh1CRNCfpGY6to28lxvNwPG4Guz/EVjgf3Jmzv0vlDp1atT9eS5dDjMYHucpHbWns6Lwf3BKz6svdw==
+
+cookies-next@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/cookies-next/-/cookies-next-4.2.1.tgz#a0c2942afee16f1ffc2bc05a003c7c0cf32deda5"
+  integrity sha512-qsjtZ8TLlxCSX2JphMQNhkm3V3zIMQ05WrLkBKBwu50npBbBfiZWIdmSMzBGcdGKfMK19E0PIitTfRFAdMGHXg==
+  dependencies:
+    "@types/cookie" "^0.6.0"
+    cookie "^0.6.0"
 
 copy-to-clipboard@^3.3.1:
   version "3.3.3"


### PR DESCRIPTION
- Fixes dark mode flash on code blocks when set to light mode
- Fixes the [X.com](http://x.com/) icon not respecting the set theme.
- Adds another section to the health check guide that mentions the use of `[healthcheck.railway.app](http://healthcheck.railway.app/)` as the hostname when health checks are performed.
- Changes some grammar about healthchecks not being used for continuous testing.
- Updates the copy for the fixing common errors page to add if clauses on the target port information. (some deploys may not be using them)
- Adds an FAQ section to the pricing faq page that covers how a user can go from a pre-paid hobby plan to an automatic payment hobby plan, or vice versa.