### PR TITLE
Closes PRO-4405: add docs page for deployment teardown settings

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -6,10 +6,10 @@ const makePage = (title: string, category?: string, slug?: string): IPage => ({
   category,
   slug: (() => {
     if (slug) {
-      return slug.startsWith('/') ? slug : '/' + slug;
+      return slug.startsWith("/") ? slug : "/" + slug;
     }
 
-    return '/' + (category ? category + '/' : '') + slugify(title);
+    return "/" + (category ? category + "/" : "") + slugify(title);
   })(),
 });
 
@@ -104,6 +104,7 @@ export const sidebarContent: ISidebarContent = [
           makePage("Optimize Performance", "guides"),
           makePage("Healthchecks", "guides"),
           makePage("Restart Policy", "guides"),
+          makePage("Deployment Teardown", "guides"),
           makePage("Monorepo", "guides"),
           makePage("Cron Jobs", "guides"),
           makePage("Optimize Usage", "guides"),
@@ -133,7 +134,11 @@ export const sidebarContent: ISidebarContent = [
         subTitle: makePage("Templates", "guides"),
         pages: [
           makePage("Create", "guides"),
-          makePage("Best Practices", "guides", "/guides/templates-best-practices"),
+          makePage(
+            "Best Practices",
+            "guides",
+            "/guides/templates-best-practices",
+          ),
           makePage("Publish and Share", "guides"),
           makePage("Deploy", "guides"),
         ],
@@ -203,9 +208,21 @@ export const sidebarContent: ISidebarContent = [
             title: "Deploy with Railway",
             url: "https://blog.railway.com/p/github-actions",
           },
-          makePage("Post-Deploy", "tutorials", "tutorials/github-actions-post-deploy"),
-          makePage("PR Environment", "tutorials", "tutorials/github-actions-pr-environment"),
-          makePage("Self Hosted Runners", "tutorials", "tutorials/github-actions-runners"),
+          makePage(
+            "Post-Deploy",
+            "tutorials",
+            "tutorials/github-actions-post-deploy",
+          ),
+          makePage(
+            "PR Environment",
+            "tutorials",
+            "tutorials/github-actions-pr-environment",
+          ),
+          makePage(
+            "Self Hosted Runners",
+            "tutorials",
+            "tutorials/github-actions-runners",
+          ),
           {
             title: "Implementing a Testing Suite",
             url: "https://blog.railway.com/p/implementing-gh-actions-testing",
@@ -218,7 +235,7 @@ export const sidebarContent: ISidebarContent = [
           {
             title: "Gitlab CI/CD with Railway",
             url: "https://blog.railway.com/p/gitlab-ci-cd",
-          }
+          },
         ],
       },
     ],

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -104,6 +104,7 @@ export const sidebarContent: ISidebarContent = [
           makePage("Optimize Performance", "guides"),
           makePage("Healthchecks", "guides"),
           makePage("Restart Policy", "guides"),
+          makePage("Deployment Teardown", "guides"),
           makePage("Monorepo", "guides"),
           makePage("Cron Jobs", "guides"),
           makePage("Optimize Usage", "guides"),

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -6,10 +6,10 @@ const makePage = (title: string, category?: string, slug?: string): IPage => ({
   category,
   slug: (() => {
     if (slug) {
-      return slug.startsWith("/") ? slug : "/" + slug;
+      return slug.startsWith('/') ? slug : '/' + slug;
     }
 
-    return "/" + (category ? category + "/" : "") + slugify(title);
+    return '/' + (category ? category + '/' : '') + slugify(title);
   })(),
 });
 
@@ -104,7 +104,6 @@ export const sidebarContent: ISidebarContent = [
           makePage("Optimize Performance", "guides"),
           makePage("Healthchecks", "guides"),
           makePage("Restart Policy", "guides"),
-          makePage("Deployment Teardown", "guides"),
           makePage("Monorepo", "guides"),
           makePage("Cron Jobs", "guides"),
           makePage("Optimize Usage", "guides"),
@@ -134,11 +133,7 @@ export const sidebarContent: ISidebarContent = [
         subTitle: makePage("Templates", "guides"),
         pages: [
           makePage("Create", "guides"),
-          makePage(
-            "Best Practices",
-            "guides",
-            "/guides/templates-best-practices",
-          ),
+          makePage("Best Practices", "guides", "/guides/templates-best-practices"),
           makePage("Publish and Share", "guides"),
           makePage("Deploy", "guides"),
         ],
@@ -208,21 +203,9 @@ export const sidebarContent: ISidebarContent = [
             title: "Deploy with Railway",
             url: "https://blog.railway.com/p/github-actions",
           },
-          makePage(
-            "Post-Deploy",
-            "tutorials",
-            "tutorials/github-actions-post-deploy",
-          ),
-          makePage(
-            "PR Environment",
-            "tutorials",
-            "tutorials/github-actions-pr-environment",
-          ),
-          makePage(
-            "Self Hosted Runners",
-            "tutorials",
-            "tutorials/github-actions-runners",
-          ),
+          makePage("Post-Deploy", "tutorials", "tutorials/github-actions-post-deploy"),
+          makePage("PR Environment", "tutorials", "tutorials/github-actions-pr-environment"),
+          makePage("Self Hosted Runners", "tutorials", "tutorials/github-actions-runners"),
           {
             title: "Implementing a Testing Suite",
             url: "https://blog.railway.com/p/implementing-gh-actions-testing",
@@ -235,7 +218,7 @@ export const sidebarContent: ISidebarContent = [
           {
             title: "Gitlab CI/CD with Railway",
             url: "https://blog.railway.com/p/gitlab-ci-cd",
-          },
+          }
         ],
       },
     ],

--- a/src/docs/guides/deployment-teardown.md
+++ b/src/docs/guides/deployment-teardown.md
@@ -12,10 +12,10 @@ To learn more about the full deployment lifecycle, see the [deploy reference](/r
 Once the new deployment is active, the previous deployment remains active for a configurable amount of time. You can control this via the "Settings" pane for the service:
 
 <Image
-src="https://res.cloudinary.com/railway/image/upload/v1749845308/docs/deployment-teardown-guide/f3iyxld1rqrxxgay0bot.png"
+src="https://res.cloudinary.com/railway/image/upload/v1750178677/docs/deployment-teardown-guide/s5pqob0j8nreoojbo6dj.png"
 alt="Screenshot of a teardown settings"
 layout="responsive"
-width={640} height={403} quality={80}/>
+width={642} height={324} quality={80}/>
 
 It can also be configured via [code](/reference/config-as-code#overlap-seconds) or the [`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
 

--- a/src/docs/guides/deployment-teardown.md
+++ b/src/docs/guides/deployment-teardown.md
@@ -3,13 +3,7 @@ title: Deployment Teardown
 description: Learn how to configure the deployment lifecycle to create graceful deploys with zero downtime.
 ---
 
-By default, Railway maintains only one deploy per service. This means that if you trigger a new deploy, the previous version will be stopped and removed after the new version deploys. There are two configuration options that allow you to slightly overlap the new and preview versions for zero downtime.
-
-To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deploy).
-
-#### Overlap Time
-
-Once the new deployment is active, the previous deployment remains active for a configurable amount of time. You can control this via the "Settings" pane for the service:
+By default, Railway maintains only one deploy per service. This means that if you trigger a new deploy, the previous version will be stopped and removed after the new version deploys. There are two configuration options in the "Settings" pane for a service that allow you to slightly overlap the new and preview versions for zero downtime:
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1750178677/docs/deployment-teardown-guide/s5pqob0j8nreoojbo6dj.png"
@@ -17,10 +11,12 @@ alt="Screenshot of a teardown settings"
 layout="responsive"
 width={642} height={324} quality={80}/>
 
-It can also be configured via [code](/reference/config-as-code#overlap-seconds) or the [`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
+To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deploy).
+
+#### Overlap Time
+
+Once the new deployment is active, the previous deployment remains active for a configurable amount of time. You can control this via the "Settings" pane for the service. It can also be configured via [code](/reference/config-as-code#overlap-seconds) or the [`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
 
 #### Draining Time
 
-Once the new deployment is active, the previous deployment is sent a SIGTERM signal and given time to gracefully shutdown before being forcefully stopped with a SIGKILL. The time to gracefully shutdown can be controlled via the "Settings" pane.
-
-It can also be configured via [code](/reference/config-as-code#draining-seconds) or the [`RAILWAY_DEPLOYMENT_DRAINING_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
+Once the new deployment is active, the previous deployment is sent a SIGTERM signal and given time to gracefully shutdown before being forcefully stopped with a SIGKILL. The time to gracefully shutdown can be controlled via the "Settings" pane. It can also be configured via [code](/reference/config-as-code#draining-seconds) or the [`RAILWAY_DEPLOYMENT_DRAINING_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).

--- a/src/docs/guides/deployment-teardown.md
+++ b/src/docs/guides/deployment-teardown.md
@@ -3,7 +3,7 @@ title: Deployment Teardown
 description: Learn how to configure the deployment lifecycle to create graceful deploys with zero downtime.
 ---
 
-By default, Railway maintains only one deploy per service. This means that if you trigger a new deploy, the previous version will be stopped and removed after the new version depoys. There are two configuration options that allow you to slightly overlap the new and preview versions for zero downtime.
+By default, Railway maintains only one deploy per service. This means that if you trigger a new deploy, the previous version will be stopped and removed after the new version deploys. There are two configuration options that allow you to slightly overlap the new and preview versions for zero downtime.
 
 To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deploy).
 
@@ -17,10 +17,10 @@ alt="Screenshot of a teardown settings"
 layout="responsive"
 width={640} height={403} quality={80}/>
 
-It can also be configured via [code](/reference/config-as-code#overlap-seconds) or [a `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
+It can also be configured via [code](/reference/config-as-code#overlap-seconds) or the [`RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
 
 #### Draining Time
 
 Once the new deployment is active, the previous deployment is sent a SIGTERM signal and given time to gracefully shutdown before being forcefully stopped with a SIGKILL. The time to gracefully shutdown can be controlled via the "Settings" pane.
 
-It can also be configured via [code](/reference/config-as-code#draining-seconds) or [a `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
+It can also be configured via [code](/reference/config-as-code#draining-seconds) or the [`RAILWAY_DEPLOYMENT_DRAINING_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).

--- a/src/docs/guides/deployment-teardown.md
+++ b/src/docs/guides/deployment-teardown.md
@@ -11,7 +11,7 @@ alt="Screenshot of a teardown settings"
 layout="responsive"
 width={642} height={324} quality={80}/>
 
-To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deploy).
+To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deployments).
 
 #### Overlap Time
 

--- a/src/docs/guides/deployment-teardown.md
+++ b/src/docs/guides/deployment-teardown.md
@@ -1,0 +1,26 @@
+---
+title: Deployment Teardown
+description: Learn how to configure the deployment lifecycle to create graceful deploys with zero downtime.
+---
+
+By default, Railway maintains only one deploy per service. This means that if you trigger a new deploy, the previous version will be stopped and removed after the new version depoys. There are two configuration options that allow you to slightly overlap the new and preview versions for zero downtime.
+
+To learn more about the full deployment lifecycle, see the [deploy reference](/reference/deploy).
+
+#### Overlap Time
+
+Once the new deployment is active, the previous deployment remains active for a configurable amount of time. You can control this via the "Settings" pane for the service:
+
+<Image
+src="https://res.cloudinary.com/railway/image/upload/v1749845308/docs/deployment-teardown-guide/f3iyxld1rqrxxgay0bot.png"
+alt="Screenshot of a teardown settings"
+layout="responsive"
+width={640} height={403} quality={80}/>
+
+It can also be configured via [code](/reference/config-as-code#overlap-seconds) or [a `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).
+
+#### Draining Time
+
+Once the new deployment is active, the previous deployment is sent a SIGTERM signal and given time to gracefully shutdown before being forcefully stopped with a SIGKILL. The time to gracefully shutdown can be controlled via the "Settings" pane.
+
+It can also be configured via [code](/reference/config-as-code#draining-seconds) or [a `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` service variable](/reference/variables#user-provided-configuration-variables).


### PR DESCRIPTION
# Why

https://github.com/railwayapp/mono/pull/17978 exposes RAILWAY_DEPLOYMENT_OVERLAP_SECONDS and RAILWAY_DEPLOYMENT_DRAINING_SECONDS as config options in the service settings UI. This PR updates the docs to have a page we can point to about these settings.

# What Changed

- add page
- register it in sidebar

# Test Plan

- docs read ✅ 

^ note, still ironing out the UI we want in the linked PR, so this docs PR won't be final until that change is finalized and merged