### PR TITLE
fix: prevent multiple PrismaClient instances in dev

### DIFF
--- a/src/clients/prisma.ts
+++ b/src/clients/prisma.ts
@@ -1,3 +1,13 @@
 import { PrismaClient } from "@prisma/client";
 
-export const prisma = new PrismaClient();
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma = globalForPrisma.prisma ?? new PrismaClient();
+
+if (process.env.NODE_ENV !== "production") globalForPrisma.prisma = prisma;
+
+process.on("beforeExit", async () => {
+  await prisma.$disconnect();
+});


### PR DESCRIPTION
This PR updates the Prisma client initialization to reuse a global instance in non-production environments.

- Prevents multiple PrismaClient instances being created during hot reloads
- Ensures proper cleanup with `beforeExit` hook
- Improves stability and avoids connection limit issues during development
