### PR TITLE
fix: healthcheck hostname

### DIFF
--- a/src/docs/guides/healthchecks-and-restarts.md
+++ b/src/docs/guides/healthchecks-and-restarts.md
@@ -48,9 +48,9 @@ To prevent data corruption, we prevent multiple deployments from being active an
 
 ### Healthcheck Hostname
 
-Railway uses the hostname `healthcheck.railway.com` or the `healthcheck.railway.app` when performing healthchecks on your service. This is the domain from which the healthcheck requests will originate.
+Railway uses the hostname `healthcheck.railway.app` when performing healthchecks on your service. This is the domain from which the healthcheck requests will originate.
 
-For applications that restrict incoming traffic based on the hostname, you'll need to add `healthcheck.railway.com` and `healthcheck.railway.app` to your list of allowed hosts. This ensures that your application will accept healthcheck requests from Railway.
+For applications that restrict incoming traffic based on the hostname, you'll need to add `healthcheck.railway.app` to your list of allowed hosts. This ensures that your application will accept healthcheck requests from Railway.
 
 If your application does not permit requests from that hostname, you may encounter errors during the healthcheck process, such as "failed with service unavailable" or "failed with status 400".
 

--- a/src/docs/guides/healthchecks-and-restarts.md
+++ b/src/docs/guides/healthchecks-and-restarts.md
@@ -48,9 +48,9 @@ To prevent data corruption, we prevent multiple deployments from being active an
 
 ### Healthcheck Hostname
 
-Railway uses the hostname `healthcheck.railway.com` when performing healthchecks on your service. This is the domain from which the healthcheck requests will originate.
+Railway uses the hostname `healthcheck.railway.com` or the `healthcheck.railway.app` when performing healthchecks on your service. This is the domain from which the healthcheck requests will originate.
 
-For applications that restrict incoming traffic based on the hostname, you'll need to add `healthcheck.railway.com` to your list of allowed hosts. This ensures that your application will accept healthcheck requests from Railway.
+For applications that restrict incoming traffic based on the hostname, you'll need to add `healthcheck.railway.com` and `healthcheck.railway.app` to your list of allowed hosts. This ensures that your application will accept healthcheck requests from Railway.
 
 If your application does not permit requests from that hostname, you may encounter errors during the healthcheck process, such as "failed with service unavailable" or "failed with status 400".
 


### PR DESCRIPTION
Noticed that Railway uses `healthcheck.railway.app` for performing health checks rather than `healthcheck.railway.com` as it mentions in the [docs](https://docs.railway.com/guides/healthchecks-and-restarts#healthcheck-hostname)


```py
2024-11-24 09:33:00,288 WARNING [django.request:241] log 3 139624116890376 Bad Request: /health/
2024-11-24 09:33:30,308 ERROR [django.security.DisallowedHost:124] exception 3 139624116890376 Invalid HTTP_HOST header: 'healthcheck.railway.app'. You may need to add 'healthcheck.railway.app' to ALLOWED_HOSTS.
Traceback (most recent call last):

  File "/env/lib/python3.12/site-packages/django/core/handlers/exception.py", line 55, in inner
    response = get_response(request)
               ^^^^^^^^^^^^^^^^^^^^^
  File "/env/lib/python3.12/site-packages/django/utils/deprecation.py", line 133, in __call__
    response = self.process_request(request)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/env/lib/python3.12/site-packages/django/middleware/common.py", line 48, in process_request
    host = request.get_host()
           ^^^^^^^^^^^^^^^^^^
  File "/env/lib/python3.12/site-packages/django/http/request.py", line 150, in get_host
    raise DisallowedHost(msg)
django.core.exceptions.DisallowedHost: Invalid HTTP_HOST header: 'healthcheck.railway.app'. You may need to add 'healthcheck.railway.app' to ALLOWED_HOSTS.
```