### PR TITLE
docs: Laravel guide - improve instruction to setup Structured logs

### DIFF
--- a/src/docs/guides/laravel.md
+++ b/src/docs/guides/laravel.md
@@ -244,13 +244,13 @@ Laravel, by default, writes logs to a directory on disk. However, on Railway’s
 
 To ensure logs and errors appear in Railway’s console or with `railway logs`, update the following environment variables:
 
-- `LOG_CHANNEL`: Set the value to `errorlog`.
+- `LOG_CHANNEL`: Set the value to `stderr`.
 
 - `LOG_STDERR_FORMATTER`: Set the value to `\Monolog\Formatter\JsonFormatter` in order to have [Structured logs](https://docs.railway.com/guides/logs#structured-logs).
 
 You can set variables via the Railway dashboard or CLI as shown:
 ```bash
-railway variables --set "LOG_CHANNEL=errorlog" --set "LOG_STDERR_FORMATTER=\Monolog\Formatter\JsonFormatter"
+railway variables --set "LOG_CHANNEL=stderr" --set "LOG_STDERR_FORMATTER=\Monolog\Formatter\JsonFormatter"
 ```
 
 ## Can I Deploy with Laravel Sail?


### PR DESCRIPTION
### Problem

Unstructured logs sent to `errorlog` are converted to errors during [normalization](https://docs.railway.com/guides/logs#normalization-strategy).  

### The simplest way to implement structured logs for Railway:
Laravel creates configuration for `stderr` channel out-of-the-box and this configuration accepts formatter from `LOG_STDERR_FORMATTER` environment variable. `\Monolog\Formatter\JsonFormatter` class is also provided with Laravel.