### PR TITLE
Update outdated info

### DIFF
--- a/public/static/faq.json
+++ b/public/static/faq.json
@@ -89,7 +89,7 @@
     "category": "general",
     "questions": ["Where do I submit a feature request?"],
     "answer": "Feature requests are greatly appreciated! You can submit a feature request on our feedback page.",
-    "link": "https://feedback.railway.com/"
+    "link": "https://station.railway.com/feedback"
   },
   "fair-use": {
     "category": "security",
@@ -139,10 +139,10 @@
       "I am reaching my free plan limits. How do I upgrade my account?",
       "How do I subscribe to the paid tier?",
       "Where do I upgrade my account?",
-      "How do I add a credit card?"
+      "How can I upgrade from Hobby to Pro?"
     ],
-    "answer": "You can upgrade on your Account Management portal under the Billing page.",
-    "link": "https://railway.com/account/billing"
+    "answer": "You can upgrade your account from within the 'Plans' page.",
+    "link": "https://railway.com/workspace/plans"
   },
   "usage-calc": {
     "category": "pricing",
@@ -168,8 +168,8 @@
   "see-usage": {
     "category": "pricing",
     "questions": ["How do I see my project's usage?"],
-    "answer": "Under the project usage tab under the Account dropdown menu.",
-    "link": "https://railway.com/account/billing"
+    "answer": "In the project settings, click on the 'Usage' tab.",
+    "link": ""
   },
   "bug-reporting": {
     "category": "misc",
@@ -177,8 +177,8 @@
       "I found a bug. Where can I report it?",
       "Where do I report a bug?"
     ],
-    "answer": "You can report a bug on our dedicated Bug Report Canny page. Bug reports are happily accepted!",
-    "link": "https://feedback.railway.com/bug-reports"
+    "answer": "You can report a bug in our Central Station. Bug reports are happily accepted!",
+    "link": "https://station.railway.com/feedback"
   },
   "hiring": {
     "category": "misc",

--- a/src/components/Search/NoResults.tsx
+++ b/src/components/Search/NoResults.tsx
@@ -27,7 +27,7 @@ const NoResults: React.FC = () => {
           <div css={tw`flex flex-row gap-4 items-center justify-center`}>
             <ContactButton href="https://station.railway.com/">
               <RailwayIcon />
-              Railway Help Station
+              Railway Central Station
             </ContactButton>
           </div>
         </div>

--- a/src/docs/community/the-conductor-program.md
+++ b/src/docs/community/the-conductor-program.md
@@ -9,11 +9,11 @@ This program aims to foster collaboration and help our Conductors grow.
 
 ## What Do Conductors Do?
 
-Our Conductors spend time in Discord and the Help Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
+Our Conductors spend time in Discord and the Central Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
 
 Here are a few key ways they contribute -
 
-- Providing community support through [Discord](https://discord.gg/railway) and the [Help Station](https://help.railway.com/).
+- Providing community support through [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
 
 - Maintaining a healthy and welcoming community atmosphere while moderating our channels and templates.
 
@@ -35,7 +35,7 @@ Here's what we look for in potential Conductors -
 
 - Maintain professional and friendly communication.
 
-- Are active participants in our Discord and Help Station.
+- Are active participants in our Discord and Central Station.
 
 - Demonstrate strong technical problem-solving abilities.
 
@@ -59,7 +59,7 @@ As part of the program, conductors will receive -
 
 - Letters of recommendation for educational institutions and employer references.
 
-- Moderation status on [Discord](https://discord.gg/railway) and the [Help Station](https://help.railway.com/).
+- Moderation status on [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
 
 - Access to a team workspace shared with other Conductors.
 
@@ -87,7 +87,7 @@ As a Conductor, you'll contribute regularly in these key areas -
 
 - Support Activities
 
-    - Helping others in [Discord](https://discord.gg/railway) and the [Help Station](https://help.railway.com/).
+    - Helping others in [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
 
     - Showing consistent engagement by regularly contributing to meaningful solutions across all Railway platforms.
 

--- a/src/docs/guides/create.md
+++ b/src/docs/guides/create.md
@@ -129,7 +129,7 @@ The current template variable functions are:
 
 ## Managing Your Templates
 
-You can see all of your templates on your <a href="https://railway.com/account/templates" target="_blank">Account's Template page</a>. Templates are separated into Personal and Published templates.
+You can see all of your templates on your <a href="https://railway.com/workspace/templates" target="_blank">Workspace's Template page</a>. Templates are separated into Personal and Published templates.
 
 You can edit, publish/unpublish and delete templates.
 

--- a/src/docs/guides/optimize-usage.md
+++ b/src/docs/guides/optimize-usage.md
@@ -9,7 +9,7 @@ Railway provides controls over resource usage in the form of usage limits and au
 
 Usage Limits allow you to set a maximum limit on your usage for a billing cycle.
 
-Visit the <a href="https://railway.com/account/usage" target="_blank">Account Usage page</a> to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal above where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd>.
+Visit the <a href="https://railway.com/workspace/usage" target="_blank">Workspace Usage page</a> to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal above where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd>.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1694775828/usage-limits_hzv9ee.png" alt="Usage Limits Modal" layout="responsive" width={1252} height={1150} />
 

--- a/src/docs/guides/publish-and-share.md
+++ b/src/docs/guides/publish-and-share.md
@@ -17,7 +17,7 @@ After you create your template, simply click the publish button and fill out the
   quality={80}
 />
 
-You can always publish your template by going to the <a href="https://railway.com/account/templates" target="_blank">Templates page in Account Settings</a> and choose `Publish` next to the template you'd like to publish.
+You can always publish your template by going to the <a href="https://railway.com/workspace/templates" target="_blank">Templates page in your Workspace settings</a> and choose `Publish` next to the template you'd like to publish.
 
 ## Sharing your Templates
 

--- a/src/docs/maturity/compare-to-fly.md
+++ b/src/docs/maturity/compare-to-fly.md
@@ -13,7 +13,7 @@ Railway offers:
 - **Flexible Deployment Options**: Use GitHub, Dockerfiles, Docker images from any registry, or local deployments via the Railway CLI.
 - **Integrated Tools**: Simplify environment variable management, CI/CD, observability, and service scaling.
 - **Networking Features:** Public and private networking.
-- **Best in Class Support:** Very active community and support on Slack, [Discord](https://discord.gg/railway) and [Help Station](https://help.railway.com/).
+- **Best in Class Support:** Very active community and support on Slack, [Discord](https://discord.gg/railway) and our [Central Station](https://station.railway.com/).
 
 We differ in the following:
 
@@ -114,7 +114,7 @@ Explore our [detailed pricing breakdown](https://docs.railway.com/reference/pric
 
 ### Customer Support and Community
 
-At Railway, we take pride in offering best-in-class support through our [vibrant Discord community](https://discord.gg/railway) and our custom-built [Help Station](https://help.railway.com/)—a support platform powered by Railway itself. We believe that every project matters, no matter how big or small. If you run into an issue, we’re here to help, and our engineers are always available to ensure you get the support you need.
+At Railway, we take pride in offering best-in-class support through our [vibrant Discord community](https://discord.gg/railway) and our custom-built [Central Station](https://station.railway.com/)—a support platform powered by Railway itself. We believe that every project matters, no matter how big or small. If you run into an issue, we’re here to help, and our engineers are always available to ensure you get the support you need.
 
 With over [880,000 users](https://railway.com/stats) who love what we do, we’re committed to continuous improvement. [Every week](https://railway.com/changelog), we ship new features and updates to make Railway even better—because great support isn’t just about answering questions, it’s about building a platform that just works.
 

--- a/src/docs/maturity/compare-to-heroku.md
+++ b/src/docs/maturity/compare-to-heroku.md
@@ -66,6 +66,6 @@ Railway serves hundreds of thousands of thousands of builders who deploy applica
 
 We feel no project, big or small- is never not important. This is our guiding philosophy to our users.
 
-As a result, we make great pains to be very communicative in our support channels, [optimistically gather feedback](https://feedback.railway.com/), provide informative docs, and encourage our community to help each other.
+As a result, we make great pains to be very communicative in our support channels, [optimistically gather feedback](https://station.railway.com/feedback), provide informative docs, and encourage our community to help each other.
 
-Having an issue with a deployment? [Join over 20k Railway users on our Discord Server!](https://discord.gg/railway) With our dedicated support channels, you can get help from the Railway team and our community of builders.
+Having an issue with a deployment? [Join over 25k Railway users on our Discord Server!](https://discord.gg/railway) With our dedicated support channels, you can get help from the Railway team and our community of builders.

--- a/src/docs/maturity/compare-to-render.md
+++ b/src/docs/maturity/compare-to-render.md
@@ -97,7 +97,7 @@ Curious about the savings? Check out a [detailed breakdown of our pricing](https
 
 ### Customer Support and Community
 
-At Railway, we take pride in providing best-in-class support through our [vibrant Discord community](https://discord.gg/railway) and our custom-built [Help Station](https://help.railway.com/)—a platform powered by Railway itself. We firmly believe that no project is too small or unimportant when it comes to addressing support needs. If an issue arises, we’re here to help.
+At Railway, we take pride in providing best-in-class support through our [vibrant Discord community](https://discord.gg/railway) and our custom-built [Central Station](https://station.railway.com/)—a platform powered by Railway itself. We firmly believe that no project is too small or unimportant when it comes to addressing support needs. If an issue arises, we’re here to help.
 
 With over [900,000 users](https://railway.com/stats) who think we’re the best thing since sliced bread, we’re committed to continuously improving. [Week after week](https://railway.com/changelog), we ship new features and updates to better support our customers.
 

--- a/src/docs/maturity/compare-to-vercel.md
+++ b/src/docs/maturity/compare-to-vercel.md
@@ -33,7 +33,7 @@ This is just scratching the surface of the similarities between Railway and Verc
 
 - **Persistent Disks** - We provide persistent disks for your application, so you don't have to worry about data loss.
 
-- **Best in Class Support** - Incredibly fast personalized support on Slack, and the [Help Station](https://help.railway.com/).
+- **Best in Class Support** - Incredibly fast personalized support on Slack, and the [Central Station](https://station.railway.com/).
 
 - **Private networking** - Seamlessly and securely connect your services together through the global wireguard network.
 
@@ -129,9 +129,9 @@ And fortunately, this simple pricing model does not change based on the region y
 
 ### Support
 
-We offer incredibly fast and personalized support on Slack, and the [Help Station](https://help.railway.com/).
+We offer incredibly fast and personalized support on Slack, and the [Central Station](https://station.railway.com/).
 
-Our help station is built in house from the ground up to allow us to provide the best possible support to you, the user.
+Our Central Station is built in house from the ground up to allow us to provide the best possible support to you, the user.
 
 Pro and enterprise users get priority support within Slack, and entrpise can also book a call with our team to get direct help from the Railway team.
 

--- a/src/docs/maturity/compliance.md
+++ b/src/docs/maturity/compliance.md
@@ -31,7 +31,7 @@ Railway follows a shared responsibility model for HIPAA compliance. Railway will
 
 If your company needs a BAA, you can contact our solutions team at [team@railway.com](mailto:team@railway.com), or click [here](https://cal.com/team/railway/work-with-railway?duration=30) to schedule some time to chat.
 
-We are working on operationalized BAAs and continually gathering requirements for health-focused workloads for Enterprises. You can share your feedback in [Help Station](https://station.railway.com/feedback).
+We are working on operationalized BAAs and continually gathering requirements for health-focused workloads for Enterprises. You can share your feedback in [Central Station](https://station.railway.com/feedback).
 
 ## Privacy
 

--- a/src/docs/maturity/incident-management.md
+++ b/src/docs/maturity/incident-management.md
@@ -11,7 +11,7 @@ Railway understands the importance of effective incident management procedures. 
 
 Railway has a robust monitoring system in place to proactively detect and address any potential incidents. We continuously monitor our infrastructure, including servers, networks, and applications, to ensure their smooth operation. By monitoring key metrics and performance indicators, we can identify any anomalies or potential issues before they escalate into full-blown incidents.
 
-However, it's important to note that while we strive to stay ahead of incidents, there may be situations where unforeseen issues arise. In such cases, we rely on qualitative customer feedback to help us identify and address any issues promptly. We encourage our customers to report any problems they encounter through our forums, Discord, or [email support](mailto:team@railway.com).
+However, it's important to note that while we strive to stay ahead of incidents, there may be situations where unforeseen issues arise. In such cases, we rely on qualitative customer feedback to help us identify and address any issues promptly. We encourage our customers to report any problems they encounter through our [Central Station](https://station.railway.com), [Slack](/reference/support#slack), or [Discord](https://discord.gg/railway).
 
 ## Status Page + Uptime
 

--- a/src/docs/migration/migrate-from-render.md
+++ b/src/docs/migration/migrate-from-render.md
@@ -15,7 +15,7 @@ Railway offers:
 - **Flexible Deployment Options**: Use GitHub, Dockerfiles, Docker images from supported registries (Docker Hub, GitHub, RedHat, GitLab, Microsoft), or local deployments via the Railway CLI.
 - **Integrated Tools**: Simplify environment variable management, CI/CD, observability, and service scaling.
 - **Networking Features:** Public and private networking.
-- **Best in Class Support:** Very active community on [Discord](https://discord.gg/railway) and [Help Station](https://help.railway.com/).
+- **Best in Class Support:** Very active community on [Discord](https://discord.gg/railway) and our [Central Station](https://station.railway.com/).
 
 ..and so much more. Want to see for yourself? [Try Railway for a spin today!](https://railway.com/new)
 

--- a/src/docs/migration/migrate-from-vercel.md
+++ b/src/docs/migration/migrate-from-vercel.md
@@ -143,6 +143,6 @@ Railway makes local development seamless with your production environment:
 
 This ensures development/production parity and helps catch issues before they reach production.
 
-That's all it takes to move your Next.js application to Railway! Need help? Our [team and community](https://help.railway.com/) are always ready to assist.
+That's all it takes to move your Next.js application to Railway! Need help? Our [team and community](https://station.railway.com/) are always ready to assist.
 
 Need more information on how we compare to Vercel? Check out our [comparison page](/maturity/compare-to-vercel).

--- a/src/docs/railway-metal.md
+++ b/src/docs/railway-metal.md
@@ -244,6 +244,6 @@ On your invoice close date, if 80 percent of your usage costs come from Railway 
 
 ## Getting Help
 
-Please reach out to us [on our Help Station](https://help.railway.com/feedback/feedback-railway-metal-a41f03a1) if you run into any issues. You can also reach out to us over [Slack](/reference/support#slack) if you are
+Please reach out to us [on our Central Station](https://station.railway.com/feedback/feedback-railway-metal-a41f03a1) if you run into any issues. You can also reach out to us over [Slack](/reference/support#slack) if you are
 a Pro or [Business Class / Enterprise](/reference/support#business-class)
 customer.

--- a/src/docs/reference/accounts.md
+++ b/src/docs/reference/accounts.md
@@ -64,7 +64,7 @@ Users can view their referral invite status on the <a href="https://railway.com/
 
 Accounts are billed monthly. Resources used by deleted projects up until deletion are still counted towards the total bill.
 
-Users can manage their billing plan as well as view historical payments on the <a href="https://railway.com/account/billing" target="_blank">billing page</a>.
+Users can manage their billing information as well as view historical payments on the <a href="https://railway.com/workspace/billing" target="_blank">billing page</a>.
 
 ## Link Discord Account
 

--- a/src/docs/reference/metal-upgrade.md
+++ b/src/docs/reference/metal-upgrade.md
@@ -87,7 +87,7 @@ For example, if your application in US West (California) Railway Metal region co
 
 If you need assistance with your Railway Metal upgrade:
 
-- Submit feedback through our [Help Station](https://help.railway.com/feedback/feedback-railway-metal-a41f03a1)
+- Submit feedback through our [Central Station](https://station.railway.com/feedback/feedback-railway-metal-a41f03a1)
 - Pro and Enterprise customers can reach out via [Slack](/reference/support#slack)
 - See our [FAQ on Railway Metal](/railway-metal#faq) for answers to common questions
 

--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -21,7 +21,7 @@ To understand how much your app will cost to run on Railway, we recommend you to
 
 1. Deploy your project with the [Trial](/reference/pricing/free-trial) or Hobby plan
 2. Allow it to run for one week
-3. Check your Estimated Usage in the [Usage Section](https://railway.com/account/usage) of your account
+3. Check your Estimated Usage in the [Usage Section](https://railway.com/workspace/usage) of your Workspace settings
 
 Keeping it running for one week allows us to rack up sufficient metrics to provide you with an estimate of your usage for the current billing cycle. You can then use this information to extrapolate the cost you should expect.
 
@@ -37,7 +37,7 @@ Check out our [guide on optimizing usage](/guides/optimize-usage).
 
 ### Why is my resource usage higher than expected?
 
-You can check your resource usage in the [Usage Section](https://railway.com/account/usage) of your account. This includes a breakdown of your resource usage by project, along with the resource it's consuming (CPU, Memory, Network, etc.)
+You can check your resource usage in the [Usage Section](https://railway.com/workspace/usage) of your Workspace settings. This includes a breakdown of your resource usage by project, along with the resource it's consuming (CPU, Memory, Network, etc.)
 
 Common reasons for high resource usage include:
 
@@ -61,7 +61,7 @@ When the amount due on your invoice is less than $0.50, and you do not have a cr
 
 ### How do I view/manage/cancel my subscription?
 
-To view and manage your subscription, visit the [billing section](https://railway.com/account/billing) of the Railway dashboard.
+To view and manage your subscription, visit the [billing section](https://railway.com/workspace/billing) of your workspace.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1715777336/docs/manage-subscription_ssyxhg.png"
@@ -81,40 +81,26 @@ When you cancel your subscription, if you're on Hobby, Pro, or Enterprise, your 
 
 If you are on the Hobby plan and using prepaid credits as your payment method, your subscription will be canceled immediately and any credit balance you may have will be forfeited.
 
-### How do I switch between Hobby plan billing models?
+### How do I switch to the auto-renewing Hobby plan billing model?
 
-At this time, we do not directly support switching between Hobby plan billing models, such as switching from a prepaid credit-based plan to an auto-renewing subscription, or vice versa.
+At this time, we do not directly support switching from a prepaid credit-based plan to an auto-renewing subscription.
 
-You can, however, cancel your current plan, wait until the end of the current billing period or until you exhaust your remaining credits, and then sign back up with the desired billing model.
+You can, however, cancel your current plan, wait until you exhaust your remaining credits, and then sign back up on the auto-renewing plan.
 
-**Note:** Cancelling your subscription does not immediately stop your [services](/overview/the-basics#services). The outcome depends on your previous plan -
-
-- For subscription-based plans: Services will run until the end of your current billing period.
-- For prepaid credits-based plans: Services will run until you exhaust your remaining credits.
+**Note:** Cancelling your subscription does not immediately stop your [services](/overview/the-basics#services). Services will run until you exhaust your remaining credits.
 
 <p><span style={{color: "var(--tw-prose-counters)"}}>1.</span> Cancel your current plan.</p>
 
-    - Head over to the <a href="https://railway.com/account/billing" target="_blank">billing page</a> of your account.
+    - Head over to the <a href="https://railway.com/workspace/billing" target="_blank">Billing page</a> of your workspace.
     - Click on **Manage Subscription**.
     - Click on **Cancel Plan**.
 
-<p><span style={{color: "var(--tw-prose-counters)"}}>2.</span> Wait until the end of the current billing period or until you exhaust your remaining credits.</p>
+<p><span style={{color: "var(--tw-prose-counters)"}}>2.</span> Wait until you exhaust your remaining credits.</p>
 
-<p><span style={{color: "var(--tw-prose-counters)"}}>3.</span> Sign up for your desired billing model.</p>
+<p><span style={{color: "var(--tw-prose-counters)"}}>3.</span> Sign up for the auto-renewing Hobby plan.</p>
 
-    1. Prepaid Credits Model.
-
-        - Head over to the <a href="https://railway.com/account/upgrade" target="_blank">upgrade page</a>.
-        - Scroll to the bottom and select **Looking for a prepaid subscription**.
-        - Enter your billing information.
-        - Enter the amount of credits you'd like to add to your account. (Minimum of $10)
-        - Click on **Purchase Credits**.
-
-        You are now on the prepaid credits model. Be sure to always keep a balance in your account to keep your services running.
-
-    2. Auto-renewing Subscription Model.
-
-        - Head over to the <a href="https://railway.com/account/upgrade" target="_blank">upgrade page</a>.
+        - Head over to the <a href="https://railway.com/workspace/plans" target="_blank">Plans page</a>.
+        - Click **Deploy with Hobby**.
         - Enter your billing information.
         - Click on **Subscribe to Hobby Plan**.
 
@@ -138,9 +124,9 @@ Your [services](/overview/the-basics#services) may be stopped by Railway for the
 
 - **Hobby credits exhausted:** You've run out of [prepaid credits](/reference/pricing/plans#credits). Add more credits to your account.
 
-- **Failed payment:** Your payment method has failed. Update your payment method and [pay your outstanding invoice](https://railway.com/account/billing).
+- **Failed payment:** Your payment method has failed. Update your payment method and [pay your outstanding invoice](https://railway.com/workspace/billing).
 
-- **Unpaid invoice:** You have an outstanding invoice. [Pay your outstanding invoice](https://railway.com/account/billing).
+- **Unpaid invoice:** You have an outstanding invoice. [Pay your outstanding invoice](https://railway.com/workspace/billing).
 
 In all cases, you can redeploy your services once the underlying issue is resolved, this can be done from the Removed deployment's [3-dot menu](/reference/deployments#deployment-menu).
 
@@ -148,7 +134,7 @@ In all cases, you can redeploy your services once the underlying issue is resolv
 
 ### I am a freelancer or represent an agency. How do I manage my billing relationships with my clients?
 
-Create a Pro plan on Railway and add the client to the team. If you run into issues when it's time to hand over your workload to your client, you can reach out to us over our [Help Station](https://station.railway.com).
+Create a Pro plan on Railway and add the client to the workspace. If you run into issues when it's time to hand over your workload to your client, you can reach out to us over our [Central Station](https://station.railway.com).
 
 ### Why did I receive another invoice after cancelling my subscription?
 

--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -97,23 +97,9 @@ For example, customers who commit to a $10,000/month spend rate can access dedic
 
 To learn more about committed spend tiers and available add-ons, please [contact our team](mailto:team@railway.com).
 
-## Credits
-
-Credits are available on Railway as a payment method for Hobby plan users who prefer to pre-pay for their subscription and usage on Railway.
-
-### Credits As a Payment Method
-
-On Railway, you can pay for your Hobby plan subscription and resource usage with pre-purchased credits. When using credits as a payment method, keep in mind that:
-
-- You must carry a credit balance sufficient to cover usage + the Hobby plan fee, otherwise your project will be paused and your subscription cancelled. If your subscription is cancelled, you will be required to resubscribe
-- If your usage within a billing period exceeds your credit balance, you will no longer be able to deploy, and your projects will be paused
-- If you cancel your subscription, any remaining credit balance will be lost
-
-Credits as a payment method is only available for Hobby plan users.
-
 ### Purchasing Credits
 
-You can purchase credits from your account's [Usage page](https://railway.com/account/usage).
+If you are already on the Pre-Paid plan, you can purchase credits from your Workspace's [Usage page](https://railway.com/workspace/usage).
 
 ### One-time Grant of Credits on the Free Trial
 

--- a/src/docs/reference/pricing/refunds.md
+++ b/src/docs/reference/pricing/refunds.md
@@ -7,7 +7,7 @@ Refunds are for new customers who no longer wish to use Railway after initially 
 
 ## Requesting A Refund
 
-You can request for a refund in [Account -> Billing](https://railway.com/account/billing) under **Billing History**:
+You can request for a refund in [Workspace Settings -> Billing](https://railway.com/workspace/billing) under **Billing History**:
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1708555357/docs/billing-refund_wg7aja.png"

--- a/src/docs/reference/production-readiness-checklist.md
+++ b/src/docs/reference/production-readiness-checklist.md
@@ -79,7 +79,7 @@ Observability and monitoring refers to tracking the health and performance of yo
 
     Setup [webhooks](/reference/deployments#deployment-states) to have the alerts sent to another system, like Slack or Discord.
 
-*What's next for observability features in Railway?  We have a ton of ideas, but we would love to hear yours in our <a href="https://help.railway.com/feature-request/better-logging-support-1e6f5676" target="_blank">community forums</a>.*
+*What's next for observability features in Railway?  We have a ton of ideas, but we would love to hear yours in our <a href="https://station.railway.com/feature-request/better-logging-support-1e6f5676" target="_blank">community forums</a>.*
 
 ---
 
@@ -131,7 +131,7 @@ Protecting your application and user data from malicious threats and vulnerabili
 
    Consider using a service like Cloudflare that offers both WAF and DDoS mitigation, to protect your services against web threats and ensure availability and performance.
 
-    *In the future, we would love to offer a native security solution.  If you agree, <a href="https://help.railway.com/feature-request/implement-a-waf-firewall-security-54fe2aaf" target="_blank">let us know</a>.*
+    *In the future, we would love to offer a native security solution.  If you agree, <a href="https://station.railway.com/feature-request/implement-a-waf-firewall-security-54fe2aaf" target="_blank">let us know</a>.*
 
 ---
 
@@ -161,4 +161,4 @@ Using a mix of native features and external tools, we hope you can feel confiden
 
 Remember, our team is always here to assist you with solutions.  Reach out in <a href="https://discord.com/channels/713503345364697088/1006629907067064482" target="_blank">Discord</a> or over email at [team@railway.com](mailto:team@railway.com) for assistance.
 
-Finally, as suggested on several sections above, we are working tirelessly to give you the best experience imaginable on Railway.  If you have requests or suggestions, please <a href="https://help.railway.com" target="_blank">let us know</a>!
+Finally, as suggested on several sections above, we are working tirelessly to give you the best experience imaginable on Railway.  If you have requests or suggestions, please <a href="https://station.railway.com" target="_blank">let us know</a>!

--- a/src/docs/reference/project-usage.md
+++ b/src/docs/reference/project-usage.md
@@ -3,7 +3,7 @@ title: Project Usage
 description: Learn how users can see the resource usage of their projects.
 ---
 
-Users are billed monthly based on their project's per-minute usage. All services within a project's environments contribute to the resources billed. The rates are as follows:
+Users are billed monthly based on the project's per-minute usage. All services within a project's environments contribute to the resources billed. The rates are as follows:
 
 1. **RAM** → $0.000231 / GB / minute
 2. **CPU** → $0.000463 / vCPU / minute
@@ -14,7 +14,7 @@ Users are billed monthly based on their project's per-minute usage. All services
 
 > **Note:** Effective March 3rd, 2025, Railway has reduced the pricing for Network Egress from $0.10/GB to $0.05/GB and Volume Storage from $0.25/GB to $0.15/GB.
 
-Users can see the usage of their projects under <a href="https://railway.com/account/usage" target="_blank">the usage page</a>.
+Users can see the usage of a project under <a href="https://railway.com/workspace/usage" target="_blank">the Usage page</a> within the Workspace settings.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1631917786/docs/project-usage_gd43fq.png"
 alt="Screenshot of Expanded Project Usage Pane"

--- a/src/docs/reference/support.md
+++ b/src/docs/reference/support.md
@@ -11,11 +11,11 @@ We prioritize support requests based on the plan you're on and the urgency of yo
 
 ### Trial & Hobby
 
-Trial & Hobby plan users are only eligible for community support over [Help Station](#help-station) or [Discord](#discord). Railway may respond to community threads, but a response is not guaranteed.
+Trial & Hobby plan users are only eligible for community support over [Central Station](#help-station) or [Discord](#discord). Railway may respond to community threads, but a response is not guaranteed.
 
 ### Pro & Business Class
 
-Pro & [Business Class](#business-class) customers can select the urgency of their request when creating a new thread in [Help Station](#help-station) or [Slack](#slack).
+Pro & [Business Class](#business-class) customers can select the urgency of their request when creating a new thread in [Central Station](#help-station) or [Slack](#slack).
 
 | Level    | Description                                                                | Eligibility                       |
 | -------- | -------------------------------------------------------------------------- | --------------------------------- |
@@ -24,15 +24,15 @@ Pro & [Business Class](#business-class) customers can select the urgency of thei
 | High     | Issues that are blocking you from using Railway                            | Pro                               |
 | Critical | Production outage or platform issues blocking your team from using Railway | [Business Class](#business-class) |
 
-## Help Station
+## Central Station
 
-Railway conducts its support over our [Help Station](https://station.railway.com) platform.
+Railway conducts its support over our [Central Station](https://station.railway.com) platform.
 
 It hosts our community of 500,000+ users and developers. It is where you can find answers to common questions, ask questions, and get in touch with the Railway team.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1733323523/docs/cs-2024-12-04-22.28_egl1hw.png"
-alt="Screenshot of Railway Help Station"
+alt="Screenshot of Railway Central Station"
 layout="intrinsic"
 width={1737} height={1384} quality={100} />
 
@@ -40,13 +40,13 @@ Please ensure that you've searched for your issue before creating a new thread, 
 
 ### Visibility
 
-For Pro plan users, threads created in the [Help Station](https://station.railway.com) are treated as **High Priority**. These threads are guaranteed a response from the Railway team within 1 business day (if community members are unable to help).
+For Pro plan users, threads created in the [Central Station](https://station.railway.com) are treated as **High Priority**. These threads are guaranteed a response from the Railway team within 1 business day (if community members are unable to help).
 
 We pay special attention to threads created by Pro users and ensure that questions or concerns are resolved in a timely manner.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1715282870/docs/pro-priority-threads_pxyodo.png"
-alt="Screenshot of Railway Help Station - Priority Threads"
+alt="Screenshot of Railway Central Station - Priority Threads"
 layout="intrinsic"
 width={772} height={269} quality={100} />
 
@@ -54,11 +54,11 @@ For teams and companies requiring SLOs and higher-priority support over chat, si
 
 ### Private Threads
 
-You create a **Private Thread** on [Help Station](https://station.railway.com/support) if you need to share sensitive information, such as invoices or personal data. Private Threads are only visible to you and Railway employees.
+You create a **Private Thread** on [Central Station](https://station.railway.com/support) if you need to share sensitive information, such as invoices or personal data. Private Threads are only visible to you and Railway employees.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1715282996/docs/priv-threads_lus6tx.png"
-alt="Screenshot of Railway Help Station - Private Threads"
+alt="Screenshot of Railway Central Station - Private Threads"
 layout="intrinsic"
 width={756} height={184} quality={100} />
 

--- a/src/docs/reference/usage-limits.md
+++ b/src/docs/reference/usage-limits.md
@@ -9,7 +9,7 @@ Usage Limits allow you to set a maximum limit on your usage for a billing cycle.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1694775828/usage-limits_hzv9ee.png" alt="Usage Limits Modal" layout="responsive" width={1252} height={1150} />
 
-Visit your [account usage page](https://railway.com/account/usage) to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal above where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd>.
+Visit your [Workspace Usage page](https://railway.com/workspace/usage) to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal above where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd>.
 
 <Banner variant="info">The link above takes you to the usage page for your personal account. If you want to set a usage limit for your team, you can use the account switcher in the top left corner of your dashboard to access the team's usage page.</Banner>
 

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -21,7 +21,7 @@ Volumes can be "Grown" after upgrading to a different plan.
 
 Pro users and above can self-serve to increase their volume up to 250 GB.
 
-Please reach out to us on our [Help Station](https://station.railway.com/questions) or [Slack](/reference/support#slack) if you need more space.
+Please reach out to us on our [Central Station](https://station.railway.com/questions) or [Slack](/reference/support#slack) if you need more space.
 
 ## Pricing
 

--- a/src/docs/tutorials/getting-started.md
+++ b/src/docs/tutorials/getting-started.md
@@ -13,5 +13,5 @@ Also checkout our [Quick Start Tutorial](/quick-start) to deploy an app in minut
 
 Pull requests are welcome.  If you make a quality tutorial for other Railway users, we would really love to include it!
 
-If there is a tutorial you hope to see, please create a post in <a href="https://help.railway.com/" target="_blank">Forums</a>!
+If there is a tutorial you hope to see, please create a post in <a href="https://station.railway.com/" target="_blank">Forums</a>!
 

--- a/src/docs/tutorials/github-post-deploy-actions.md
+++ b/src/docs/tutorials/github-post-deploy-actions.md
@@ -50,4 +50,4 @@ It's that simple! You can now customize the final run step to execute any comman
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/reference/support#slack) or the [Help Station](https://help.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/reference/support#slack) or the [Central Station](https://station.railway.com). Happy coding!

--- a/src/docs/tutorials/github-pr-environment-actions.md
+++ b/src/docs/tutorials/github-pr-environment-actions.md
@@ -58,4 +58,4 @@ This can very easily be modified to run commands in order to find variables and 
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/reference/support#slack) or the [Help Station](https://help.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/reference/support#slack) or the [Central Station](https://station.railway.com). Happy coding!


### PR DESCRIPTION
- `feedback.railway.com` -> `station.railway.com`
- `help.railway.com` -> `station.railway.com`
- `Help Station` -> `Central Station`
- `https://railway.com/account/*` -> `https://railway.com/workspace/*`
- Removed information about signing up with credits since we discontinued pre-paid for new sign-ups.