### PR TITLE
Normalize minutely pricing to reference plan page

### DIFF
--- a/src/docs/maturity/compare-to-digitalocean.md
+++ b/src/docs/maturity/compare-to-digitalocean.md
@@ -81,11 +81,7 @@ We handle SSL/TLS certificates automatically, while DigitalOcean users need to m
 
 ### Pricing
 
-Railway's pricing is based on actual resource usage:
-- Memory: $1.00 per 100 MB /month
-- CPU: $2.00 per 0.1 vCPU /month
-- Storage: $0.15 per GB/month
-- Outbound Data: $0.05 per GB
+Railway's pricing is based on actual resource usage. You can find [specific per-minute pricing here](/reference/pricing/plans#default-plan-resources).
 
 DigitalOcean's pricing is based on fixed-size droplets or VMs and requires manual scaling, which will lead to overprovisioning and higher costs.
 

--- a/src/docs/maturity/compare-to-vercel.md
+++ b/src/docs/maturity/compare-to-vercel.md
@@ -113,15 +113,7 @@ Best of all, through our [Kickback Program](https://railway.com/open-source-kick
 
 ### Pricing
 
-Railway offers straightforward and transparent, [resource-based pricing](/reference/pricing/plans) that scales with your needs, pay only for the resources you use.
-
-- **Memory:** $10 per GB / month
-
-- **CPU:** $10 per vCPU / month
-
-- **Storage:** $0.25 per GB / month
-
-- **Outbound Data:** $0.10 per GB used
+Railway offers straightforward and transparent, [resource-based pricing](/reference/pricing/plans) that scales with your needs, pay only for the resources you use. You can find [specific per-minute pricing here](/reference/pricing/plans#default-plan-resources).
 
 Unlike Vercel's function-based pricing, we charge based on actual resource usage (CPU, Memory, Storage), making costs more predictable and often more economical for backend services.
 

--- a/src/docs/railway-metal.md
+++ b/src/docs/railway-metal.md
@@ -151,8 +151,6 @@ The migration is aimed to be completed by the 4th of July, 2025.
 
 ## Pricing Updates
 
-_These billing rates will enter in effect on March 3rd_
-
 If you migrate 80 percent of your workloads to Railway Metal, you'll benefit from significantly reduced costs:
 
 - **Egress Fees**: Reduced by 50%, from $0.10/GB to $0.05/GB.

--- a/src/docs/reference/accounts.md
+++ b/src/docs/reference/accounts.md
@@ -56,7 +56,7 @@ width={1141} height={604} quality={80} />
 
 Every account has an editable referral link. Users can copy and share their personal referral link to earn credits.
 
-For every referral who incurs more than $10 worth of usage and pays their first bill, users receive 5$ of credit.
+For every referral who incurs more than $10 worth of usage and pays their first bill, users receive $5 of credit.
 
 Users can view their referral invite status on the <a href="https://railway.com/account/referrals" target="_blank">referrals page</a>.
 

--- a/src/docs/reference/backups.md
+++ b/src/docs/reference/backups.md
@@ -51,7 +51,7 @@ The changes will be applied and your service will be redeployed.
 
 Backups are incremental and Copy-on-Write, we only charge for the data exclusive to them, that aren't from other snapshots or the volume itself.
 
-You are only billed for the incremental size of the backup at $0.25 / GB, billed monthly.
+You are only billed for the incremental size of the backup at a rate per GB / minutely, and invoiced monthly. Backups follow the same pricing as Volumes. You can find [specific per-minute pricing here](/reference/pricing/plans#default-plan-resources).
 
 ## Caveats
 

--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -57,7 +57,7 @@ You are only charged for the resources you actually use, which helps prevent run
 | **RAM**                                                    | $10 / GB / month ($0.000231 / GB / minute)            |
 | **CPU**                                                    | $20 / vCPU / month ($0.000463 / vCPU / minute)        |
 | **Network Egress**                                         | $0.05 / GB ($0.000000047683716 / KB)                  |
-| (Optional Add-on) [**Volume Storage**](/reference/volumes) | $0.15 / GB / month ($0.000003472222222 / GB / minute) |
+| [**Volume Storage**](/reference/volumes)                   | $0.15 / GB / month ($0.000003472222222 / GB / minute) |
 
 To learn more about controlling your resource usage costs, read our FAQ on [How do I prevent spending more than I want to?](/reference/pricing/faqs#how-do-i-prevent-spending-more-than-i-want-to)
 

--- a/src/docs/reference/project-usage.md
+++ b/src/docs/reference/project-usage.md
@@ -3,16 +3,7 @@ title: Project Usage
 description: Learn how users can see the resource usage of their projects.
 ---
 
-Users are billed monthly based on the project's per-minute usage. All services within a project's environments contribute to the resources billed. The rates are as follows:
-
-1. **RAM** → $0.000231 / GB / minute
-2. **CPU** → $0.000463 / vCPU / minute
-3. **Network Egress** → $0.000000047683716 / KB (effective March 3rd, 2025)
-   - Previous rate: $0.000000095367432 / KB until March 2nd, 2025
-4. **Volume Storage** → $0.000003472222222 / GB / minute (effective March 3rd, 2025)
-   - Previous rate: $0.000005787037037 / GB / minute until March 2nd, 2025
-
-> **Note:** Effective March 3rd, 2025, Railway has reduced the pricing for Network Egress from $0.10/GB to $0.05/GB and Volume Storage from $0.25/GB to $0.15/GB.
+Users are billed monthly based on the project's per-minute usage. All services within a project's environments contribute to the resources billed. You can find [specific per-minute pricing here](/reference/pricing/plans#default-plan-resources).
 
 Users can see the usage of a project under <a href="https://railway.com/workspace/usage" target="_blank">the Usage page</a> within the Workspace settings.
 

--- a/src/docs/reference/teams.md
+++ b/src/docs/reference/teams.md
@@ -9,46 +9,46 @@ For more information, visit our [documentation on pricing](/reference/pricing) o
 
 > **Note:** Effective March 3rd, 2025, for users on Railway hosted metal instances, all seat costs will be waived.
 
-## Creating a Team
+## Creating a Workspace
 
-Organizations can create a team by heading to the <a href="https://railway.com/new/team" target="_blank">Create Team</a> page and entering the required information.
+Organizations can create a workspace by heading to the <a href="https://railway.com/new/workspace" target="_blank">Create Workspace</a> page and entering the required information.
 
-## Managing Teams
+## Managing Workspaces
 
-You can open your team's settings page to manage team members and see billing information by clicking the gear icon next to the name of your team on the dashboard.
+You can open your workspace's settings page to manage members and see billing information by clicking the gear icon next to the name of your workspace on the dashboard.
 
 ## Inviting Members
 
-Under the People tab of the settings page, you can invite members to access the project.
+Under the People tab of the settings page, you can invite members.
 
-There are three roles for Team members:
+There are three roles for Workspace members:
 
-- Admin: Full administration of the Team and all Team projects
-- Member: Access to all Team projects
-- Deployer: View projects and deploy through commits to repos via github integration.
+- Admin: Full administration of the Workspace and all Workspace projects
+- Member: Access to all Workspace projects
+- Deployer: View projects and deploy through commits to repos via GitHub integration.
 
-_Note_: Changes that trigger a deployment will skip the approval requirement when the author has a Deployer role (or higher) and their Github account is connected.
+_Note_: Changes that trigger a deployment will skip the approval requirement when the author has a Deployer role (or higher) and their GitHub account is connected.
 
 ## Trusted Domains
 
-Trusted domains may be configured on the team settings page. Note that team members added via trusted domain will be billed at the normal rate.
+Trusted domains may be configured on the workspace settings page. Note that workspace members added via trusted domain will be billed at the normal rate.
 
 <Image 
     src="https://res.cloudinary.com/railway/image/upload/v1733955730/docs/t-d_jbtbm7.png"
     width="1200"
     height="548"
-    alt="Trusted domains are configurable via the team settings"
+    alt="Trusted domains are configurable via the workspace settings"
 />
 
-You can automate the onboarding of new team members with trusted domains. Railway users that sign up with one of the trusted domains associated with your team will automatically be granted access to the team with the specified role (see above).
+You can automate the onboarding of new workspace members with trusted domains. Railway users that sign up with one of the trusted domains associated with your workspace will automatically be granted access to the workspace with the specified role (see above).
 
-For example, new users with `example.com` email addresses will automatically be added to your teams that have the `example.com` trusted domain.
+For example, new users with `example.com` email addresses will automatically be added to your workspaces that have the `example.com` trusted domain.
 
-We verify that you have administrative access to the domain by looking for services in your team that use this domain or a subdomain. Make sure to [setup a custom domain](/guides/public-networking#custom-domains) on your service before adding it as a trusted domain.
+We verify that you have administrative access to the domain by looking for services in your workspace that use this domain or a subdomain. Make sure to [setup a custom domain](/guides/public-networking#custom-domains) on your service before adding it as a trusted domain.
 
 ## Transferring Projects
 
-Transfer projects from another Team or Hobby workspace easily. Detailed instructions can be found [here](/guides/projects#transferring-projects).
+Transfer projects from another Workspace or Hobby workspace easily. Detailed instructions can be found [here](/guides/projects#transferring-projects).
 
 ## Invoicing and Billing
 
@@ -76,4 +76,4 @@ As of March 3rd, 2025, Railway waives all seat costs for users on Railway hosted
 
 If you're interested in moving to Railway hosted metal instances to take advantage of this benefit, please [contact our team](mailto:team@railway.com) to discuss your requirements and set up a dedicated host solution.
 
-The seat cost waiver provides significant savings for teams of all sizes, especially as your team grows. This is part of our commitment to providing more flexible and cost-effective pricing options for our customers.
+The seat cost waiver provides significant savings for workspaces of all sizes, especially as your workspace grows. This is part of our commitment to providing more flexible and cost-effective pricing options for our customers.

--- a/src/docs/reference/teams.md
+++ b/src/docs/reference/teams.md
@@ -58,11 +58,9 @@ However, if you expect to use a consistent amount of resources for large compani
 
 ### Committed Spend Tiers
 
-As of March 3rd, 2025, Railway offers committed spend tiers for customers with consistent usage needs. Instead of negotiated contract pricing, customers can commit to a specific monthly spend level to unlock additional features and services.
+Railway offers committed spend tiers for customers with consistent usage needs. Instead of negotiated contract pricing, customers can commit to a specific monthly threshold to [unlock additional features and services.](/reference/pricing/plans#committed-spend-tiers)
 
-For example, customers who commit to a $10,000/month spend rate can access dedicated hosts as an add-on, with all pricing going towards their usage. This approach provides more flexibility and transparency compared to traditional contract pricing.
-
-To learn more about committed spend tiers and available add-ons, please [contact our team](mailto:team@railway.com).
+Monthly thresholds for addons is found in our [commited spend pricing](/reference/pricing#committed-spend-tiers).
 
 Reach out to us at [team@railway.com](mailto:team@railway.com) for more information.
 
@@ -73,8 +71,8 @@ Reach out to us at [team@railway.com](mailto:team@railway.com) for more informat
 As of March 3rd, 2025, Railway waives all seat costs for users on Railway hosted metal instances. To qualify for this benefit:
 
 1. Your workspace must be on the Pro plan
-2. Your services must be running on Railway hosted metal instances
-3. This waiver will be automatically applied by the time of your invoice close date
+2. Your services must be quality for metal pricing and run on Railway hosted metal instances
+3. This waiver will be automatically applied for your next monthly invoice
 
 If you're interested in moving to Railway hosted metal instances to take advantage of this benefit, please [contact our team](mailto:team@railway.com) to discuss your requirements and set up a dedicated host solution.
 

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -25,9 +25,7 @@ For Pro and above users, please reach out to us on our [Central Station](https:/
 
 ## Pricing
 
-Volumes are billed at **$0.15 / GB**, billed monthly (effective March 3rd, 2025).
-
-> **Note:** Previous rate was **$0.25 / GB** until March 2nd, 2025.
+Volumes are billed at a rate per GB / minutely, and invoiced monthly. You can find [specific per-minute pricing here](/reference/pricing/plans#default-plan-resources).
 
 You are only charged for the amount of storage used by your volumes. _Each volume requires aprox 2-3% of the total storage to store metadata about the filesystem, so a new volume will always start with some used amount of space used depending on the size._
 


### PR DESCRIPTION
Centralizing our pricing so it doesn't become out of date is important, so with this change I swapped hard-coded minutely prices with references.

Perhaps at some point in the future we abstract these pricing blocks to MDX to be more reusable around the docs but that day is not today my friend. :aragorn:

There's quite a sprawl of hard coded references:
```
/src/docs/reference/project-usage.md
/src/docs/reference/volumes.md
/src/docs/reference/backups.md
/src/docs/reference/teams.md
/src/docs/reference/usage-limits.md
/src/docs/reference/support.md
/src/docs/reference/accounts.md
/src/docs/reference/templates.md
/src/docs/railway-metal.md
/src/docs/maturity/compliance.md
/src/docs/maturity/compare-to-vercel.md
/src/docs/maturity/compare-to-render.md
/src/docs/maturity/compare-to-fly.md
/src/docs/maturity/compare-to-digitalocean.md
/public/static/faq.json
```