### PR TITLE
fix(seo): clean up next-seo imports

### DIFF
--- a/src/components/SEO.tsx
+++ b/src/components/SEO.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
-import { DefaultSeo, NextSeo, NextSeoProps } from "next-seo";
+import { DefaultSeo, NextSeo, NextSeoProps, DefaultSeoProps } from "next-seo";
 import Head from "next/head";
-import { DefaultSeoProps } from "next-seo";
 
 export interface Props extends NextSeoProps {
   title?: string;


### PR DESCRIPTION
Simplifies the SEO component imports by consolidating DefaultSeoProps into the main next-seo import. It removes redundant lines and ensures consistency in import structure. This makes the file cleaner and easier to maintain going forward.