### PR TITLE
Update Slack Connect channel gating

### DIFF
--- a/src/docs/maturity/compare-to-vercel.md
+++ b/src/docs/maturity/compare-to-vercel.md
@@ -125,7 +125,7 @@ We offer incredibly fast and personalized support on Slack, and the [Central Sta
 
 Our Central Station is built in house from the ground up to allow us to provide the best possible support to you, the user.
 
-Pro and enterprise users get priority support within Slack, and entrpise can also book a call with our team to get direct help from the Railway team.
+Enterprise users with $2,000/month committed spend get priority support within Slack, and enterprise can also book a call with our team to get direct help from the Railway team.
 
 ## Ready to Switch?
 

--- a/src/docs/reference/metal-upgrade.md
+++ b/src/docs/reference/metal-upgrade.md
@@ -88,7 +88,7 @@ For example, if your application in US West (California) Railway Metal region co
 If you need assistance with your Railway Metal upgrade:
 
 - Submit feedback through our [Central Station](https://station.railway.com/feedback/feedback-railway-metal-a41f03a1)
-- Pro and Enterprise customers can reach out via [Slack](/reference/support#slack)
+- Enterprise customers with $2,000/month committed spend can reach out via [Slack](/reference/support#slack)
 - See our [FAQ on Railway Metal](/railway-metal#faq) for answers to common questions
 
 Remember, this is a free upgrade for all users and is designed to provide an improved experience across all aspects of the Railway platform.

--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -106,6 +106,7 @@ For example, customers who commit to a $10,000/month spend rate can access dedic
 | **RBAC**                                                        | $500/month       | Role-Based Access Control to manage user permissions and access.                                                                   |
 | [**Business Class Support**](/reference/support#business-class) | $500/month       | Improved support SLOs and response times. [Contact us](mailto:team@railway.com?subject=Business%20Class%20Support) to get started. |
 | **HIPAA BAAs**                                                  | $1,000/month     | HIPAA Business Associate Agreements for compliant health data handling. Requires a year commitment paid monthly.                   |
+| **Slack Connect channels**                                       | $2,000/month     | Dedicated Slack Connect channels for enhanced communication and support with Railway team.                                         |
 | **SLOs**                                                        | $2,000/month     | Service Level Objectives to ensure and track application performance.                                                              |
 | **Dedicated Hosts**                                             | $10,000/month    | Custom dedicated infrastructure for enhanced performance and control.                                                              |
 

--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -106,7 +106,7 @@ For example, customers who commit to a $10,000/month spend rate can access dedic
 | **RBAC**                                                        | $500/month       | Role-Based Access Control to manage user permissions and access.                                                                   |
 | [**Business Class Support**](/reference/support#business-class) | $500/month       | Improved support SLOs and response times. [Contact us](mailto:team@railway.com?subject=Business%20Class%20Support) to get started. |
 | **HIPAA BAAs**                                                  | $1,000/month     | HIPAA Business Associate Agreements for compliant health data handling. Requires a year commitment paid monthly.                   |
-| **Slack Connect channels**                                       | $2,000/month     | Dedicated Slack Connect channels for enhanced communication and support with Railway team.                                         |
+| **Slack Connect channels**                                       | $2,000/month     | Dedicated Slack Connect channels for enhanced communication and support with the Railway team.                                     |
 | **SLOs**                                                        | $2,000/month     | Service Level Objectives to ensure and track application performance.                                                              |
 | **Dedicated Hosts**                                             | $10,000/month    | Custom dedicated infrastructure for enhanced performance and control.                                                              |
 

--- a/src/docs/reference/support.md
+++ b/src/docs/reference/support.md
@@ -77,7 +77,9 @@ Please ask your questions in the <a href="https://discord.com/channels/713503345
 
 ## Slack
 
-Railway offers Slack channels to companies and prospective customers. Customers can raise issues, coordinate their migration over to Railway, and provide feedback within a Slack Connect channel.
+Railway offers Slack Connect channels to Enterprise plan customers with a minimum committed spend of $2,000/month. Customers can raise issues, coordinate their migration over to Railway, and provide feedback within a Slack Connect channel.
+
+Additionally, the solutions team at Railway may provide a shared Slack Connect channel to facilitate better communication and support.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1733324712/docs/cs-2024-12-04-22.20_bms1sa.png"
@@ -85,7 +87,7 @@ alt="Screenshot of Slack"
 layout="intrinsic"
 width={571} height={743} quality={100} />
 
-All teams can create a Slack channel within the Team settings page:
+Enterprise teams with $2,000/month committed spend can create a Slack Connect channel within the Team settings page:
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1733324438/docs/cs-2024-12-04-23.00_uvchnr.png"

--- a/src/docs/reference/support.md
+++ b/src/docs/reference/support.md
@@ -15,7 +15,7 @@ Trial & Hobby plan users are only eligible for community support over [Central S
 
 ### Pro & Business Class
 
-Pro & [Business Class](#business-class) customers can select the urgency of their request when creating a new thread in [Central Station](#help-station) or [Slack](#slack).
+Pro & [Business Class](#business-class) customers can select the urgency of their request when creating a new thread in [Central Station](#help-station). Enterprise customers with $2,000/month committed spend can also use [Slack](#slack).
 
 | Level    | Description                                                                | Eligibility                       |
 | -------- | -------------------------------------------------------------------------- | --------------------------------- |
@@ -134,7 +134,7 @@ We prioritize Business Class customers over all other support requests.
 | P2 (Bugs)                            | Same Business Day    |
 | P3 (Integrations, General Questions) | Two Business Days    |
 
-For Business Class customers with a shared Slack Connect channel with us, you have access to
+For Enterprise customers with $2,000/month committed spend who have a shared Slack Connect channel with us, you have access to
 "Critical" urgency level support requests:
 
 <Image

--- a/src/docs/reference/volumes.md
+++ b/src/docs/reference/volumes.md
@@ -21,7 +21,7 @@ Volumes can be "Grown" after upgrading to a different plan.
 
 Pro users and above can self-serve to increase their volume up to 250 GB.
 
-For Pro and above users, please reach out to us on our [Central Station](https://station.railway.com/questions) or [Slack](/reference/support#slack) if you need more then 250GB.
+For Pro and above users, please reach out to us on our [Central Station](https://station.railway.com/questions) if you need more then 250GB. Enterprise users with $2,000/month committed spend can also use [Slack](/reference/support#slack).
 
 ## Pricing
 


### PR DESCRIPTION
Enterprise plans now state that they require committed spend as per our pricing page. 

- Updated support documentation to specify Slack Connect channels are now gated to Enterprise plan customers with minimum 2,000/month committed spend
- Added note about solutions team potentially providing channels
- Added Slack Connect channels to committed spend tiers table at 2,000/month level
- Updated language from 'All teams' to 'Enterprise teams with 2,000/month committed spend'