### PR TITLE
Update year from 2024 to 2025 on other doc pages

### DIFF
--- a/src/docs/maturity/compliance.md
+++ b/src/docs/maturity/compliance.md
@@ -27,7 +27,7 @@ SOC 2 Type II certification is expected before the end of 2024.
 
 Railway follows a shared responsibility model for HIPAA compliance. Railway will make its best effort to advise your company on setting up encryption for your data, auditing the storage of keys, establishing access control, and ensuring secure storage of sensitive patient data. When a BAA is in effect, the Railway team will no longer be able to directly access your running workloads.
 
-> **Note:** Effective March 3rd, 2024, Railway is moving from negotiated contract pricing for HIPAA BAA to committed spend tiers. Customers who meet the required monthly spend threshold (e.g., $1,000/month) and commit to that level can access HIPAA BAA as an add-on, with all pricing going towards their usage.
+> **Note:** Effective March 3rd, 2025, Railway is moving from negotiated contract pricing for HIPAA BAA to committed spend tiers. Customers who meet the required monthly spend threshold (e.g., $1,000/month) and commit to that level can access HIPAA BAA as an add-on, with all pricing going towards their usage.
 
 If your company needs a BAA, you can contact our solutions team at [team@railway.com](mailto:team@railway.com), or click [here](https://cal.com/team/railway/work-with-railway?duration=30) to schedule some time to chat.
 

--- a/src/docs/reference/project-usage.md
+++ b/src/docs/reference/project-usage.md
@@ -7,12 +7,12 @@ Users are billed monthly based on their project's per-minute usage. All services
 
 1. **RAM** → $0.000231 / GB / minute
 2. **CPU** → $0.000463 / vCPU / minute
-3. **Network Egress** → $0.000000047683716 / KB (effective March 3rd, 2024)
-   - Previous rate: $0.000000095367432 / KB until March 2nd, 2024
-4. **Volume Storage** → $0.000003472222222 / GB / minute (effective March 3rd, 2024)
-   - Previous rate: $0.000005787037037 / GB / minute until March 2nd, 2024
+3. **Network Egress** → $0.000000047683716 / KB (effective March 3rd, 2025)
+   - Previous rate: $0.000000095367432 / KB until March 2nd, 2025
+4. **Volume Storage** → $0.000003472222222 / GB / minute (effective March 3rd, 2025)
+   - Previous rate: $0.000005787037037 / GB / minute until March 2nd, 2025
 
-> **Note:** Effective March 3rd, 2024, Railway has reduced the pricing for Network Egress from $0.10/GB to $0.05/GB and Volume Storage from $0.25/GB to $0.15/GB.
+> **Note:** Effective March 3rd, 2025, Railway has reduced the pricing for Network Egress from $0.10/GB to $0.05/GB and Volume Storage from $0.25/GB to $0.15/GB.
 
 Users can see the usage of their projects under <a href="https://railway.com/account/usage" target="_blank">the usage page</a>.
 

--- a/src/docs/reference/teams.md
+++ b/src/docs/reference/teams.md
@@ -7,7 +7,7 @@ Workspaces are how organizations are represented within Railway. A default works
 
 For more information, visit our [documentation on pricing](/reference/pricing) or <a href="https://railway.com/pricing" target="_blank">railway.com/pricing</a>.
 
-> **Note:** Effective March 3rd, 2024, for users on Railway hosted metal instances, all seat costs will be waived.
+> **Note:** Effective March 3rd, 2025, for users on Railway hosted metal instances, all seat costs will be waived.
 
 ## Creating a Team
 
@@ -58,7 +58,7 @@ However, if you expect to use a consistent amount of resources for large compani
 
 ### Committed Spend Tiers
 
-As of March 3rd, 2024, Railway offers committed spend tiers for customers with consistent usage needs. Instead of negotiated contract pricing, customers can commit to a specific monthly spend level to unlock additional features and services.
+As of March 3rd, 2025, Railway offers committed spend tiers for customers with consistent usage needs. Instead of negotiated contract pricing, customers can commit to a specific monthly spend level to unlock additional features and services.
 
 For example, customers who commit to a $10,000/month spend rate can access dedicated hosts as an add-on, with all pricing going towards their usage. This approach provides more flexibility and transparency compared to traditional contract pricing.
 
@@ -70,7 +70,7 @@ Reach out to us at [team@railway.com](mailto:team@railway.com) for more informat
 
 ### How do I get my Pro seat costs waived?
 
-As of March 3rd, 2024, Railway waives all seat costs for users on Railway hosted metal instances. To qualify for this benefit:
+As of March 3rd, 2025, Railway waives all seat costs for users on Railway hosted metal instances. To qualify for this benefit:
 
 1. Your workspace must be on the Pro plan
 2. Your services must be running on Railway hosted metal instances

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -25,9 +25,9 @@ Please reach out to us on our [Help Station](https://station.railway.com/questio
 
 ## Pricing
 
-Volumes are billed at **$0.15 / GB**, billed monthly (effective March 3rd, 2024).
+Volumes are billed at **$0.15 / GB**, billed monthly (effective March 3rd, 2025).
 
-> **Note:** Previous rate was **$0.25 / GB** until March 2nd, 2024.
+> **Note:** Previous rate was **$0.25 / GB** until March 2nd, 2025.
 
 You are only charged for the amount of storage used by your volumes. _Each volume requires aprox 2-3% of the total storage to store metadata about the filesystem, so a new volume will always start with some used amount of space used depending on the size._
 


### PR DESCRIPTION
Realized there were more pages in with the same issue as mentioned in #690 – this PR should fix that