### PR TITLE
Fix broken links

### DIFF
--- a/src/docs/guides/build-a-database-service.md
+++ b/src/docs/guides/build-a-database-service.md
@@ -77,5 +77,5 @@ Here are some suggestions to check out -
 - <a href="https://railway.com/template/SMKOEA" target="_blank">Minio</a>
 - <a href="https://railway.com/template/clickhouse" target="_blank">ClickHouse</a>
 - <a href="https://railway.com/template/dragonfly" target="_blank">Dragonfly</a>
-- <a href="https://railway.com/template/tifygm" target="_blank">Chroma</a>
+- <a href="https://railway.com/template/kbvIRV" target="_blank">Chroma</a>
 - <a href="https://railway.com/template/elasticsearch" target="_blank">Elastic Search</a>

--- a/src/docs/guides/django.md
+++ b/src/docs/guides/django.md
@@ -344,7 +344,7 @@ width={2752} height={2094} quality={100} />
 
 - **App Service**: This service should be running and is the only one that should have a public domain, allowing users to access your application.
 
-**Note:** There is a [community template](https://railway.app/template/yZDfUu) available that demonstrates this deployment approach. You can easily deploy this template and then connect it to your own GitHub repository for your application.
+**Note:** There is a [community template](https://railway.com/template/yZDfUu) available that demonstrates this deployment approach. You can easily deploy this template and then connect it to your own GitHub repository for your application.
 
 ## Next Steps
 

--- a/src/docs/guides/express.md
+++ b/src/docs/guides/express.md
@@ -125,15 +125,15 @@ If you’re looking for the fastest way to get started with Express, Pug and con
 
 Click the button below to begin:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/BC51z6)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/BC51z6)
 
 For Express API, here's another template you can begin with:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/Y6zLKF)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/Y6zLKF)
 
 We highly recommend that [you eject from the template after deployment](/guides/deploy#eject-from-template-repository) to create a copy of the repo on your GitHub account.
 
-**Note:** You can also choose from a <a href="https://railway.app/templates?q=express" target="_blank">variety of Express app templates</a> created by the community.
+**Note:** You can also choose from a <a href="https://railway.com/templates?q=express" target="_blank">variety of Express app templates</a> created by the community.
 
 ### Deploy From the CLI
 
@@ -176,7 +176,7 @@ width={2194} height={1652} quality={100} />
 To deploy an Express app to Railway directly from GitHub, follow the steps below:
 
 1. **Create a New Project on Railway**:
-    - Go to <a href="https://railway.app/new" target="_blank">Railway</a> to create a new project.
+    - Go to <a href="https://railway.com/new" target="_blank">Railway</a> to create a new project.
 2. **Deploy from GitHub**: 
     - Select **Deploy from GitHub repo** and choose your repository.
         - If your Railway account isn’t linked to GitHub yet, you’ll be prompted to do so.

--- a/src/docs/guides/nest.md
+++ b/src/docs/guides/nest.md
@@ -142,11 +142,11 @@ If you’re looking for the fastest way to get started with Nest connected to a 
 
 Click the button below to begin:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/nvnuEH)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/nvnuEH)
 
 We highly recommend that [you eject from the template after deployment](/guides/deploy#eject-from-template-repository) to create a copy of the repo on your GitHub account.
 
-**Note:** You can also choose from a <a href="https://railway.app/templates?q=nest" target="_blank">variety of Nest app templates</a> created by the community.
+**Note:** You can also choose from a <a href="https://railway.com/templates?q=nest" target="_blank">variety of Nest app templates</a> created by the community.
 
 ### Deploy from the CLI
 
@@ -193,7 +193,7 @@ width={2069} height={2017} quality={100} />
 To deploy a Nest app to Railway directly from GitHub, follow the steps below:
 
 1. **Create a New Project on Railway**:
-    - Go to <a href="https://railway.app/new" target="_blank">Railway</a> to create a new project.
+    - Go to <a href="https://railway.com/new" target="_blank">Railway</a> to create a new project.
 2. **Deploy from GitHub**: 
     - Select **Deploy from GitHub repo** and choose your repository.
         - If your Railway account isn’t linked to GitHub yet, you’ll be prompted to do so.

--- a/src/docs/quick-start.md
+++ b/src/docs/quick-start.md
@@ -146,7 +146,7 @@ Railway will now provision a new service for your project based on the specified
 
 And that's it! 🎉 Your project is now ready for use.
 
-**Note:** Deploying from a [private Docker registry is available on the Pro plan](guides/services#deploying-a-private-docker-image).
+**Note:** Deploying from a [private Docker registry is available on the Pro plan](/guides/services#deploying-a-private-docker-image).
 
 ## The Canvas
 

--- a/src/docs/reference/databases.md
+++ b/src/docs/reference/databases.md
@@ -43,7 +43,7 @@ Here are some examples -
 - [Minio](https://railway.com/template/SMKOEA)
 - [ClickHouse](https://railway.com/template/clickhouse)
 - [Dragonfly](https://railway.com/template/dragonfly)
-- [Chroma](https://railway.com/template/tifygm)
+- [Chroma](https://railway.com/template/kbvIRV)
 
 ## Support
 

--- a/src/docs/reference/errors/nixpacks-was-unable-to-generate-a-build-plan.md
+++ b/src/docs/reference/errors/nixpacks-was-unable-to-generate-a-build-plan.md
@@ -85,4 +85,4 @@ To unblock yourself, you can try to deploy your application using a [Dockerfile]
 
 If your project contains a `Dockerfile` Railway will automatically use it to build your application.
 
-Read more about [using a Dockerfile](guides/dockerfiles).
+Read more about [using a Dockerfile](/guides/dockerfiles).

--- a/src/docs/tutorials/add-a-cdn-using-cloudfront.md
+++ b/src/docs/tutorials/add-a-cdn-using-cloudfront.md
@@ -25,7 +25,7 @@ In this tutorial, you will learn how to -
 **Prerequisites**
 
 To be successful using this tutorial, you should already have - 
-- Latest version of the Railway [CLI installed](guides/cli#installing-the-cli)
+- Latest version of the Railway [CLI installed](/guides/cli#installing-the-cli)
 - An [AWS account](https://aws.amazon.com/) with permissions to create new resources
 - Latest version of the [AWS CLI](https://aws.amazon.com/cli/) installed and authenticated to your AWS account
 - Latest version of the [AWS CDK](https://aws.amazon.com/cdk/) installed
@@ -35,7 +35,7 @@ To be successful using this tutorial, you should already have -
 
 ## 1. Create and Deploy a Fastify Server
 
-First, let's create and deploy a simple Fastify server using the [Railway CLI](guides/cli#installing-the-cli)
+First, let's create and deploy a simple Fastify server using the [Railway CLI](/guides/cli#installing-the-cli)
 
 - On your local machine, create a folder called "fastify"
 - Inside of the folder, create a file called "server.js"

--- a/src/docs/tutorials/deploy-an-otel-collector-stack.md
+++ b/src/docs/tutorials/deploy-an-otel-collector-stack.md
@@ -24,7 +24,7 @@ In this tutorial you will learn how to -
 
 To be successful using this tutorial, you should already have - 
 
-- Latest version of Railway [CLI installed](guides/cli#installing-the-cli)
+- Latest version of Railway [CLI installed](/guides/cli#installing-the-cli)
 - A GitHub account
 
 **OpenTelemetry Collector Template and Demo**
@@ -276,7 +276,7 @@ In the same Railway project -
 - In the Settings tab, under Networking, click `Generate Domain`
 
 ### Deploy from the Railway CLI
-*This step assumes you have the latest version of the [Railway CLI](guides/cli#installing-the-cli) installed.*
+*This step assumes you have the latest version of the [Railway CLI](/guides/cli#installing-the-cli) installed.*
 
 On your local machine -
 - Open your terminal and change directory to the `otel-example-app` folder

--- a/src/docs/tutorials/deploy-and-monitor-mongo.md
+++ b/src/docs/tutorials/deploy-and-monitor-mongo.md
@@ -25,7 +25,7 @@ In this tutorial, you will learn how to -
 To be successful using this tutorial, you should already have - 
 - A [Railway API token](/guides/public-api#creating-a-token)
 - A Github account connected to Railway
-- Latest version of Railway [CLI installed](guides/cli#installing-the-cli)
+- Latest version of Railway [CLI installed](/guides/cli#installing-the-cli)
 
 Most of the source code you will deploy as part of this tutorial can be found [here](https://github.com/railwayapp-templates/init-mongo-ha).
 
@@ -45,7 +45,7 @@ width={1477} height={823} quality={100} />
 
 First, we will deploy the Mongo replica set using the template in the Railway marketplace.
 
-- <a href="https://railway.com/new/template/gFmvuY" target="_blank">Click here to open the deployment page for the Mongo replica set</a>
+- <a href="https://railway.com/new/template/ha-mongo" target="_blank">Click here to open the deployment page for the Mongo replica set</a>
 - Click `Configure` next to the **init-mongo-ha** service and add your [Railway API token](/guides/public-api#creating-a-token)
 - Click `Deploy`
 
@@ -153,7 +153,7 @@ In the Railway project that contains your Mongo replica set -
 - In the Settings tab, under Networking, click `Generate Domain`
 
 ### Deploy from the Railway CLI
-*This step assumes you have the latest version of the [Railway CLI](guides/cli#installing-the-cli) installed.*
+*This step assumes you have the latest version of the [Railway CLI](/guides/cli#installing-the-cli) installed.*
 
 On your local machine -
 - Open your terminal and change directory to the `fastApi` folder

--- a/src/docs/tutorials/set-up-a-datadog-agent.md
+++ b/src/docs/tutorials/set-up-a-datadog-agent.md
@@ -19,7 +19,7 @@ If you are looking for a quicker way to get started, you can also deploy this pr
 
 To be successfull, you should already have - 
 
-- Railway [CLI installed](guides/cli#installing-the-cli)
+- Railway [CLI installed](/guides/cli#installing-the-cli)
 - Datadog API key and site value
 
 **Caveats**


### PR DESCRIPTION
- CLI installation references were didn't have a `/` prefix
- Mongo Replica Set template's URL changed to ha-mongo