### PR TITLE
Revert "feat: add search configuration check and disable input accordingly instead of breaking"

### DIFF
--- a/src/components/Search/Modal.tsx
+++ b/src/components/Search/Modal.tsx
@@ -18,7 +18,7 @@ const Modal: React.FC<Props> = ({ closeModal }) => {
     highlightPreTag: "<span>",
     highlightPostTag: "</span>",
   };
-  const { clearResponse, isSearching, query, setQuery, results, isConfigured } =
+  const { clearResponse, isSearching, query, setQuery, results } =
     useDebouncedSearch<Search.Document, Search.Result>(
       process.env.NEXT_PUBLIC_MEILISEARCH_HOST ?? "",
       process.env.NEXT_PUBLIC_MEILISEARCH_READ_API_KEY ?? "",
@@ -43,15 +43,10 @@ const Modal: React.FC<Props> = ({ closeModal }) => {
             clearResponse={clearResponse}
             query={query}
             setQuery={setQuery}
-            disabled={!isConfigured}
           />
         </div>
         <div className="search-results">
-          {!isConfigured ? (
-            <div tw="p-6 text-center text-gray-500 dark:text-gray-600">
-              Search is not configured
-            </div>
-          ) : isSearching ? (
+          {isSearching ? (
             <span tw="p-10 flex items-center justify-center">
               <LoadingIndicator />
             </span>

--- a/src/components/Search/QueryInput.tsx
+++ b/src/components/Search/QueryInput.tsx
@@ -7,15 +7,9 @@ interface Props {
   clearResponse: () => void;
   query: string;
   setQuery: (q: string) => void;
-  disabled?: boolean;
 }
 
-const QueryInput: React.FC<Props> = ({
-  clearResponse,
-  query,
-  setQuery,
-  disabled = false,
-}) => {
+const QueryInput: React.FC<Props> = ({ clearResponse, query, setQuery }) => {
   return (
     <div css={tw`flex flex-col`}>
       <form css={tw`flex flex-row`}>
@@ -26,8 +20,7 @@ const QueryInput: React.FC<Props> = ({
           autoFocus
           css={tw`w-full focus:outline-none bg-transparent`}
           type="text"
-          placeholder={disabled ? "Search is not configured" : "Search"}
-          disabled={disabled}
+          placeholder="Search"
           value={query}
           onChange={e => setQuery(e.target.value)}
         />

--- a/src/hooks/useDebouncedSearch.ts
+++ b/src/hooks/useDebouncedSearch.ts
@@ -72,10 +72,15 @@ export const useDebouncedSearch = <
     Result
   > = defaultTransformResponse as Transformer<any, any>,
 ) => {
-  const isConfigured = useMemo(
-    () => host !== "" && apiKey !== "" && indexName !== "",
-    [host, apiKey, indexName],
-  );
+  if (host === "") {
+    console.error(`useDebouncedSearch.host is missing`);
+  }
+  if (apiKey === "") {
+    console.error(`useDebouncedSearch.apiKey is missing`);
+  }
+  if (indexName === "") {
+    console.error(`useDebouncedSearch.indexName is missing`);
+  }
 
   // Controlled input for rendering
   const [rawInput, setRawInput] = useState("");
@@ -88,14 +93,16 @@ export const useDebouncedSearch = <
 
   // Get index
   const index = useMemo(() => {
-    if (!isConfigured) return null;
-    const meilisearch = new MeiliSearch({ host, apiKey });
+    const meilisearch = new MeiliSearch({
+      host,
+      apiKey,
+    });
     return meilisearch.index<Response>(indexName);
-  }, [host, apiKey, indexName, isConfigured]);
+  }, [host, apiKey, indexName]);
 
   // Get search response
   const search = useCallback(async () => {
-    if (query === "" || !isConfigured || !index) {
+    if (query === "") {
       return;
     }
     setIsSearching(true);
@@ -107,7 +114,7 @@ export const useDebouncedSearch = <
       console.error(`Search for query "${query}" failed (${e})`);
     }
     setIsSearching(false);
-  }, [query, isConfigured, index, params, transformResponse]);
+  }, [query, setIsSearching]);
 
   // Perform search and clear search results if query is empty
   useEffect(() => {
@@ -134,6 +141,5 @@ export const useDebouncedSearch = <
     },
     setQuery: setRawInput,
     results,
-    isConfigured,
   };
 };


### PR DESCRIPTION
Reverts railwayapp/docs#844

[Discord](https://discord.com/channels/713503345364697088/1422276678352109720)

Caused the search pane to lock up and do an infinite loop of searching