### PR TITLE
fix: add method validation and error handling for feedback endpoint

### DIFF
--- a/src/pages/api/feedback.ts
+++ b/src/pages/api/feedback.ts
@@ -9,7 +9,12 @@ export interface FeedbackBody {
 }
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
-  if (req.method == "POST") {
+  if (req.method !== "POST") {
+    res.status(405).json({ error: "Method not allowed" });
+    return;
+  }
+
+  try {
     const body: FeedbackBody = JSON.parse(req.body);
     const feedbackMessage =
       body.feedback?.trim() === "" ? null : body.feedback?.trim();
@@ -44,7 +49,10 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
         },
       });
     }
-  }
 
-  res.status(200).json({ status: "Success" });
+    res.status(200).json({ status: "Success" });
+  } catch (error) {
+    res.status(500).json({ error: "Failed to process feedback" });
+    return;
+  }
 };


### PR DESCRIPTION
- Added a method guard in the feedback API to return a 405 error for non-POST requests, preventing any further processing
- Introduced error handling for feedback persistence, returning a 500 status when operations fail to stop execution early