### PR TITLE
this package is not used anywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "dependencies": {
     "@nanostores/react": "^0.4.1",
-    "@next/env": "^13.2.1",
     "@prisma/client": "4.10.1",
     "@radix-ui/react-scroll-area": "^1.0.2",
     "@tailwindcss/typography": "^0.5.9",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1439,11 +1439,6 @@
   resolved "https://registry.yarnpkg.com/@next/env/-/env-14.2.5.tgz#1d9328ab828711d3517d0a1d505acb55e5ef7ad0"
   integrity sha512-/zZGkrTOsraVfYjGP8uM0p6r0BDT6xWpkjdVbcz66PJVSpwXX3yNiRycxAuDfBKGWBrZBXRuK/YVlkNgxHGwmA==
 
-"@next/env@^13.2.1":
-  version "13.2.1"
-  resolved "https://registry.npmjs.org/@next/env/-/env-13.2.1.tgz"
-  integrity sha512-Hq+6QZ6kgmloCg8Kgrix+4F0HtvLqVK3FZAnlAoS0eonaDemHe1Km4kwjSWRE3JNpJNcKxFHF+jsZrYo0SxWoQ==
-
 "@next/swc-darwin-arm64@14.2.5":
   version "14.2.5"
   resolved "https://registry.yarnpkg.com/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.5.tgz#d0a160cf78c18731c51cc0bff131c706b3e9bb05"


### PR DESCRIPTION
Remove `@next/env` because it is not used anywhere. It also seems to be trying to import `dotenv` as a dev dep in production
