### PR TITLE
Add more info to app sleeping

### DIFF
--- a/src/docs/reference/app-sleeping.md
+++ b/src/docs/reference/app-sleeping.md
@@ -6,22 +6,35 @@ App Sleeping (aka "Serverless") allows you to increase the efficiency of resourc
 
 ## How it Works
 
-App sleeping is configured on a service and enables automated detection of an inactivity based on outbound traffic.
+When App Sleeping is enabled for a service, Railway automatically detects inactivity based on outbound traffic.
 
 #### Inactive Service Detection
 
-Inactivity is based on detection of any outbound packets, which could include telemetry or NTP. If no packets are sent from the service for over 10 minutes or longer, the service is considered inactive.
+Inactivity is based on the detection of any outbound packets, which could include network requests, database connections, or even NTP. If no packets are sent from the service for over 10 minutes, the service is considered inactive.
+
+Some things than can prevent a service from being put to sleep -
+
+- Keeping active database connections open, such as a database connection pooler.
+- Frameworks that report telemetry to their respective services, such as [Next.js](https://nextjs.org/telemetry).
+- Making requests to other services in the same [project](/overview/the-basics#project--project-canvas) over the [private network](/reference/private-networking).
+- Making requests to other Railway services over the public internet.
+- Making requests to external services over the public internet.
+- Receiving traffic from other services in the same project over the private network.
+- Receiving traffic from other Railway services over the public internet.
+- Receiving traffic from external services over the public internet.
+
+It's important to note that the networking graph in the metrics tab only displays public internet traffic. If you're using a private network to communicate with other services, this traffic won't appear in the metrics tab. However, it's still counted as outbound traffic and will prevent the service from being put to sleep.
 
 #### Waking a Service Up
 
-A service is woken when it receives traffic from the internet.
+A service is woken when it receives traffic from the internet or from another service in the same project through the [private network](/reference/private-networking).
 
 The first request made to a slept service wakes it. It may take a small amount of time for the service to spin up again on the first request (commonly known as "cold boot time").
 
 ## Caveats
 
 - There will be a small delay in the response time of the first request sent to a slept service (commonly known as "cold boot times")
-- For Railway to put a service to sleep, a service must not send _outbound_ traffic for at least 10 minutes. Outbound traffic can include telemetry, NTP, etc. Inbound traffic is excluded from considering when to sleep a service.
+- For Railway to put a service to sleep, a service must not send _outbound_ traffic for at least 10 minutes. Outbound traffic can include telemetry, database connections, NTP, etc. Inbound traffic is excluded from considering when to sleep a service.
 - Enabling App Sleeping will apply the setting across all [Replicas](/reference/scaling#horizontal-scaling-with-replicas)
 - Slept services still consume a slot on our infrastructure, enabling App Sleeping de-prioritizes your workload and in remote cases, may require a rebuild to re-live the service.
 

--- a/src/utils/scroll.ts
+++ b/src/utils/scroll.ts
@@ -4,17 +4,24 @@ export const scrollToID =
     // if input is a string with #, then split it and take the last element
     // if input is not a string with #, then take the input
     // this is needed because the input can be a relative path such as "/quick-start#deploying-your-project---from-github"
-    const id = input.split("#")[1] || input;
+    const splitInput = input.split("#");
 
-    if (!id) return;
+    // if input links to a different page, then don't scroll, let the browser navigate to the path
+    if (splitInput.length == 2 && splitInput[0] && splitInput[0] != window.location.pathname) {
+      return;
+    }
 
-    const element = document.getElementById(id);
+    const slug = splitInput[1] || input;
+
+    if (!slug) return;
+
+    const element = document.getElementById(slug);
 
     if (!element) return;
 
     event.preventDefault();
 
-    history.pushState(null, "", `#${id}`);
+    history.pushState(null, "", `#${slug}`);
 
     if (skipScroll) return;
 


### PR DESCRIPTION
- Adds more information to the App Sleeping reference page. Specially, adding scenarios that will keep the app from sleeping and make it clearer that private network traffic will prevent the app from sleeping,
- Fix a smooth scroll bug where links to different pages would smooth scroll to an element on the current page if the link had a hash for an element that existed on the current page, we now check if the link's path is the same as the windows path before deciding to smooth scroll or treat it as a regular link.