### PR TITLE
Ensure that adding description to a page is compulsory.

### DIFF
--- a/contentlayer.config.ts
+++ b/contentlayer.config.ts
@@ -16,7 +16,7 @@ const Page = defineDocumentType(() => ({
     description: {
       type: "string",
       description: "The description of the page",
-      required: false,
+      required: true,
     },
   },
   computedFields: {

--- a/src/docs/reference/public-domains.md
+++ b/src/docs/reference/public-domains.md
@@ -1,5 +1,6 @@
 ---
 title: Public Domains
+description: Learn about public domains on Railway.
 ---
 
 Railway can provide a public domain to any service that is listening for traffic.  You are also free to use your own custom domain.

--- a/src/docs/reference/regions.md
+++ b/src/docs/reference/regions.md
@@ -1,5 +1,6 @@
 ---
 title: Regions
+description: Explore the multiple regions worldwide where you can deploy your apps on Railway.
 ---
 
 Railway's infrastructure spans multiple regions across the globe. This allows you to deploy your applications closer to your users no matter where they are located. **This feature is only available to Pro plan workspaces.**


### PR DESCRIPTION
This PR turns on the setting that ensures descriptions are added to every page in the docs.