### PR TITLE
Misc Updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ jobs:
           cache: "yarn"
 
       - name: Install packages
-        run: yarn install
+        run: yarn install --frozen-lockfile
 
-      - name: Build
-        run: yarn build
+      - name: Build Contentlayer
+        run: |
+          yarn contentlayer build 2>&1 | tee build.log
+          if grep -q "Warning: Found .* problems" build.log; then
+            echo "Contentlayer build produced warnings. Failing build."
+            exit 1
+          fi
+
+      - name: Build Next.js
+        run: next build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
           fi
 
       - name: Build Next.js
-        run: next build
+        run: yarn next build

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -2,4 +2,4 @@
 /// <reference types="next/image-types/global" />
 
 // NOTE: This file should not be edited
-// see https://nextjs.org/docs/pages/building-your-application/configuring/typescript for more information.
+// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,10 +1,4 @@
-const RAILWAY_STATIC_URL = process.env.RAILWAY_STATIC_URL;
 module.exports = {
-  siteUrl:
-    // If we're on the prod environment, remap to the linked domain,
-    // otherwise use the provided static URL.
-    RAILWAY_STATIC_URL === "railway-docs-production.up.railway.app"
-      ? "https://docs.railway.com/"
-      : `https://${RAILWAY_STATIC_URL}/`,
+  siteUrl: process.env.NEXT_PUBLIC_RAILWAY_DOCS_URL || "https://docs.railway.com",
   generateRobotsTxt: true,
 };

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "typescript": "^4.2.4"
   },
   "engines": {
-    "node": ">=18.17.0"
+    "node": "18"
   },
   "babelMacros": {
     "twin": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "railway-docs",
   "version": "0.1.0",
-  "private": true,
+  "private": false,
+  "license": "MIT",
   "scripts": {
     "dev": "next dev --port ${PORT-3001}",
     "build": "contentlayer build && next build",

--- a/src/components/InlineCode.tsx
+++ b/src/components/InlineCode.tsx
@@ -27,10 +27,11 @@ export const InlineCode: React.FC<Props> = ({ children, colorModeSSR }) => {
 
   return (
     <code
-      css={tw`px-2 py-1 rounded font-mono whitespace-nowrap before:content-[''] after:content-['']`}
+      css={tw`rounded font-mono whitespace-nowrap inline-block before:content-[''] after:content-['']`}
       style={{
         backgroundColor: String(theme['pre[class*="language-"]'].background),
         color: theme['code[class*="language-"]'].color,
+        padding: "0 0.35rem",
       }}
       data-colormode={colorMode}
     >

--- a/src/docs/guides/laravel.md
+++ b/src/docs/guides/laravel.md
@@ -24,11 +24,17 @@ We highly recommend that [you eject from the template after deployment](/guides/
 To deploy a Laravel app on GitHub to Railway, follow the steps below:
 
 1. Create a <a href="https://railway.com/new" target="_blank">New Project.</a>
+
 2. Click **Deploy from GitHub repo**.
+
 3. Select your GitHub repo.
+
     - Railway requires a valid GitHub account to be linked. If your Railway account isn't associated with one, you will be prompted to link it.
+
 4. Click **Add Variables**. 
+
     - Add all your app environment variables.
+
 5. Click **Deploy**.
 
 Once the deployment is successful, a Railway [service](/guides/services) will be created for you. By default, this service will not be publicly accessible.
@@ -50,15 +56,25 @@ width={2855} height={2109} quality={100} />
 If you have your Laravel app locally, you can follow these steps:
 
 1. <a href="/guides/cli#installing-the-cli" target="_blank">Install</a> and <a href="/guides/cli#authenticating-with-the-cli" target="_blank">authenticate with the Railway CLI.</a>
-2. Run `railway init` within your Laravel app root directory to create a new project on Railway. 
+
+2. Run `railway init` within your Laravel app root directory to create a new project on Railway.
+
     - Follow the steps in the prompt to give your project a name.
+
 3. Run `railway up` to deploy.
+
     - The CLI will now scan, compress and upload our Laravel app files to Railway's backend for deployment.
+
     - Your terminal will display real-time logs as your app is being deployed on Railway.
+
 4. Once the deployment is successful, click on **View logs** on the recent deployment on the dashboard.
+
     - You'll see that the server is running. However you'll also see logs prompting you to add your env variables.
+
 5. Click on the <a href="/overview/the-basics#service-variables">**Variables**</a> section of your service on the Railway dashboard.
+
 6. Click on **Raw Editor** and add all your app environment variables.
+
 7. Click on **Deploy** to redeploy your app.
 
 To set up a publicly accessible URL for the service, navigate to the **Networking** section in the [Settings](/overview/the-basics#service-settings) tab of your new service and click on [Generate Domain](/guides/public-networking#railway-provided-domain).
@@ -70,9 +86,13 @@ To set up a publicly accessible URL for the service, navigate to the **Networkin
 This setup deploys your Laravel app on Railway, ensuring that your database, scheduled tasks (crons), and queue workers are all fully operational.
 
 The deployment structure follows a "majestic monolith" architecture, where the entire Laravel app is managed as a single codebase but split into four separate services on Railway:
+
 - **App Service**: Handles HTTP requests and user interactions.
+
 - **Cron Service**: Manages scheduled tasks (e.g., sending emails or running reports).
+
 - **Worker Service**: Processes background jobs from the queue.
+
 - **Database Service**: Stores and retrieves your application's data.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/f_auto,q_auto/v1727910244/docs/quick-start/deploy%20architecture.png"
@@ -81,10 +101,9 @@ layout="responsive"
 width={3118} height={1776} quality={100} />
 _My Majestic Monolith Laravel app_
 
-
 Please follow these steps to get started:
 
-1. Create four bash scripts in the root directory of your Laravel app: `build-app.sh`, `run-app.sh`, `run-worker.sh`, and `run-cron.sh`. 
+1. Create four bash scripts in the root directory of your Laravel app: `build-app.sh`, `run-worker.sh`, and `run-cron.sh`. 
 
     These scripts will contain the commands needed to deploy and run the app, worker, and cron services for your Laravel app on Railway.
     - Add the content below to the `build-app.sh` file:
@@ -93,6 +112,9 @@ Please follow these steps to get started:
         ```bash
         #!/bin/bash
         # Make sure this file has executable permissions, run `chmod +x build-app.sh`
+
+        # Exit the script if any command fails
+        set -e
 
         # Build assets using NPM
         npm run build
@@ -106,15 +128,7 @@ Please follow these steps to get started:
         php artisan route:cache
         php artisan view:cache
         ```
-    - Add the content below to the `run-app.sh` file:
 
-        **Note:** This is required to start your app service after the build phase is complete.
-        ```bash
-        #!/bin/bash
-        # Make sure this file has executable permissions, run `chmod +x run-app.sh`
-        # Run migrations, process the Nginx configuration template and start Nginx
-        php artisan migrate --force && node /assets/scripts/prestart.mjs /assets/nginx.template.conf  /nginx.conf && (php-fpm -y /assets/php-fpm.conf & nginx -c /nginx.conf)
-        ```
     -  Add the content below to the `run-worker.sh` file:
         ```bash
         #!/bin/bash
@@ -124,6 +138,7 @@ Please follow these steps to get started:
         # An alternative is to use the php artisan queue:listen command
         php artisan queue:work     
         ```
+
     -  Add the content below to the `run-cron.sh` file:
         ```bash
         #!/bin/bash
@@ -137,33 +152,59 @@ Please follow these steps to get started:
                 sleep 60
             done
         ```
+
 2. Create a Postgres Database service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas.</a>
      - Click on **Deploy**.
+
 3. Create a new service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas.</a>
     -  Name the service **App service**, and click on <a href="/overview/the-basics#service-settings">**Settings**</a> to configure it.
+
     - Connect your GitHub repo to the  **Source Repo** in the **Source** section.
+
     - Add `chmod +x ./build-app.sh && sh ./build-app.sh` to the **Custom Build Command** in the <a href="/guides/build-configuration#customize-the-build-command">**Build**</a> section.
-    - Add `chmod +x ./run-app.sh && sh ./run-app.sh` to the <a href="/guides/start-command">**Custom Start Command**</a> in the **Deploy** section.
+
+    - Add `php artisan migrate` to the <a href="/guides/pre-deploy-command">**Pre-Deploy Command**</a> in the **Deploy** section.
+
     - Head back to the top of the service and click on <a href="/overview/the-basics#service-variables">**Variables**</a>.
+
     - Add all the necessary environment variables required for the Laravel app especially the ones listed below.
+
         - `APP_KEY`: Set the value to what you get from the `php artisan key:generate` command.
+
         - `DB_CONNECTION`: Set the value to `pgsql`.
+
         - `QUEUE_CONNECTION`: Set the value to `database`.
+
         - `DB_URL`: Set the value to `${{Postgres.DATABASE_URL}}` (this references the URL of your new Postgres database). Learn more about [referencing service variables](/guides/variables#referencing-another-services-variable). 
+
     - Click **Deploy**.
-4. Create a new service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>. 
+
+4. Create a new service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
+
     - Name the service **cron service**, and click on <a href="/overview/the-basics#service-settings">**Settings**</a>.
+
     - Connect your GitHub repo to the  **Source Repo** in the **Source** section.
+
     - Add `chmod +x ./run-cron.sh && sh ./run-cron.sh` to the <a href="/guides/start-command">**Custom Start Command**</a> in the **Deploy** section.
+
     - Head back to the top of the service and click on  <a href="/overview/the-basics#service-variables">**Variables**</a>.
+
     - Add all the necessary environment variables especially those highlighted already in step 3.
+
     - Click **Deploy**.
-5. Create a new service again on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>. 
+
+5. Create a new service again on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
+
     - Name the service **worker service**, and click on <a href="/overview/the-basics#service-settings">**Settings**</a>.
+
     - Connect your GitHub repo to the  **Source Repo** in the **Source** section.
+
     - Add `chmod +x ./run-worker.sh && sh ./run-worker.sh` to the <a href="/guides/start-command">**Custom Start Command**</a> in the **Deploy** section.
+
     - Head back to the top of the service and click on <a href="/overview/the-basics#service-variables">**Variables**</a>.
+
     - Add all the necessary environment variables especially those highlighted already in step 3.
+
     - Click **Deploy**.
 
 At this point, you should have all three services deployed and connected to the Postgres Database service:
@@ -181,6 +222,7 @@ layout="responsive"
 width={2165} height={1873} quality={100} />
 
 - **Worker Service**: This service should be running and ready to process jobs from the queue.
+
 - **App Service**: This service should be running and is the only one that should have a public domain, allowing users to access your application.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/f_auto,q_auto/v1727885952/docs/quick-start/CleanShot_2024-10-02_at_17.18.04_2x_nn78ga.png"

--- a/src/docs/overview/the-basics.md
+++ b/src/docs/overview/the-basics.md
@@ -25,7 +25,7 @@ Your main entrypoint to Railway where all your [projects](/overview/the-basics#p
 
 Projects contain your [services](/overview/the-basics#services) and [environments](/reference/environments).
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722187321/docs/the-basics/dashboard_ycmxnk.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785111/docs/the-basics/dashboard_ycmxnk.png"
 alt="Screenshot of the Railway dashboard"
 layout="responsive"
 width={1305} height={735} quality={100} />
@@ -36,7 +36,7 @@ A project represents a capsule for composing infrastructure in Railway.  You can
 
 Services within a project are automatically joined to a [private network](/reference/private-networking) scoped to that project.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144285/docs/the-basics/project_canvas_dxpzxe.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785173/docs/the-basics/project_canvas_dxpzxe.png"
 alt="Screenshot of the project canvas"
 layout="responsive"
 width={1365} height={765} quality={100} />
@@ -45,7 +45,7 @@ width={1365} height={765} quality={100} />
 
 This page contains all the project level settings.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144286/docs/the-basics/project_settings_ghwzih.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785164/docs/the-basics/project_settings_ghwzih.png"
 alt="Screenshot of the project settings page"
 layout="responsive"
 width={1365} height={765} quality={100} />
@@ -64,7 +64,7 @@ Some of the most commonly used project settings are -
 
 A Railway service is a deployment target for your deployment source. Deployment sources can be [code repositories](https://docs.github.com/en/repositories/creating-and-managing-repositories/about-repositories) or [Docker Images](https://docs.docker.com/guides/docker-concepts/the-basics/what-is-an-image/). Once you create a service and choose a source, Railway will analyze the source, build a Docker image (if the source is a code repository), and deploy it to the service.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144283/docs/the-basics/services_zuyl56.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785212/docs/the-basics/services_zuyl56.png"
 alt="Screenshot of the project canvas with services highlighted"
 layout="responsive"
 width={1365} height={765} quality={100} />
@@ -79,16 +79,39 @@ You can configure variables scoped to services. These variables are specific to 
 
 If you want to access variables from this service in another service within the same project, you need to utilize a [Reference Variable](/reference/variables#reference-variables).
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144282/docs/the-basics/service_variables_galkry.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785219/docs/the-basics/service_variables_galkry.png"
 alt="Screenshot of the service variables tab"
 layout="responsive"
 width={1365} height={765} quality={100} />
+
+### Backups
+
+If your service has a [volume](/overview/the-basics#volumes) attached, this is where you can manage backups.
+
+Backups are incremental and Copy-on-Write, we only charge for the data exclusive to them, that aren't from other snapshots or the volume itself.
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785142/docs/the-basics/backups_fdx09o.png"
+alt="Screenshot of the service backups tab"
+layout="responsive"
+width={1365} height={765} quality={100} />
+
+From here you can perform the following actions -
+
+- Create a backup - Manually create a backup of the volume with a press of a button.
+
+- Delete a backup - Remove a backup from the list via the backup's 3-dot menu.
+
+- Lock a backup - Prevent a backup from being deleted via the backup's 3-dot menu.
+
+- [Restore a backup](/reference/backups#how-to-restore-a-backup) - Click the `Restore` button on the backup.
+
+- Modify the backup schedule - Click the `Edit schedule` button on the header to make changes to the schedule.
 
 ### Service Metrics
 
 Service [Metrics](/reference/metrics) provide an essential overview of CPU, memory, and network usage for a given service.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144286/docs/the-basics/service_metrics_dcbfms.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785153/docs/the-basics/service_metrics_dcbfms.png"
 alt="Screenshot of the service metrics tab"
 layout="responsive"
 width={1365} height={770} quality={100} />
@@ -97,7 +120,7 @@ width={1365} height={770} quality={100} />
 
 This tab contains all the service level settings.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144287/docs/the-basics/service_settings_lnyql0.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785132/docs/the-basics/service_settings_lnyql0.png"
 alt="Screenshot of the service settings tab"
 layout="responsive"
 width={1365} height={765} quality={100} />
@@ -116,7 +139,7 @@ Some of the most commonly used service settings are -
 
 [Deployments](/reference/deployments) involve building and delivering your [Service](/overview/the-basics#services).
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722196270/docs/the-basics/deployment_l0trj8.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785123/docs/the-basics/deployment_l0trj8.png"
 alt="Screenshot of a service open with a deployment highlighted"
 layout="responsive"
 width={1365} height={790} quality={100} />
@@ -125,7 +148,7 @@ width={1365} height={790} quality={100} />
 
 [Volumes](/reference/volumes) are a feature that allows services on Railway to [maintain persistent data](/guides/volumes).
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144284/docs/the-basics/volumes_yom2km.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785187/docs/the-basics/volumes_yom2km.png"
 alt="Screenshot of the project canvas with a volume highlighted"
 layout="responsive"
 width={1365} height={765} quality={100} />
@@ -134,7 +157,7 @@ width={1365} height={765} quality={100} />
 
 Volume Metrics show the amount of data stored in the volume and its maximum capacity.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144283/docs/the-basics/volume_metrics_thv60n.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785205/docs/the-basics/volume_metrics_thv60n.png"
 alt="Screenshot of the volume metrics tab"
 layout="responsive"
 width={1365} height={826} quality={100} />
@@ -143,7 +166,7 @@ width={1365} height={826} quality={100} />
 
 This tab contains all the volume centric settings.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1722144283/docs/the-basics/volume_settings_kirpdn.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785195/docs/the-basics/volume_settings_kirpdn.png"
 alt="Screenshot of the volume settings tab"
 layout="responsive"
 width={1365} height={826} quality={100} />

--- a/src/docs/overview/the-basics.md
+++ b/src/docs/overview/the-basics.md
@@ -12,6 +12,7 @@ This document outlines the core concepts of Railway, providing foundational know
   - **[Project Settings](#project-settings)** - Contains all project-level settings.
 - **[Service](#services)** - A target for a deployment source (e.g. Web Application).
   - **[Service Variables](#service-variables)** - A collection of configurations and secrets.
+  - **[Backups](#backups)** - A collection of backups for a service.
   - **[Service Metrics](#service-metrics)** - Rundown of metrics for a service.
   - **[Service Settings](#service-settings)** - Contains all service-level settings.
 - **[Deployment](#deployments)** - Built and deliverable unit of a service.

--- a/src/docs/reference/backups.md
+++ b/src/docs/reference/backups.md
@@ -21,6 +21,32 @@ You can set the schedule in the service settings panel, under the Backups tab.
 
 You can select multiple backup schedules for a single volume. These schedules can be modified at any time, and you can also manually trigger backups as needed.
 
+## How to restore a backup
+
+The available backups for a volume are listed in the attached [service's](/overview/the-basics#services) Backups tab.
+
+<Image src="https://res.cloudinary.com/railway/image/upload/v1737785142/docs/the-basics/backups_fdx09o.png"
+alt="Screenshot of the service backups tab"
+layout="responsive"
+width={1365} height={765} quality={100} />
+
+To restore a backup, first locate the backup you want to restore via its date stamp, then click the `Restore` button on the backup.
+
+**Note:** Depending on the size of the backup, this may take a few seconds to a few minutes to complete.
+
+Once completed, we will [stage the change](/guides/staged-changes) for you to review, click the `Details` button at the top of the [project canvas](/overview/the-basics#project--project-canvas) to view the changes.
+
+During this process, you will see a new [volume](/overview/the-basics#volumes) mounted to the same location as the original volume, its name will be the date stamp of the backup.
+
+The previous volume will be retained but has been unmounted from the service, it will have the original volume name such as `silk-volume`.
+
+**Note:** Restoring a backup will remove any newer backups you may have created after the backup you are restoring, you will still have access to backups older than the one you are restoring.
+
+If everything looks good and you're ready to proceed, click the `Deploy` button to complete the restore.
+
+The changes will be applied and your service will be redeployed.
+
+
 ## Pricing
 
 Backups are incremental and Copy-on-Write, we only charge for the data exclusive to them, that aren't from other snapshots or the volume itself.

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -1,5 +1,6 @@
 ---
 title: Volumes
+description: Volumes are a feature that enables persistent data for services on Railway.
 ---
 
 Volumes are a feature that enables persistent data for [services](/reference/services) on Railway.

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -1,6 +1,5 @@
 ---
 title: Volumes
-description: Volumes are a feature that enables persistent data for services on Railway.
 ---
 
 Volumes are a feature that enables persistent data for [services](/reference/services) on Railway.
@@ -28,7 +27,7 @@ Please reach out to us on our [Help Station](https://help.railway.com/questions)
 
 Volumes are billed at **$0.25 / GB**, billed monthly.
 
-You are only charged for the amount of storage used by your volumes. *Each volume requires a small amount of space to store metadata about the filesystem, so a new volume will start with a small amount of space used.*
+You are only charged for the amount of storage used by your volumes. *Each volume requires aprox 2-3% of the total storage to store metadata about the filesystem, so a new volume will always start with some used amount of space used depending on the size.*
 
 ## Backups
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+import { allPages, Page } from "contentlayer/generated";
+
+// This middleware is used to rewrite the pathname to the SSR path during runtime as middleware is not ran during build
+export function middleware(request: NextRequest) {
+  const page = allPages.find(p => p.url === request.nextUrl.pathname);
+
+  if (!page) {
+    return NextResponse.next();
+  }
+
+  const url = request.nextUrl.clone();
+  url.pathname = "/dynamic" + url.pathname;
+  return NextResponse.rewrite(url);
+}
+
+export const config = {
+  matcher: "/:path*",
+};


### PR DESCRIPTION
- Make CI fail if contentlayer warnings are found.
- Clean up next-sitemap config.
- Pin Node to v18, contentlayer was throwing an error on Node 19 - 20.
- Update the Laravel guide to mention the Pre-Depoloy command.
- Updated image on the basics page, new border image.
- Added a "Backups" section and image to the basics page.
- Added a "How to restore a backup" guide to the backups reference page.
- Tweaked the copy mentioning the small amount of filesystem overheard for volumes.
- Fixed the issue preventing the site map from being generated, SSG is done during build, and SSR is done during runtime now.
- Prevent inline code blocks from having their padding wrap.

Note: I have omitted a description to test CI.