### PR TITLE
Document how to authenticate with public API using a project key

### DIFF
--- a/src/docs/guides/cli.md
+++ b/src/docs/guides/cli.md
@@ -108,6 +108,7 @@ Some actions you can perform with a project token include -
 Some actions you **cannot** perform with a project token include -
 - Creating a new project - `railway init`
 - Printing information about the user - `railway whoami`
+- Linking to another workspace - `railway link`
 
 Use the token by setting the `RAILWAY_TOKEN` environment variable and then running `railway <command>`.
 

--- a/src/docs/guides/public-api.md
+++ b/src/docs/guides/public-api.md
@@ -29,30 +29,31 @@ https://backboard.railway.com/graphql/v2
 
 ### Creating a Token
 
-To use the API, you will need an API token. You can create one by visiting the [tokens page](https://railway.com/account/tokens) in your account settings. There are two types of tokens you can create.
+To use the API, you will need an API token. There are three types of tokens you can create.
+
+#### Team Token and Personal Token
+
+You can create an API token from the [tokens page](https://railway.com/account/tokens) in your account settings.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1667386744/docs/new-token-form_rhrbw8.png"
 alt="New token form"
 layout="responsive"
 width={1618 } height={378} quality={80} />
 
-#### Team Token
-
-Select a team in the `Team` dropdown to create a token tied to a team.  A team token -
-- Has access to all the team's resources
-- Cannot be used to access your personal resources on Railway
+- **Team token** - Select a team in the `Team` dropdown to create a token tied to a team. A team token has access to all the team's resources, and cannot be used to access your personal resources on Railway. Feel free to share this token with your teammates.
+- **Personal token** - If you do not select a team, the token will be tied to your Railway account and will have access to all your resources. Do not share this token with anyone else.
 
 *Note that Teams are a Pro feature.*
 
-#### Personal Token
-
-If you do not select a team, the token will be tied to your Railway account and will have access to all your resources. Do not share this token with anyone else.
-
 #### Project Token
+
+You can create a project token from the tokens page in your project settings.
 
 Project tokens are scoped to a specific environment within a project and can only be used to authenticate requests to that environment.
 
 ### Execute a Test Query
+
+#### Using a Team or Personal Token
 
 Once you have your token, you can pass it within the `Authorization` header of your request. You can try the query below in the terminal of your choice. It should return your name and email on Railway:
 
@@ -62,6 +63,18 @@ curl --request POST \
   --header 'Authorization: Bearer <API_TOKEN_GOES_HERE>' \
   --header 'Content-Type: application/json' \
   --data '{"query":"query { me { name email } }"}'
+```
+
+#### Using a Project Token
+
+If you have a project token, you can use it to authenticate requests to a specific environment within a project.  The query below should return the project and environment IDs:
+
+```bash
+curl --request POST \
+  --url https://backboard.railway.com/graphql/v2 \
+  --header 'Project-Access-Token: <PROJECT_TOKEN_GOES_HERE>' \
+  --header 'Content-Type: application/json' \
+  --data '{"query":"query { projectToken { projectId environmentId } }"}'
 ```
 
 ## Viewing the Schema

--- a/src/docs/guides/public-api.md
+++ b/src/docs/guides/public-api.md
@@ -31,7 +31,7 @@ https://backboard.railway.com/graphql/v2
 
 To use the API, you will need an API token. There are three types of tokens you can create.
 
-#### Team Token and Personal Token
+#### Team Tokens and Account Tokens
 
 You can create an API token from the [tokens page](https://railway.com/account/tokens) in your account settings.
 
@@ -41,7 +41,7 @@ layout="responsive"
 width={1618 } height={378} quality={80} />
 
 - **Team token** - Select a team in the `Team` dropdown to create a token tied to a team. A team token has access to all the team's resources, and cannot be used to access your personal resources on Railway. Feel free to share this token with your teammates.
-- **Personal token** - If you do not select a team, the token will be tied to your Railway account and will have access to all your resources. Do not share this token with anyone else.
+- **Account token** - If you do not select a team, the token will be tied to your Railway account and will have access to all your resources including the teams you are a part of. Do not share this token with anyone else.
 
 *Note that Teams are a Pro feature.*
 
@@ -53,9 +53,11 @@ Project tokens are scoped to a specific environment within a project and can onl
 
 ### Execute a Test Query
 
-#### Using a Team or Personal Token
+Once you have your token, you can pass it within the Authorization header of your request.
 
-Once you have your token, you can pass it within the `Authorization` header of your request. You can try the query below in the terminal of your choice. It should return your name and email on Railway:
+#### Using an Account Token
+
+You can try the query below in the terminal of your choice. It should return your name and email on Railway:
 
 ```bash
 curl --request POST \
@@ -64,6 +66,22 @@ curl --request POST \
   --header 'Content-Type: application/json' \
   --data '{"query":"query { me { name email } }"}'
 ```
+
+**Note:** This query **cannot** be used with a team or project token because the data returned is scoped to your personal account.
+
+#### Using a Team Token
+
+If you have a team token, you can use it to authenticate requests to a specific team. The query below should return the team name and ID:
+
+```bash
+curl --request POST \
+  --url https://backboard.railway.com/graphql/v2 \
+  --header 'Team-Access-Token: <TEAM_TOKEN_GOES_HERE>' \
+  --header 'Content-Type: application/json' \
+  --data '{"query":"query { team(id: \"<TEAM_ID_GOES_HERE>\") { name id } }"}'
+```
+
+**Note:** This query **can** also be used with an account token as long as you are a member of the team.
 
 #### Using a Project Token
 

--- a/src/docs/reference/public-api.md
+++ b/src/docs/reference/public-api.md
@@ -14,7 +14,14 @@ https://backboard.railway.com/graphql/v2
 
 ## Authentication
 
-To use the API, you will need an API token. You can create one by visiting the <a href="https://railway.com/account/tokens" target="_blank">tokens page</a> in your account settings.
+To use the API, you will need an API token. There are three types of tokens you can create.
+
+#### Team Token and Personal Token
+
+You can create an API token by visiting the <a href="https://railway.com/account/tokens" target="_blank">tokens page</a> in your account settings.
+
+- **Team tokens** are tied to a team and will have access to all the team's resources. This token cannot be used to access your personal resources on Railway so feel free to share it with your teammates.
+- **Non-team tokens** will be tied to your Railway account and will have access to all your resources. Do not share this token with anyone else.
 
 ```bash
 curl --request POST \
@@ -24,18 +31,19 @@ curl --request POST \
   --data '{"query":"query { me { name email } }"}'
 ```
 
-
-### Team Token
-
-Team tokens are tied to a team and will have access to all the team's resources. This token cannot be used to access your personal resources on Railway so feel free to share it with your teammates.
-
-### Personal Token
-
-Non-team tokens will be tied to your Railway account and will have access to all your resources. Do not share this token with anyone else.
-
 #### Project Token
 
+You can create a project token by visiting the tokens page in your project settings.
+
 Project tokens are scoped to a specific environment within a project and can only be used to authenticate requests to that environment.
+
+```bash
+curl --request POST \
+  --url https://backboard.railway.com/graphql/v2 \
+  --header 'Project-Access-Token: <PROJECT_TOKEN_GOES_HERE>' \
+  --header 'Content-Type: application/json' \
+  --data '{"query":"query { projectToken { projectId environmentId } }"}'
+```
 
 ## Schema
 


### PR DESCRIPTION
Current docs mention project keys as one of the key types supported by the public API, but doesn't mention how to use them.

This clarifies that requests authenticated with a project key must use a `Project-Access-Token` header (rather than `Authorization`), as found in the CLI's code [here](https://github.com/railwayapp/cli/blob/master/src/client.rs#L20).