### PR TITLE
Add best practices section to template index page

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -4,7 +4,13 @@ import { slugify } from "@/utils/slugify";
 const makePage = (title: string, category?: string, slug?: string): IPage => ({
   title,
   category,
-  slug: slug ?? `/${category != null ? category + "/" : ""}` + slugify(title),
+  slug: (() => {
+    if (slug) {
+      return slug.startsWith('/') ? slug : '/' + slug;
+    }
+
+    return '/' + (category ? category + '/' : '') + slugify(title);
+  })(),
 });
 
 export const sidebarContent: ISidebarContent = [

--- a/src/docs/guides/templates.md
+++ b/src/docs/guides/templates.md
@@ -10,9 +10,10 @@ Templates provide a way to jumpstart a project by giving users the means to pack
 #### Highlights
 |||
 |-|-|
-| **Bootstrap Projects** | Templates are the best way to bootstrap a project by enabling you to provision a service or set of services in a matter of clicks.  Choose a template to deploy from the marketplace, or create your own from your personal scaffold.                                                                                   |
+| **Bootstrap Projects** | Templates are the best way to bootstrap a project by enabling you to provision a service or set of services in a matter of clicks.  Choose a template to deploy from the marketplace, or create your own from your personal scaffold. |
+| **Best Practices** | Creating templates can get complex, but these best practices will help you create templates that are easy to use and maintain. |
 | **Community Clout** | When you publish a template, it is placed into our template marketplace for all users of the Railway community to take advantage. |
-| [**Kickback Program**](/reference/templates#kickback-program) | Usage incurred by deployed templates from the marketplace are automatically eligible for a 50% kickback of the usage. In short, get paid for building templates!                                                                                                            |
+| [**Kickback Program**](/reference/templates#kickback-program) | Usage incurred by deployed templates from the marketplace are automatically eligible for a 50% kickback of the usage. In short, get paid for building templates! |
 |||
 
 Excited about templates?  Dig into the next pages to learn how to create, publish, and deploy them.


### PR DESCRIPTION
- Add the best practices link to the template index page.
- Simplify the slug logic.