### PR TITLE
refactor: tighten custom icons props to SVGSVGElement

### DIFF
--- a/src/components/Icons.tsx
+++ b/src/components/Icons.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from "../styles/theme";
 import { useIsMounted } from "@/hooks/useIsMounted";
 
-export const XIcon: React.FC<any> = props => {
+export const XIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => {
   const { colorMode } = useTheme();
 
   const isMounted = useIsMounted();
@@ -33,7 +33,7 @@ export const XIcon: React.FC<any> = props => {
   );
 };
 
-export const DiscordIcon: React.FC<any> = props => (
+export const DiscordIcon: React.FC<React.SVGProps<SVGSVGElement>> = props => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 127.14 96.36" {...props}>
     <g data-name="\\u56FE\\u5C42 2">
       <g data-name="Discord Logo">


### PR DESCRIPTION
Replaces any with React.SVGProps<SVGSVGElement> for custom icons to improve type safety.