### PR TITLE
Compare to vercel --> railway vs vercel

### DIFF
--- a/src/docs/maturity/compare-to-vercel.md
+++ b/src/docs/maturity/compare-to-vercel.md
@@ -1,5 +1,5 @@
 ---
-title: Compare to Vercel
+title: Railway vs. Vercel
 description: Looking for the best deployment platform? This guide breaks down Railway vs. Vercel, covering scalability, pricing, features, and why Railway is the superior choice.
 ---
 


### PR DESCRIPTION
All our other "compare to" pages actually have a title of "railway vs. ___". The vs is optimized for SEO, the "compare to" is not because it doesn't contain our brand name. Updating vercel.