### PR TITLE
docs: update config-as-code.md

### DIFF
--- a/src/docs/guides/config-as-code.md
+++ b/src/docs/guides/config-as-code.md
@@ -46,7 +46,7 @@ For example, these configuration definitions are equivalent:
         {
           "$schema": "https://railway.com/railway.schema.json",
           "build": {
-            "builder": "nixpacks",
+            "builder": "NIXPACKS",
             "buildCommand": "echo building!"
             },
           "deploy": {


### PR DESCRIPTION
- according to the docs, `nixpacks` should be capitalized
https://docs.railway.com/reference/config-as-code#specify-the-builder