### PR TITLE
clarify that the config as code path is absolute in the repo

### DIFF
--- a/src/docs/guides/build-configuration.md
+++ b/src/docs/guides/build-configuration.md
@@ -59,7 +59,7 @@ width={1200} height={421} quality={80} />
 When specified, all build and deploy
 commands will operate within the defined root directory.
 
-**Note:** The **Railway Config File** does not follow the **Root Directory** path. You have to specify the absolute path for the `railway.json` or `railway.toml` file.
+**Note:** The **Railway Config File** does not follow the **Root Directory** path. You have to specify the absolute path for the `railway.json` or `railway.toml` file, for example: `/backend/railway.toml`
 
 ## Configure Watch Paths
 

--- a/src/docs/guides/config-as-code.md
+++ b/src/docs/guides/config-as-code.md
@@ -89,7 +89,8 @@ width={1200} height={631} quality={100} />
 
 ## Using a Custom Config as Code File
 
-You can use a custom config file by setting it on the service settings page. The file is relative to your app source.
+You can use a custom config file by setting it on the service settings page. You should provide the absolute path to the file in your repository,
+for example: `/backend/railway.toml`
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1743195631/docs/config-file_f1wf32.png"

--- a/src/docs/guides/monorepo.md
+++ b/src/docs/guides/monorepo.md
@@ -37,7 +37,7 @@ alt="Screenshot of root directory configuration"
 layout="intrinsic"
 width={980} height={380} quality={80} />
 
-**Note:** The **Railway Config File** does not follow the **Root Directory** path. You have to specify the absolute path for the `railway.json` or `railway.toml` file.
+**Note:** The **Railway Config File** does not follow the **Root Directory** path. You have to specify the absolute path for the `railway.json` or `railway.toml` file, for example: `/backend/railway.toml`
 
 ## Deploying a Shared Monorepo
 


### PR DESCRIPTION
There's conflicting language in the current docs: e.g. "absolute" vs "relative" and "app source" vs. "root directory"