### PR TITLE
docs: update recommendations regarding ioredis IP family selection

### DIFF
--- a/src/docs/guides/private-networking.md
+++ b/src/docs/guides/private-networking.md
@@ -151,6 +151,9 @@ Some libraries and components require you to be explicit when either listening o
 
 `ioredis` is a Redis client for node.js, commonly used for connecting to Redis from a node application.
 
+Versions prior to `ioredis@v5.8.2` have defaulted to selecting IPv4 family by default. Upgrading to `v5.8.2` (or later) should make `ioredis` connect
+to both IPv6 and IPv4 endpoints automatically. If upgrading is not an option, follow the instructions below.
+
 When initializing a Redis client using `ioredis`, you must specify `family=0` in the connection string to support connecting to both IPv6 and IPv4 endpoints:
 
 ```javascript
@@ -168,6 +171,9 @@ const ping = await redis.ping();
 <Collapse title="bullmq">
 
 `bullmq` is a message queue and batch processing library for node.js, commonly used for processing jobs in a queue.
+
+`bullmq` running on `ioredis` versions prior to `v5.8.2` has defaulted to selecting IPv4 family by default. Upgrading to `v5.8.2` (or later) should make `ioredis` (and thus `bullmq`) connect
+to both IPv6 and IPv4 endpoints automatically. If upgrading is not an option, follow the instructions below.
 
 When initializing a bullmq client, you must specify `family: 0` in the connection object to support connecting to both IPv6 and IPv4 Redis endpoints:
 

--- a/src/docs/reference/errors/enotfound-redis-railway-internal.md
+++ b/src/docs/reference/errors/enotfound-redis-railway-internal.md
@@ -11,7 +11,7 @@ The error code `ENOTFOUND` means that your application could not resolve the `re
 
 This error can occur for a few different reasons, but the main reason is because your application uses the [`ioredis`](https://www.npmjs.com/package/ioredis) package to connect to the Redis database, or uses a package that uses ioredis as a dependency such as [`bullmq`](https://docs.bullmq.io/).
 
-By default, ioredis will only do an IPv4 (A record) lookup for the `redis.railway.internal` hostname.
+By default, ioredis (pre `v5.8.2`) will only do an IPv4 (A record) lookup for the `redis.railway.internal` hostname.
 
 That presents a problem given that Railway's private network uses only IPv6 (AAAA records).
 
@@ -35,6 +35,9 @@ The solution depends on the package you are using to connect to the Redis databa
 
 #### Using ioredis directly in your application
 
+`ioredis` starting with `v5.8.2` sets ip family to `0` by default and not manual configuration should be required.
+If upgrading is not an option, follow the instructions below.
+
 `ioredis` has an option to do a dual stack lookup, which will try to resolve the `redis.railway.internal` hostname using both IPv4 and IPv6 addresses (A and AAAA records).
 
 To enable this, in your `REDIS_URL` environment variable, you can set the `family` to `0` to enable dual stack lookup.
@@ -49,7 +52,7 @@ const ping = await redis.ping();
 
 #### Using bullmq
 
-Similarly, for `bullmq` since it uses `ioredis` as a dependency, you can set the `family` option to `0` in your connection object.
+Similarly, for `bullmq` since it uses `ioredis` as a dependency, you can update `ioredis` to `v5.8.2` (or later) or you can set the `family` option to `0` in your connection object.
 
 ```js
 import { Queue } from "bullmq";
@@ -75,7 +78,7 @@ console.log(jobs);
 
 Above we covered the two most common packages that can cause this error, but there are other packages that use `ioredis` as a dependency that may also cause this error.
 
-If you are using a package that uses `ioredis` as a dependency, you can try to find a way to set the `family` option to `0` either in your connection object or in your `REDIS_URL` environment variable. Similar to the examples above.
+If you are using a package that uses `ioredis` as a dependency, you can update `ioredis` to `v5.8.2` (or later) or you can try to find a way to set the `family` option to `0` either in your connection object or in your `REDIS_URL` environment variable. Similar to the examples above.
 
 ### Redis database in a different project
 


### PR DESCRIPTION
This should now be obsolete for users running `ioredis@v5.8.2` (see https://github.com/redis/ioredis/issues/2026 and https://github.com/redis/ioredis/releases/tag/v5.8.2).

I wasn't sure if the old recommendations should stay. My gut feeling is yes - as long as some users are not yet able to update `ioredis` they still need to fight with custom `family` setting.