### PR TITLE
small updates

### DIFF
--- a/src/docs/guides/optimize-usage.md
+++ b/src/docs/guides/optimize-usage.md
@@ -44,9 +44,8 @@ Using [Private Networking](/guides/private-networking) when communicating with o
 
 ### With databases
 
-Communicate with your Railway database over private networking by using the `DATABASE_PRIVATE_URL` environment variable, instead of `DATABASE_PUBLIC_URL`:
+Communicate with your Railway database over private networking by using the `DATABASE_URL` environment variable, instead of `DATABASE_PUBLIC_URL`:
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1715870608/docs/privnet-db_iujd9g.png" alt="Database Private URL" layout="responsive" width={664} height={452} />
 
 ### With other services
 

--- a/src/docs/overview/best-practices.md
+++ b/src/docs/overview/best-practices.md
@@ -17,7 +17,7 @@ Railway is a highly versatile platform, offering various ways to use it, though 
 
 [Private networking](/reference/private-networking) allows services within a [project](/overview/the-basics#project--project-canvas) to communicate internally without the need to expose them [publicly](/guides/public-networking), while also providing faster communication and increased throughput.
 
-When configuring environment variables in your service to reference domains or URLs of other services, ensure you use the private versions of these variables, such as `RAILWAY_PRIVATE_DOMAIN` or `DATABASE_PRIVATE_URL`.
+When configuring environment variables in your service to reference domains or URLs of other services, ensure you use the private versions of these variables, such as `RAILWAY_PRIVATE_DOMAIN` or `DATABASE_URL`.
 
 Using the private network enables communication between services within the same project without incurring service-to-service egress costs, which is particularly beneficial when interacting with databases or other internal services.
 

--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -33,7 +33,7 @@ Depending on the plan you are on, you are allowed to use up these resources per 
 | Plan           | **RAM**    | **CPU**     | **Ephemeral Storage** | **Volume Storage** |
 | -------------- | ---------- | ----------- | --------------------- | ------------------ |
 | **Trial**      | **0.5 GB** | **2 vCPU**  | **1 GB**              | **0.5 GB**         | 
-| **Hobby**      | **8 GB**   | **8 vCPU**  | **100 GB**            | **5 GB**           |
+| **Hobby**      | **8 GB**   | **8 vCPU**  | **10 GB**            | **5 GB**           |
 | **Pro**        | **32 GB**  | **32 vCPU** | **100 GB**            | **50 GB**          |
 | **Enterprise** | **64 GB**  | **64 vCPU** | **100 GB**            | **50 GB**          |
 
@@ -91,7 +91,7 @@ Credits as a payment method is only available for Hobby plan users.
 
 ### Purchasing credits
 
-You can purchase credits from your account's [billing page](https://railway.app/account/billing).
+You can purchase credits from your account's [usage page](https://railway.app/account/usage).
 
 ### One-time grant of credits on the Free Trial
 

--- a/src/docs/reference/public-networking.md
+++ b/src/docs/reference/public-networking.md
@@ -20,7 +20,7 @@ If you have your own Domain already, Railway also supports adding custom domains
 | **Certificate Issuance** | - Railway attempts to issue a certificate for **up to 72 hours** after domain creation before failing.<br/>- Certificates are expected to be issued within an hour. |
 | **TLS** | - Support for TLS 1.2 and TLS 1.3 with specific ciphersets.<br/>- Certificates are valid for 90 days and renewed every 30 days.<br/>- Cloudflare Proxying does impact certificate issuance and support for wildcard domains. |
 | **Edge Traffic** | - Support for HTTP/1.1 and HTTP/2.<br/>- Support for websockets over HTTP/1.1 (may be interrupted after 2-4hrs, clients should handle reconnect).<br/>- Idle timeout of 900 seconds.<br/>- Max 100 request headers.<br /> - Max 100 concurrent streams per HTTP2 connection.<br/>- Max duration of 5 minutes for HTTP requests. |
-| **Request Headers** | - `X-Forwarded-For` for identifying client's remote IP.<br/>- `X-Forwarded-Proto` always indicates HTTPS.<br/>- `X-Railway-Request-Id` for correlating requests against network logs. |
+| **Request Headers** | - `X-Real-IP` for identifying client's remote IP.<br/>- `X-Forwarded-Proto` always indicates `https`.<br/>- `X-Railway-Request-Id` for correlating requests against network logs. |
 | **Requests** | - Inbound traffic must be TLS-encrypted<br/>- HTTP GET requests to port 80 are redirected to HTTPS.<br/>- HTTP POST requests to port 80 are redirected to HTTPS as GET requests.<br/>- SNI is required for correct certificate matching. |
 
 ## Domain Rate Limits


### PR DESCRIPTION
- Removes some mentions of private database URLs since the URLs are private ones by default now.
- Corrects how much ephemeral storage Hobby users are allowed.
- Fixes a URL on where to load credits.
- Updates the request header that users should be using to get the client's IP from the incoming request.