### PR TITLE
docs(reference): update pricing table and ephemeral storage docs to match the pricing page

### DIFF
--- a/src/docs/reference/pricing/plans.md
+++ b/src/docs/reference/pricing/plans.md
@@ -39,9 +39,9 @@ Depending on the plan you are on, you are allowed to use up these resources per 
 | -------------- | --------- | ----------- | --------------------- | ------------------ | -------------- |
 | **Trial**      | **1 GB**  | **2 vCPU**  | **1 GB**              | **0.5 GB**         | **4 GB**       |
 | **Free**       | **0.5 GB**| **1 vCPU**  | **1 GB**              | **0.5 GB**         | **4 GB**       | 
-| **Hobby**      | **8 GB**  | **8 vCPU**  | **10 GB**             | **5 GB**           | **100 GB**     |
-| **Pro**        | **32 GB** | **32 vCPU** | **100 GB**            | **50 GB \***       | **100 GB**     |
-| **Enterprise** | **48 GB** | **64 vCPU** | **100 GB**            | **2 TB \***        | **100 GB**     |
+| **Hobby**      | **8 GB**  | **8 vCPU**  | **100 GB**            | **5 GB**           | **100 GB**     |
+| **Pro**        | **32 GB** | **32 vCPU** | **100 GB**            | **50 GB \***       | **Unlimited**  |
+| **Enterprise** | **48 GB** | **64 vCPU** | **100 GB**            | **2 TB \***        | **Unlimited**  |
 
 Note that these are initial values and users on the Pro and Enterprise plans can request limit increases.
 

--- a/src/docs/reference/services.md
+++ b/src/docs/reference/services.md
@@ -41,7 +41,7 @@ Services can be deployed from a local machine by using the [Railway CLI](/refere
 
 Every service deployment has access ephemeral storage, with the limits being 1GB on the Free plan and 100GB on a paid plan. If a service deployment consumes more than its ephemeral storage limit, it can be forcefully stopped and redeployed.
 
-If your service requires data to persist between deployments, or needs more than 10GB of storage, you should add a [volume](/reference/volumes).
+If your service requires data to persist between deployments, or needs more storage, you should add a [volume](/reference/volumes).
 
 ## Templates
 

--- a/src/docs/reference/services.md
+++ b/src/docs/reference/services.md
@@ -39,7 +39,7 @@ Services can be deployed from a local machine by using the [Railway CLI](/refere
 
 ## Ephemeral Storage
 
-Every service deployment has access to 10GB of ephemeral storage. If a service deployment consumes more than 10GB, it can be forcefully stopped and redeployed.
+Every service deployment has access ephemeral storage, with the limits being 1GB on the Free plan and 100GB on a paid plan. If a service deployment consumes more than its ephemeral storage limit, it can be forcefully stopped and redeployed.
 
 If your service requires data to persist between deployments, or needs more than 10GB of storage, you should add a [volume](/reference/volumes).
 


### PR DESCRIPTION
All values are directly taken from Railway's new pricing page: https://railway.com/pricing
- ephemeral storage limits: 1GB on the Free/Trial plan, 100GB on a paid plan
- image size is now unlimited for the Pro and Enterprise plan