### PR TITLE
feat: add search configuration check and disable input accordingly instead of breaking

### DIFF
--- a/src/components/Search/Modal.tsx
+++ b/src/components/Search/Modal.tsx
@@ -18,7 +18,7 @@ const Modal: React.FC<Props> = ({ closeModal }) => {
     highlightPreTag: "<span>",
     highlightPostTag: "</span>",
   };
-  const { clearResponse, isSearching, query, setQuery, results } =
+  const { clearResponse, isSearching, query, setQuery, results, isConfigured } =
     useDebouncedSearch<Search.Document, Search.Result>(
       process.env.NEXT_PUBLIC_MEILISEARCH_HOST ?? "",
       process.env.NEXT_PUBLIC_MEILISEARCH_READ_API_KEY ?? "",
@@ -43,10 +43,15 @@ const Modal: React.FC<Props> = ({ closeModal }) => {
             clearResponse={clearResponse}
             query={query}
             setQuery={setQuery}
+            disabled={!isConfigured}
           />
         </div>
         <div className="search-results">
-          {isSearching ? (
+          {!isConfigured ? (
+            <div tw="p-6 text-center text-gray-500 dark:text-gray-600">
+              Search is not configured
+            </div>
+          ) : isSearching ? (
             <span tw="p-10 flex items-center justify-center">
               <LoadingIndicator />
             </span>

--- a/src/components/Search/QueryInput.tsx
+++ b/src/components/Search/QueryInput.tsx
@@ -7,9 +7,15 @@ interface Props {
   clearResponse: () => void;
   query: string;
   setQuery: (q: string) => void;
+  disabled?: boolean;
 }
 
-const QueryInput: React.FC<Props> = ({ clearResponse, query, setQuery }) => {
+const QueryInput: React.FC<Props> = ({
+  clearResponse,
+  query,
+  setQuery,
+  disabled = false,
+}) => {
   return (
     <div css={tw`flex flex-col`}>
       <form css={tw`flex flex-row`}>
@@ -20,7 +26,8 @@ const QueryInput: React.FC<Props> = ({ clearResponse, query, setQuery }) => {
           autoFocus
           css={tw`w-full focus:outline-none bg-transparent`}
           type="text"
-          placeholder="Search"
+          placeholder={disabled ? "Search is not configured" : "Search"}
+          disabled={disabled}
           value={query}
           onChange={e => setQuery(e.target.value)}
         />


### PR DESCRIPTION
<img width="1099" height="267" alt="Screenshot 2025-08-25 at 11 33 47 AM" src="https://github.com/user-attachments/assets/4cd79ce1-3b1d-4268-b9d7-2fde45ac34c0" />

Right now, not config while development breaks the app unexpectedly

<img width="1307" height="749" alt="image" src="https://github.com/user-attachments/assets/49a61580-2912-40f5-ab3b-e0654e2f9156" />
