### PR TITLE
Fixing affiliate image ratio

### DIFF
--- a/src/docs/community/affiliate-program.md
+++ b/src/docs/community/affiliate-program.md
@@ -9,7 +9,7 @@ Railway's Affiliate Program is meant for creators to share the power of Railway 
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1631917786/docs/referrals_cash_ashj73.png"
 alt="Screenshot of Referrals Page"
-layout="responsive"
+layout="intrinsic"
 width={1141} height={604} quality={80} />
 
 Follow these steps to start earning:

--- a/src/docs/community/affiliate-program.md
+++ b/src/docs/community/affiliate-program.md
@@ -10,7 +10,7 @@ Railway's Affiliate Program is meant for creators to share the power of Railway 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1631917786/docs/referrals_cash_ashj73.png"
 alt="Screenshot of Referrals Page"
 layout="intrinsic"
-width={1141} height={604} quality={80} />
+width={1784} height={1104} quality={80} />
 
 Follow these steps to start earning:
 


### PR DESCRIPTION
On the affiliate page, the image is stretched - don't stretch it.