### PR TITLE
fix: update .gitignore and typings for SVGProps interface caused typecheck errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ public/robots.txt
 /.envrc
 /.direnv/
 .turbo
+tsconfig.tsbuildinfo

--- a/typings/twin.d.ts
+++ b/typings/twin.d.ts
@@ -17,7 +17,7 @@ declare module "react" {
   }
 
   // The inline svg css prop
-  interface SVGProps<T> extends SVGProps<SVGSVGElement> {
+  interface SVGProps<T> {
     css?: CSSProp;
     tw?: string;
   }
@@ -29,13 +29,4 @@ declare module "react" {
   }
 }
 
-// The 'as' prop on styled components
-declare global {
-  namespace JSX {
-    interface IntrinsicAttributes<T> extends DOMAttributes<T> {
-      as?: string | React.ComponentType;
-      tw?: string;
-      css?: CSSProp;
-    }
-  }
-}
+// Do not override JSX.IntrinsicAttributes to preserve React's built-in `key`/`ref` types


### PR DESCRIPTION
Update .gitignore and typings for SVGProps interface caused typecheck errors

<img width="1388" height="576" alt="image" src="https://github.com/user-attachments/assets/bff52102-b771-4406-bf35-4ab2cf3f90c9" />
