### PR TITLE
fix: correct Pug template syntax highlighting in Express guide

### DIFF
--- a/src/docs/guides/express.md
+++ b/src/docs/guides/express.md
@@ -96,9 +96,14 @@ The page is only rendered after successfully receiving the database response to 
 
 4. Open the `views/index.pug` file, and update it to display the `timeFromDB` value on the page.
 
-```html
-extends layout block content h1= title p Welcome to #{title} p This is the time
-retrieved from the database: p #{timeFromDB}
+```pug
+extends layout 
+
+block content 
+  h1= title 
+  p Welcome to #{title} 
+  p This is the time retrieved from the database: 
+  p #{timeFromDB}
 ```
 
 5. Run the app again to see your changes in action!


### PR DESCRIPTION
### Update

Small update to fix highlighting and formatting for the Pug template code block in the Express deployment guide.

The code block language has been changed from `html` to `pug` to enable proper syntax highlighting. The Pug template has been reformatted with correct indentation and line breaks, which improves code readability for developers following the guide.

### Before
<img width="1358" height="194" alt="CleanShot 2025-10-12 at 16 57 59@2x" src="https://github.com/user-attachments/assets/ee1aa640-d6c6-440d-b637-2f611a0af62a" />

### After 
<img width="1464" height="418" alt="CleanShot 2025-10-12 at 17 00 47@2x" src="https://github.com/user-attachments/assets/b43b155e-3a41-4434-95aa-bf5a543a960a" /><br>

The `extends layout` and `block content` structure has been confirmed to follow the correct format as specified in the [Pug Template Inheritance section](https://pugjs.org/language/inheritance.html).