### PR TITLE
Update faqs.md to include info on how to remove your payment method

### DIFF
--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -86,7 +86,7 @@ If you are on the Hobby plan and using prepaid credits as your payment method, y
 If your subscription is canceled and you have no pending invoices, you can remove your saved payment method by doing the following:
 
 1. Go to the [billing page](https://railway.com/workspace/billing) for your workspace
-2. Click the "Delete" in the payment method section
+2. Click "Delete" in the payment method section
 
 ### How do I switch to the auto-renewing Hobby plan billing model?
 

--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -86,7 +86,7 @@ If you are on the Hobby plan and using prepaid credits as your payment method, y
 If your subscription is canceled and you have no pending invoices, you can remove your saved payment method by doing the following:
 
 1. Go to the [billing page](https://railway.com/workspace/billing) for your workspace
-2. Click the "Delete" in the Payment Method section
+2. Click the "Delete" in the payment method section
 
 ### How do I switch to the auto-renewing Hobby plan billing model?
 

--- a/src/docs/reference/pricing/faqs.md
+++ b/src/docs/reference/pricing/faqs.md
@@ -81,6 +81,13 @@ When you cancel your subscription, if you're on Hobby, Pro, or Enterprise, your 
 
 If you are on the Hobby plan and using prepaid credits as your payment method, your subscription will be canceled immediately and any credit balance you may have will be forfeited.
 
+### How do I remove my saved payment method from my account?
+
+If your subscription is canceled and you have no pending invoices, you can remove your saved payment method by doing the following:
+
+1. Go to the [billing page](https://railway.com/workspace/billing) for your workspace
+2. Click the "Delete" in the Payment Method section
+
 ### How do I switch to the auto-renewing Hobby plan billing model?
 
 At this time, we do not directly support switching from a prepaid credit-based plan to an auto-renewing subscription.


### PR DESCRIPTION
# Why

We just shipped a way for users to remove their saved payment method when they are no longer a subscriber + have no pending invoices, but we haven't documented it 

# What changed

- Added faq to pricing