### PR TITLE
feat: added instructions to enable IPv6 networking on application servers

### DIFF
--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -65,14 +65,6 @@ quality={100}
 
 **Below are some solution examples for common languages and frameworks.**
 
-
-#### Node
-
-If you using a custom Node server ([example](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server)) and trying to access it from another service via private networking, you will need to enable dual stack networking (IPv4 & IPv6) as Railway does not have support for IPv4. You may do so by passing the `HOSTNAME` environment variable like in the example below:
-```bash
-HOSTNAME=:: PORT=3000 node server.js
-```
-
 #### Node / Express
 
 ```javascript
@@ -101,6 +93,7 @@ async function bootstrap() {
 #### Node / Next
 
 Next needs an additional flag to listen on `PORT`:
+
 ```bash
 next start --port ${PORT-3000}
 ```
@@ -108,21 +101,15 @@ next start --port ${PORT-3000}
 #### Python / Gunicorn
 
 `gunicorn` listens on `0.0.0.0` and the `PORT` environment variable by default:
+
 ```bash
 gunicorn main:app
-```
-
-There is no additional configuration necessary.
-
-If you using a Gunicorn server and trying to access it from another service via private networking, you will need to enable dual stack networking (IPv4 & IPv6) as Railway does not have support for IPv4. You may do so by passing the `-b` flag followed by `[::]:$PORT` like in the example below:
-
-```bash
-gunicorn -b '[::]:$PORT' main:app
 ```
 
 #### Python / Uvicorn
 
 `uvicorn` needs additional configuration flags to listen on `0.0.0.0` and `PORT`:
+
 ```bash
 uvicorn main:app --host 0.0.0.0 --port $PORT
 ```

--- a/src/docs/guides/fixing-common-errors.md
+++ b/src/docs/guides/fixing-common-errors.md
@@ -65,6 +65,14 @@ quality={100}
 
 **Below are some solution examples for common languages and frameworks.**
 
+
+#### Node
+
+If you using a custom Node server ([example](https://nextjs.org/docs/pages/building-your-application/configuring/custom-server)) and trying to access it from another service via private networking, you will need to enable dual stack networking (IPv4 & IPv6) as Railway does not have support for IPv4. You may do so by passing the `HOSTNAME` environment variable like in the example below:
+```bash
+HOSTNAME=:: PORT=3000 node server.js
+```
+
 #### Node / Express
 
 ```javascript
@@ -105,6 +113,12 @@ gunicorn main:app
 ```
 
 There is no additional configuration necessary.
+
+If you using a Gunicorn server and trying to access it from another service via private networking, you will need to enable dual stack networking (IPv4 & IPv6) as Railway does not have support for IPv4. You may do so by passing the `-b` flag followed by `[::]:$PORT` like in the example below:
+
+```bash
+gunicorn -b '[::]:$PORT' main:app
+```
 
 #### Python / Uvicorn
 

--- a/src/docs/guides/private-networking.md
+++ b/src/docs/guides/private-networking.md
@@ -17,9 +17,13 @@ To communicate over the private network, there are some specific things to know 
 
 ### Listen on IPv6
 
-Since the private network is an IPv6 network, applications that will receive requests over the private network must be configured to listen on IPv6.  On most web frameworks, you can do this via `::` and specifying the port(s) to which you want to bind.
+Since the private network is an IPv6 only network, applications that will receive requests over the private network must be configured to listen on IPv6. On most web frameworks, you can do this by binding to the host `::`.
 
-For example - 
+Some examples are below -
+
+#### Node / Express
+
+Listen on `::` to bind to both IPv4 and IPv6.
 
 ```javascript
 const port = process.env.PORT || 3000;
@@ -27,6 +31,64 @@ const port = process.env.PORT || 3000;
 app.listen(port, '::', () => {
     console.log(`Server listening on [::]${port}`);
 });
+```
+
+#### Node / Nest
+
+Listen on `::` to bind to both IPv4 and IPv6.
+
+```javascript
+const port = process.env.PORT || 3000;
+
+async function bootstrap() {
+  await app.listen(port, '::');
+}
+```
+
+#### Node / Next
+
+Update your start command to bind to both IPv4 and IPv6.
+
+```bash
+next start --hostname :: --port ${PORT-3000}
+```
+
+Or if you are using a custom server, set `hostname` to `::` in the configuration object passed to the `next()` function.
+
+```javascript
+const port = process.env.PORT || 3000;
+
+const app = next({
+  // ...
+  hostname: '::',
+  port: port
+});
+```
+
+If neither of these options are viable, you can set a `HOSTNAME` [service variable](/guides/variables#service-variables) with the value `::` to listen on both IPv4 and IPv6.
+
+#### Python / Gunicorn
+
+Update your start command to bind to both IPv4 and IPv6.
+
+```bash
+gunicorn app:app --bind [::]:${PORT-3000}
+```
+
+#### Python / Hypercorn
+
+Update your start command to bind to both IPv4 and IPv6.
+
+```bash
+hypercorn app:app --bind [::]:${PORT-3000}
+```
+
+#### Python / Uvicorn
+
+Update your start command to bind to IPv6.
+
+```bash
+uvicorn app:app --host :: --port ${PORT-3000}
 ```
 
 **Note:** If your application needs to be accessible over both private and public networks, your application server must support dual stack binding. Most servers handle this automatically when listening on `::`, but some, like Uvicorn, do not.


### PR DESCRIPTION
I struggled to reach my services over Railway private networking and ended up solving the problem by enabling IPv6 on my application servers. https://github.com/phasehq/console/pull/395

Thought this might save some folks a headache.

I'm putting this together in a hurry. Please feel free to rewrite the language / put this else ware if it makes better sense to do so.