### PR TITLE
refactor(types): use typeof lightColors for colorThemes

### DIFF
--- a/src/styles/colors.ts
+++ b/src/styles/colors.ts
@@ -98,7 +98,7 @@ darkColors = {
   background: "#131415",
 };
 
-export const colorThemes: Record<ColorMode, any> = {
+export const colorThemes: Record<ColorMode, typeof lightColors> = {
   light: lightColors,
   dark: darkColors,
 };


### PR DESCRIPTION
Replaces any with typeof lightColors for colorThemes and keeps darkColors generation unchanged. This tightens type safety and improves editor autocomplete without affecting runtime behavior. Small, scoped typing refactor for the colors module.