### PR TITLE
Update possible builder values in config-as-code.md

### DIFF
--- a/src/docs/reference/config-as-code.md
+++ b/src/docs/reference/config-as-code.md
@@ -53,8 +53,6 @@ Possible values are:
 - `NIXPACKS`
 - `DOCKERFILE`
 - `RAILPACK`
-- `HEROKU`
-- `PAKETO`
 
 Note: Railway will always build with a Dockerfile if it finds one. To build with nixpacks, you can remove or rename the Dockerfile.
 


### PR DESCRIPTION
Hello,

I was recently going through the Railway documentation and I noticed that Railpack wasn't specified as a possible value for builder in a config file such as `railway.json`.

I went to the schema link (https://railway.com/railway.schema.json), and updated the list of possible builder values according to the up-to-date schema. 

Thanks for all your hard work on Railway, it's fantastic! 🚄

Please let me know if I should make any other changes to help get this PR approved.

Jack