### PR TITLE
perf: optimize page lookup using Set for faster matching and remove unused Page

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,12 +1,12 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { allPages, Page } from "contentlayer/generated";
+import { allPages } from "contentlayer/generated";
+
+const pageUrlSet = new Set(allPages.map(page => page.url));
 
 // This middleware is used to rewrite the pathname to the SSR path during runtime as middleware is not ran during build
 export function middleware(request: NextRequest) {
-  const page = allPages.find(p => p.url === request.nextUrl.pathname);
-
-  if (!page) {
+  if (!pageUrlSet.has(request.nextUrl.pathname)) {
     return NextResponse.next();
   }
 


### PR DESCRIPTION
- Converts `allPages` URLs into a Set for `O(1)` lookups
- Simplifies conditional logic for checking valid routes
- Reduces overhead during runtime, especially for large page collections
- Remove the unused `Page` import