### PR TITLE
Shorten NodeJS SIGTERM title for readability and embed

### DIFF
--- a/src/docs/guides/nodejs-sigterm.md
+++ b/src/docs/guides/nodejs-sigterm.md
@@ -1,6 +1,6 @@
 ---
-title: Why SIGTERM handling may not work with Node.js runtime scripts
-description: SIGTERM might sometimes fail to process on shutdown. Here's why
+title: NodeJS SIGTERM Handling
+description: SIGTERM might sometimes fail to process on shutdown. Here's why.
 ---
 
 If you’ve tried to capture SIGTERM in your Node.js app and noticed your handler never runs, the cause is usually the package manager.


### PR DESCRIPTION
Embed completely breaks with the current, and it's a lot to have at the top of the page anyways. Probably easier to fix this then to change the embed system.