### PR TITLE
docs: update copy for continuity of meaning and clarity

### DIFF
--- a/src/docs/maturity/philosophy.md
+++ b/src/docs/maturity/philosophy.md
@@ -17,7 +17,7 @@ Railway is a company staffed with people who know developers would prefer to use
 
 Companies should be as upfront as possible about their product and offerings to help you decide what is best for your team and users.
 
-Let's talk about the number one use case: delivering apps to users in a Production environment. Railway, the company, is sustainable, building our product, team, and company to last as your projects.
+Let's talk about the number one use case: delivering apps to users in a Production environment. Railway, the company, is sustainable, building our product, team, and company to last as long as your projects.
 
 ## Objective
 


### PR DESCRIPTION
-This PR adds the words "...long as..." in the final sentence of the last paragraph of the first Philosophy section on the Philosophy page: https://docs.railway.com/maturity/philosophy

-Currently the copy is an incomplete semantic thought missing a predicate that is rather ambiguous.

-The result by adding the two words introduces an adverbial modification which establishes duration, completing the thought. I will admit, I am assuming that the intent of the sentence is to evoke a feeling of longevity and almost immortality, which is not present as the current sentence reads.