### PR TITLE
Trial Accounts: Make explicit the 5 services limitation

### DIFF
--- a/src/docs/reference/pricing/free-trial.md
+++ b/src/docs/reference/pricing/free-trial.md
@@ -34,7 +34,7 @@ When you sign up for the free Trial, you will receive a one-time grant of $5 in 
 
 ### What resources can I access during the Trial?
 
-During the trial, you can access the same features as on the Hobby plan, however you will be limited to 500MB of RAM and shared (rather than dedicated) vCPU cores.
+During the trial, you can access the same features as on the Hobby plan, however you will be limited to 500MB of RAM and shared (rather than dedicated) vCPU cores. Additionally, your projects will be limited to 5 services per project.
 
 As a trial user, you can always spin-up databases. However, to deploy code, you must be on the [Full Trial](#full-vs-limited-trial).
 


### PR DESCRIPTION
While I was working during the Free Trial, I ran into a limitation where any project that I made could only have a maximum of 5 services (even empty services). I would receive an error "Failed to deploy" in the toast notification, but no other information was available.

I upgraded to the Hobby plan and this error immediately went away.

There should probably be a mention of this limitation in the relevant documentation, and it might be helpful to explicitly have an error message for Trial accounts should they reach this limitation.

If this limitation is instead a bug that's not intended, then please feel free to decline the PR (and likely open a bug internally for whatever exactly the issue might be)