### PR TITLE
Fix meilisearch index

### DIFF
--- a/meilisearch-docs-scraper.config.json
+++ b/meilisearch-docs-scraper.config.json
@@ -1,10 +1,9 @@
 {
   "index_uid": "docs_railway_app_production",
-  "stop_urls": [
-    "https://docs.railway.app/quick-start"
-  ],
-  "sitemap_urls": [
-    "https://docs.railway.app/sitemap.xml"
+  "start_urls": [
+    {
+      "url": "https://docs.railway.app/"
+    }
   ],
   "js_render": false,
   "scrape_start_urls": false,


### PR DESCRIPTION
Looks like somehow the XML sitemap got fucked. This rejigs the config to just crawl all backlinks
