### PR TITLE
LOG-3748: run index after prod deploy

### DIFF
--- a/.github/workflows/build-search-index.yml
+++ b/.github/workflows/build-search-index.yml
@@ -2,17 +2,17 @@ name: Build Search Index
 
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+  deployment_status:
+    states: [success]
 
 jobs:
   build-index:
     runs-on: ubuntu-latest
+    if: >
+      github.event.deployment_status.state == 'success' &&
+      github.event.deployment.environment == 'production'
     steps:
       - uses: actions/checkout@master
-      - name: Wait for Railway deployment
-        run: sleep 600
       - name: Scrape and index docs
         env:
           HOST_URL: ${{ secrets.MEILISEARCH_HOST_URL }}

--- a/.github/workflows/build-search-index.yml
+++ b/.github/workflows/build-search-index.yml
@@ -2,15 +2,17 @@ name: Build Search Index
 
 on:
   workflow_dispatch:
-    # Manually hit button. Ideally this should be triggered automatically,
-    # after a build/deploy step, but it's not worth it to make a custom build
-    # right now.
+  push:
+    branches:
+      - main
 
 jobs:
   build-index:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
+      - name: Wait for Railway deployment
+        run: sleep 600
       - name: Scrape and index docs
         env:
           HOST_URL: ${{ secrets.MEILISEARCH_HOST_URL }}


### PR DESCRIPTION
Leaves the button in the UI via workflow_dispatch should we want to trigger manually, but will deploy after the deploy state is reported back from railway as success