### PR TITLE
Remove HA docs

### DIFF
--- a/src/docs/guides/mongodb.md
+++ b/src/docs/guides/mongodb.md
@@ -1,21 +1,13 @@
 ---
-title: Deploy MongoDB
-description: Learn how to deploy a MongoDB database on Railway, whether as a standalone instance or a high-availability replica set, for scalability and reliability.
+title: MongoDB
+description: Learn how to deploy a MongoDB database on Railway.
 ---
 
-Railway offers two MongoDB deployment options to accommodate different needs: a **Standalone Instance** and a **High Availability (HA) Replica Set**.
-
-- **Standalone Instance** - a single MongoDB database server that is easy to manage; ideal for development environments, smaller projects, or services that are less sensitive to disruption.
-
-- **High Availability (HA) Replica Set** - intended for production workloads where uptime is critical. It consists of three MongoDB nodes configured as a [replica set](https://www.mongodb.com/docs/manual/replication/).
-
-##  Standalone MongoDB
-
-Let's talk about how to deploy, connect, and manage the standalone instance.
+The Railway MongoDB database template allows you to provision and connect to a MongoDB database with zero configuration.
 
 ## Deploy
 
-You can deploy a standalone MongoDB database via the `CMD + K` menu or by clicking the `+ New` button on the Project Canvas.
+Add a MongoDB database to your project via the `ctrl / cmd + k` menu or by clicking the `+ New` button on the Project Canvas.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1695934218/docs/databases/addDB_qxyctn.gif"
 alt="GIF of the Adding Database"
@@ -26,11 +18,11 @@ You can also deploy it via the [template](https://railway.com/template/mongodb) 
 
 #### Deployed Service
 
-Upon deployment, you will have a standalone MongoDB service running in your project, deployed from the official [mongo](https://hub.docker.com/_/mongo) Docker image.
+Upon deployment, you will have a MongoDB service running in your project, deployed from the official [mongo](https://hub.docker.com/_/mongo) Docker image.
 
 #### Custom Start Command
 
-The MongoDB database service starts with the following [Start Command](/deploy/deployments#start-command) to enable communication over [Private Network](/reference/private-networking): `mongod --ipv6 --bind_ip ::,0.0.0.0`
+The MongoDB database service starts with the following [Start Command](/deploy/deployments#start-command) to enable communication over [Private Network](/reference/private-networking): `mongod --ipv6 --bind_ip ::,0.0.0.0  --setParameter diagnosticDataCollectionEnabled=false`
 
 ## Connect
 
@@ -51,60 +43,6 @@ It is possible to connect to MongoDB externally (from outside of the [project](/
 ### Modify the Deployment
 
 Since the deployed container is pulled from the official [MongoDB](https://hub.docker.com/_/mongo) image in Docker Hub, you can modify the deployment based on the [instructions in Docker Hub](https://hub.docker.com/_/mongo).
-
-## High Availability MongoDB Replica Set
-
-<Banner>
-**Released August 2024** 
-
-Be aware that this template has not been battle-tested like the standalone instance.  We are seeking feedback to improve the experience using this template, please provide your input [here](https://station.railway.com/templates/mongo-replica-set-948643d5).
-</Banner>
-
-We'll cover how to deploy, connect, and manage the [High Availability (HA) MongoDB Replica Set](https://www.mongodb.com/docs/manual/replication/) in this section.
-
-### Deploy
-
-You can deploy a HA MongoDB Replica Set via the [template in the marketplace](https://railway.com/template/ha-mongo).
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723605087/docs/databases/CleanShot_2024-08-13_at_21.10.13_2x_xs9enn.png"
-alt="MongoDB HA in the marketplace"
-layout="responsive"
-width={405} height={396} quality={100} />
-
-#### Deployed Services
-
-Upon deployment, a cluster of 3 MongoDB nodes will be added to your project.  The nodes are deployed from a [custom Dockerfile](https://github.com/railwayapp-templates/mongo-replica-set/tree/main/nodes). The Dockerfile pulls the [mongo Docker image](https://hub.docker.com/_/mongo) and copies a script into the container.  The script is run when the container starts to generate the [keyfile](https://www.mongodb.com/docs/manual/tutorial/deploy-replica-set-with-keyfile-access-control/) for authentication.
-
-An [init service](https://github.com/railwayapp-templates/mongo-replica-set/tree/main/initService) is also deployed alongside the nodes to initiate the replica set once the nodes are up.  It should be deleted post-deploy.
-
-#### Multi-region Deployment
-
-By default, each node is deployed to a different region (US West, US East, and EU West) for fault tolerance.
-
-Since region selection is a Pro-only feature, this only applies to Pro users. If you deploy this template as a Hobby user, all nodes will deploy to US West.
-
-### Connect
-
-To connect to the MongoDB Replica Set, you should construct your MongoDB URI to include all nodes in the set.  Each node exposes a `REPLICA_SET_PRIVATE_URI` environment variable that can be referenced to connect to the cluster.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723762488/docs/databases/CleanShot_2024-08-15_at_16.53.37_udssxa.gif"
-alt="Mongo URI variable"
-layout="responsive"
-width={655} height={396} quality={100} />
-
-For some examples, check out the [example apps](https://github.com/railwayapp-templates/mongo-replica-set/tree/main/exampleApps) within the source repo for the replica set.
-
-#### Connecting Externally
-
-It is possible to connect to the MongoDB Replica Set externally (from outside of the [project](/develop/projects) in which it is deployed) by setting up a tunnel into the private network.
-
-Check out this [tutorial](/tutorials/set-up-a-tailscale-subnet-router) for more information on how to implement a Tailscale subnet router, to tunnel into the private network and connect to the replica set.
-
-### Modify the Deployment
-
-Since the containers deployed are based on the MongoDB image, you can reference the [documentation in Docker hub](https://hub.docker.com/_/mongo) to understand how to customize them using environment variables.
-
-You can also fork the [Mongo Cluster](https://github.com/railwayapp-templates/mongo-replica-set) repository to make changes not supported by environment variables.
 
 ## Backup and Monitoring
 

--- a/src/docs/guides/mysql.md
+++ b/src/docs/guides/mysql.md
@@ -1,21 +1,13 @@
 ---
-title: Deploy MySQL
-description: Learn how to deploy a MySQL database on Railway, whether as a standalone instance or a high-availability cluster, for scalability and reliability.
+title: MySQL
+description: Learn how to deploy a MySQL database on Railway.
 ---
 
-Railway offers two MySQL deployment options to accommodate different needs: a **Standalone Instance** and a **High Availability (HA) Cluster**.
-
-- **Standalone Instance** - a single MySQL database server that is easy to manage; ideal for development environments, smaller projects, or services which are less sensitive to disruption.
-
-- **High Availability (HA) Cluster** - intended for production workloads where uptime is critical. It consists of three MySQL nodes configured as an [InnoDB Cluster](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-innodb-cluster.html) as well as a [MySQL Router](https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general.html) service for connecting to the cluster.
-
-## Standalone MySQL
-
-Let's talk about how to deploy, connect, and manage the standalone instance.
+The Railway MySQL database template allows you to provision and connect to a MySQL database with zero configuration.
 
 ### Deploy
 
-You can deploy a standalone MySQL database via the `CMD + K` menu or by clicking the `+ New` button on the Project Canvas.
+Add a MySQL database to your project via the `ctrl / cmd + k` menu or by clicking the `+ New` button on the Project Canvas.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1695934218/docs/databases/addDB_qxyctn.gif"
 alt="GIF of the Adding Database"
@@ -26,7 +18,7 @@ You can also deploy it via the [template](https://railway.com/template/mysql) fr
 
 #### Deployed Service
 
-Upon deployment, you will have a standalone MySQL service running in your project, deployed directly from the [mysql Docker image](https://hub.docker.com/_/mysql).
+Upon deployment, you will have a MySQL service running in your project, deployed directly from the [mysql Docker image](https://hub.docker.com/_/mysql).
 
 ### Connect
 
@@ -48,75 +40,6 @@ It is possible to connect to MySQL externally (from outside of the [project](/de
 ### Modify the Deployment
 
 Since the deployed container is pulled from the official MySQL image in Docker hub, you can modify the deployment based on the [instructions in Docker hub](https://hub.docker.com/_/mysql).
-
-## High Availability MySQL InnoDB Cluster
-
-<Banner>
-**Released August 2024** 
-
-Be aware that this template has not been battle-tested like the standalone instance.  We are seeking feedback to improve the experience using this template, please provide your input [here](https://station.railway.com/templates/my-sql-inno-db-cluster-6afff85d).
-</Banner>
-
-We'll cover how to deploy, connect, and manage the [High Availability (HA) MySQL InnoDB Cluster](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-innodb-cluster.html) in this section.
-
-### Deploy
-
-You can deploy a HA MySQL InnoDB cluster via the [template in the marketplace](https://railway.com/template/ha-mysql).  
-
-You will need a [Railway API token](/guides/public-api#creating-a-token) to deploy the service.  You will be prompted for your token upon deploying the template.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723603487/docs/databases/mysqlcluster_lumnfh.png"
-alt="MySQL HA in the marketplace"
-layout="responsive"
-width={380} height={396} quality={100} />
-
-#### Deployed Services
-
-Upon deployment, a cluster of 3 MySQL nodes will be added to your project.  The nodes are deployed from a [custom Dockerfile](https://github.com/railwayapp-templates/mysql-cluster/tree/main/nodes).  The Dockerfile pulls the [mysql Docker image](https://hub.docker.com/_/mysql) and copies a `my.cnf` file into each container, configuring the necessary settings to prep the nodes to join the [InnoDB cluster](https://dev.mysql.com/doc/mysql-shell/8.0/en/mysql-innodb-cluster.html).
-
-An [initialization service](https://github.com/railwayapp-templates/mysql-cluster/tree/main/initService) is also deployed, which waits for the nodes to come online before initializing the cluster and joining the nodes.
-
-Lastly, a [MySQL Router](https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general.html) service is also deployed, which serves as a proxy to the cluster. This router is built from the [MySQL Router image](https://hub.docker.com/r/mysql/mysql-router).
-
-#### Multi-region Deployment
-
-By default, each node is deployed to a different region (US West, US East, and EU West) for fault tolerance.
-
-Since region selection is a Pro-only feature, this only applies to Pro users. If you deploy this template as a Hobby user, all nodes will deploy to US West.
-
-### Connect
-
-You should connect to the cluster via a proxy service which is aware of all of the cluster nodes.  We have included a [MySQL Router](https://dev.mysql.com/doc/mysql-router/8.0/en/mysql-router-general.html) service in the template deployment for this purpose.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723760996/docs/databases/CleanShot_2024-08-15_at_16.28.42_miy2og.gif"
-alt="MySQL Router variables"
-layout="responsive"
-width={655} height={396} quality={100} />
-
-Connect to the cluster via the environment variables provided in the MySQL Router:
-
-- `MYSQL_ROUTER_HOST`
-- `MYSQL_ROUTER_PORT`
-- `MYSQL_USER`
-- `MYSQL_PASSWORD`
-- `MYSQL_DB`
-
-For an example, check out the [example app](https://github.com/railwayapp-templates/mysql-cluster/blob/main/exampleApps/python/main.py#L19) in the template's source repo.
-
-#### Connecting Externally
-
-It is possible to connect to the MySQL cluster externally (from outside of the [project](/develop/projects) in which it is deployed), by using the [TCP Proxy](/deploy/exposing-your-app#tcp-proxying).
-
-*Keep in mind that you will be billed for [Network Egress](/reference/pricing/plans#resource-usage-pricing) when using the TCP Proxy.*
-
-### Modify the Deployment
-
-Since the containers deployed are based on MySQL images in Docker hub, you can reference the documentation for each, to understand how to customize them using environment variables.
-
-- [MySQL](https://hub.docker.com/_/mysql)
-- [MySQL Router](https://hub.docker.com/r/mysql/mysql-router)
-
-We also encourage you to fork the [MySQL Cluster](https://github.com/railwayapp-templates/mysql-cluster/tree/main) repository to make changes not supported by environment variables.
 
 ## Backups and Observability
 

--- a/src/docs/guides/postgresql.md
+++ b/src/docs/guides/postgresql.md
@@ -1,21 +1,13 @@
 ---
-title: Deploy PostgreSQL
-description: Learn how to deploy a PostgreSQL database on Railway, whether as a standalone instance or a high-availability cluster, for scalability and reliability.
+title: PostgreSQL
+description: Learn how to deploy a PostgreSQL database on Railway.
 ---
 
-Railway offers two PostgreSQL deployment options to accommodate different needs: a **Standalone Instance** and a **High Availability (HA) Cluster**.
+The Railway PostgreSQL database template allows you to provision and connect to a PostgreSQL database with zero configuration.
 
-- **Standalone Instance** - a single Postgres database server that is easy to manage; ideal for development environments, smaller projects, or services which are less sensitive to disruption.
+## Deploy
 
-- **High Availability (HA) Cluster** - intended for production workloads where uptime is critical.  It consists of three Postgres nodes in replication mode managed by [Repmgr](https://www.repmgr.org/docs/current/getting-started.html), complemented by a [Pgpool-II](https://www.pgpool.net/mediawiki/index.php/Main_Page) proxy service.
-
-## Standalone PostgreSQL
-
-Let's talk about how to deploy, connect, and manage the standalone instance.
-
-### Deploy
-
-You can deploy a standalone PostgreSQL database via the `CMD + K` menu or by clicking the `+ New` button on the Project Canvas.
+Add a PostgreSQL database to your project via the `ctrl / cmd + k` menu or by clicking the `+ New` button on the Project Canvas.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1695934218/docs/databases/addDB_qxyctn.gif"
 alt="GIF of the Adding Database"
@@ -26,7 +18,7 @@ You can also deploy it via the [template](https://railway.com/template/postgres)
 
 #### Deployed Service
 
-Upon deployment, you will have a standalone PostgreSQL service running in your project, deployed from Railway's [SSL-enabled Postgres image](https://github.com/railwayapp-templates/postgres-ssl/pkgs/container/postgres-ssl), which uses the official [postgres](https://hub.docker.com/_/postgres) image in Docker Hub as its base.
+Upon deployment, you will have a PostgreSQL service running in your project, deployed from Railway's [SSL-enabled Postgres image](https://github.com/railwayapp-templates/postgres-ssl/pkgs/container/postgres-ssl), which uses the official [Postgres](https://hub.docker.com/_/postgres) image from Docker Hub as its base.
 
 ### Connect
 
@@ -53,60 +45,6 @@ It is possible to connect to PostgreSQL externally (from outside of the [project
 Since the deployed container is based on an image built from the official [PostgreSQL](https://hub.docker.com/_/postgres) image in Docker hub, you can modify the deployment based on the [instructions in Docker hub](https://hub.docker.com/_/postgres#:~:text=How%20to%20extend%20this%20image).
 
 We also encourage you to fork the [Railway postgres-ssl repository](https://github.com/railwayapp-templates/postgres-ssl) to customize it to your needs, or feel free to open a PR in the repo!
-
-## High Availability PostgreSQL Cluster
-
-<Banner>
-**Released August 2024** 
-
-Be aware that this template has not been battle-tested like the standalone instance.  We are seeking feedback to improve the experience using this template, please provide your input [here](https://station.railway.com/templates/postgre-sql-ha-with-repmgr-33c997a9).
-</Banner>
-
-We'll cover how to deploy, connect, and manage the [High Availability (HA) PostgreSQL](https://www.postgresql.org/docs/current/high-availability.html) cluster in this section.
-
-### Deploy
-
-You can deploy a HA PostgreSQL cluster via the [template in the marketplace](https://railway.com/template/ha-postgres).
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723589926/docs/databases/postgrescluster_ac7vld.png"
-alt="PostgreSQL HA in the marketplace"
-layout="responsive"
-width={405} height={396} quality={100} />
-
-#### Deployed Services
-
-Upon deployment, you will have a cluster of 3 PostgreSQL nodes deployed from the [bitnami/postgres-repmgr](https://hub.docker.com/r/bitnami/postgresql-repmgr) image, running in [replication mode](https://www.postgresql.org/docs/16/high-availability.html) and managed by [repmgr](https://www.repmgr.org/).
-
-You will also have a [Pgpool-II](https://www.pgpool.net/docs/latest/en/html/) service deployed from the [bitnami/pgpool](https://hub.docker.com/r/bitnami/pgpool) image which is intended to be used as a proxy to the cluster.
-
-#### Multi-region Deployment
-
-By default, each node is deployed to a different region (US West, US East, and EU West) for fault tolerance.
-
-Since region selection is a Pro-only feature, this only applies to Pro users.  If you deploy this template as a Hobby user, all nodes will deploy to US West.
-
-### Connect
-
-You should connect to the cluster via a proxy service which is aware of all of the cluster nodes.  We have included a [Pgpool-II](https://www.pgpool.net/docs/latest/en/html/) service in the template deployment for this purpose.
-
-Connect to the cluster via Pgpool by [referencing the environment variable](/guides/variables#referencing-another-services-variable) `DATABASE_URL` available in the Pgpool service.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723755568/docs/databases/CleanShot_2024-08-15_at_14.58.11_yyzinw.gif"
-alt="Pgpool variables"
-layout="responsive"
-width={655} height={396} quality={100} />
-
-#### Connecting Externally
-
-It is possible to connect to the PostgreSQL cluster externally (from outside of the [project](/develop/projects) in which it is deployed), by using the [TCP Proxy](/deploy/exposing-your-app#tcp-proxying).  To do so, you should reference the `DATABASE_PUBLIC_URL` environment variable available in the Pgpool service.
-
-*Keep in mind that you will be billed for [Network Egress](/reference/pricing/plans#resource-usage-pricing) when using the TCP Proxy.*
-
-### Modify the Deployment
-
-Since the containers are deployed from bitnami images, you can reference the documentation for each, to understand how to customize them:
-- [bitnami/postgres-repmgr](https://github.com/bitnami/containers/blob/main/bitnami/postgresql-repmgr/README.md#environment-variables)
-- [bitnami/pgpool](https://github.com/bitnami/containers/blob/main/bitnami/pgpool/README.md#environment-variables)
 
 ## Backups and Observability
 

--- a/src/docs/guides/redis.md
+++ b/src/docs/guides/redis.md
@@ -1,21 +1,13 @@
 ---
-title: Deploy Redis
-description: Learn how to deploy a Redis database on Railway, whether as a standalone instance or a high-availability cluster, for scalability and reliability.
+title: Redis
+description: Learn how to deploy a Redis database on Railway.
 ---
 
-Railway offers two Redis deployment options to accommodate different needs: a **Standalone Instance** and a **High Availability (HA) Cluster**.
+The Railway Redis database template allows you to provision and connect to a Redis database with zero configuration.
 
-- **Standalone Instance** - a single Redis server that is easy to manage; ideal for development environments, smaller projects, or services that are less sensitive to disruption.
+## Deploy
 
-- **High Availability (HA) Cluster** - intended for production workloads where uptime is critical. It consists of three Redis nodes in [replication mode](https://redis.io/docs/latest/operate/oss_and_stack/management/replication/), complemented by three [Sentinel services](https://redis.io/learn/operate/redis-at-scale/high-availability/understanding-sentinels) for automatic failover.
-
-## Standalone Redis
-
-Let's talk about how to deploy, connect, and manage the standalone instance.
-
-### Deploy
-
-You can deploy a standalone Redis database via the `CMD + K` menu or by clicking the `+ New` button on the Project Canvas.
+Add a Redis database to your project via the `ctrl / cmd + k` menu or by clicking the `+ New` button on the Project Canvas.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1695934218/docs/databases/addDB_qxyctn.gif"
 alt="GIF of the Adding Database"
@@ -26,7 +18,7 @@ You can also deploy it via the [template](https://railway.com/template/redis) fr
 
 #### Deployed Service
 
-Upon deployment, you will have a standalone Redis service running in your project, deployed from the [bitnami/redis](https://hub.docker.com/r/bitnami/redis) Docker image.
+Upon deployment, you will have a Redis service running in your project, deployed from the [bitnami/redis](https://hub.docker.com/r/bitnami/redis) Docker image.
 
 ### Connect
 
@@ -47,61 +39,6 @@ It is possible to connect to Redis externally (from outside of the [project](/de
 ### Modify the Deployment
 
 Since the deployed container is pulled from the [bitnami Redis](https://hub.docker.com/r/bitnami/redis) image in Docker Hub, you can modify the deployment based on the [instructions in Docker Hub](https://hub.docker.com/r/bitnami/redis).
-
-## High Availability Redis Cluster
-
-<Banner>
-**Released August 2024** 
-
-Be aware that this template has not been battle-tested like the standalone instance.  We are seeking feedback to improve the experience using this template, please provide your input [here](https://station.railway.com/templates/redis-ha-with-sentinel-4c4c487d).
-</Banner>
-
-We'll cover how to deploy, connect, and manage the [High Availability (HA) Redis Cluster](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) in this section.
-
-### Deploy
-
-You can deploy a HA Redis Cluster via the [template in the marketplace](https://railway.com/template/ha-redis).
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723667697/docs/databases/rediscluster_x6zzwd.png"
-alt="Redis HA in the marketplace"
-layout="responsive"
-width={376} height={396} quality={100} />
-
-#### Deployed Services
-
-Upon deployment, you will have a cluster of 3 Redis nodes deployed from the [bitnami/redis](https://hub.docker.com/r/bitnami/redis) image, running in replication mode. 
-
-Additionally, 3 Sentinel nodes will be deployed from the [bitnami/redis-sentinel](https://hub.docker.com/r/bitnami/redis-sentinel) image to manage failover.
-
-#### Multi-region Deployment
-
-By default, each node is deployed to a different region (US West, US East, and EU West) for fault tolerance.
-
-Since region selection is a Pro-only feature, this only applies to Pro users. If you deploy this template as a Hobby user, all nodes will deploy to US West.
-
-### Connect
-
-To connect to the Redis cluster, you should connect via the Sentinel services using the environment variables available in the Sentinel services.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1723761949/docs/databases/CleanShot_2024-08-15_at_16.43.46_ngja7a.gif"
-alt="Sentinel variables"
-layout="responsive"
-width={655} height={396} quality={100} />
-
-The exact method to configure your client will depend on the client library you are using.  As an example, a Node.js server using `ioredis` can be found here [here](https://github.com/railwayapp-templates/redis-ha-sentinel/blob/main/exampleApps/node/server.js#L4).
-
-#### Connecting Externally
-
-It is possible to connect to the Redis cluster externally (from outside of the [project](/develop/projects) in which it is deployed) by using the [TCP Proxy](/deploy/exposing-your-app#tcp-proxying).
-
-*Keep in mind that you will be billed for [Network Egress](/reference/pricing/plans#resource-usage-pricing) when using the TCP Proxy.*
-
-### Modify the Deployment
-
-Since the deployed containers are based on the `bitnami/redis` and `bitnami/redis-sentinel` images, you can refer to the documentation for each to understand how to customize them:
-- [bitnami/redis](https://hub.docker.com/r/bitnami/redis)
-- [bitnami/redis-sentinel](https://hub.docker.com/r/bitnami/redis-sentinel)
-- [Redis Official Documentation](https://redis.io/documentation)
 
 ## Backup and Monitoring
 


### PR DESCRIPTION
We no longer publish the templates, so we are also removing our documentation on them.