### PR TITLE
docs: fix faulty "Deploy a Laravel app" guide

### DIFF
--- a/src/docs/guides/laravel.md
+++ b/src/docs/guides/laravel.md
@@ -184,7 +184,7 @@ Please follow these steps to get started:
 
    - Click **Deploy**.
 
-5. Create a new service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
+4. Create a new service on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
 
    - Name the service **cron service**, and click on <a href="/overview/the-basics#service-settings">**Settings**</a>.
 
@@ -198,7 +198,7 @@ Please follow these steps to get started:
 
    - Click **Deploy**.
 
-6. Create a new service again on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
+5. Create a new service again on the <a href="/overview/the-basics#project--project-canvas" target="_blank">Project Canvas</a>.
 
    - Name the service **worker service**, and click on <a href="/overview/the-basics#service-settings">**Settings**</a>.
 


### PR DESCRIPTION
I did everything by the guide and have been receiving the following exception:
```text
Illuminate\Database\QueryException
SQLSTATE[08006] [7] could not translate host name "postgres.railway.internal" to address: Name or service not known (Connection: pgsql, SQL: delete from "cache")
```

Guide suggested to call `php artisan optimize:clear` in `build-app.sh` that should be used in "Custom Build Command". The thing is that Laravel have `CACHE_STORE=database` configured by default, it tries to access the DB to clean cache, but `"postgres.railway.internal"` url is not available during Build phase, so build fails with a `QueryException`.