### PR TITLE
Update webhook docs with new payload format and in-app notifications

### DIFF
--- a/src/docs/guides/observability.md
+++ b/src/docs/guides/observability.md
@@ -97,7 +97,10 @@ To persist your changes, make sure you press Save at the top right corner.
 
 ## Monitors
 
-The Observability Dashboard includes configurable monitoring alerts that send email notifications when thresholds are reached.
+The Observability Dashboard includes configurable monitoring alerts that send
+email and in-app notifications when thresholds are reached. You can also
+configure [webhooks](/guides/webhooks) to receive notifications when thresholds are reached.
+
 <Banner variant="info">
 Monitors requires a [Pro plan](/reference/pricing/plans#plans).
 </Banner>

--- a/src/docs/guides/webhooks.md
+++ b/src/docs/guides/webhooks.md
@@ -7,10 +7,10 @@ Webhooks can be used to notify your own application of deployment status changes
 
 ## Setup a Webhook
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1743196876/docs/new-webhook_lrfxxa.png"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1763768800/new-webhooks_lhw6p2.png"
 alt="New Webhook"
 layout="responsive"
-width={1200} height={754} quality={80} />
+width={821} height={485} quality={80} />
 
 Complete the following steps to setup a webhook:
 
@@ -27,27 +27,25 @@ The URL you provide will receive a webhook payload when any service's deployment
 
 ```json
 {
-  "type": "DEPLOY",
-  "timestamp": "2025-02-01T00:00:00.000Z",
-  "project": {
-    "id": "[project ID]",
-    "name": "[project name]",
-    "description": "...",
-    "createdAt": "2025-02-01T00:00:00.000Z"
+  "type": "Deployment.failed",
+  "details": {
+    "id": "8107edff-4b8e-44fc-b43a-04566e847a2a",
+    "source": "GitHub",
+    "status": "SUCCESS",
+    "branch": "...",
+    "commitHash": "...",
+    "commitAuthor": "...",
+    "commitMessage": "...",
   },
-  "environment": {
-    "id": "[environment ID]",
-    "name": "[environment name]"
+  "resource": {
+    "workspace": { "id": "<workspace id>", "name": "<workspace name>" },
+    "project": { "id": "<project id>", "name": "<project name>" },
+    "environment": { "id": "<environment id>", "name": "<environment name>", "isEphemeral": false },
+    "service": { "id": "<service id>", "name": "<service name>" },
+    "deployment": { "id": "<deployment id>" }
   },
-  "deployment": {
-    "id": "[deploy ID]",
-    "creator": {
-      "id": "[user id]",
-      "name": "...",
-      "avatar": "..."
-    },
-    "meta": {}
-  }
+  "severity": "WARNING",
+  "timestamp": "2025-11-21T23:48:42.311Z"
 }
 ```
 

--- a/src/docs/reference/production-readiness-checklist.md
+++ b/src/docs/reference/production-readiness-checklist.md
@@ -71,11 +71,11 @@ Observability and monitoring refers to tracking the health and performance of yo
 
   Familiarize yourself with the [Log Explorer](/guides/logs#log-explorer) so you can query logs across all of your services in one place.
 
-**&check; Setup webhooks and email notifications**
+**&check; Setup webhooks, email, and in-app notifications**
 
 - Ensure you are alerted if the [deployment status](/reference/deployments#deployment-states) of your services change.
 
-  Enable email notifications in you Account Settings to receive these alerts via email.
+  Enable email and in-app notifications in you Account Settings to receive these alerts via email.
 
   Setup [webhooks](/reference/deployments#deployment-states) to have the alerts sent to another system, like Slack or Discord.
 

--- a/src/docs/reference/webhooks.md
+++ b/src/docs/reference/webhooks.md
@@ -5,26 +5,22 @@ description: Learn about webhooks on Railway.
 
 Webhooks can be used to notify your own application of alerts or deployment status changes.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1743196876/docs/new-webhook_lrfxxa.png"
-alt="New Webhook UI"
+<Image src="https://res.cloudinary.com/railway/image/upload/v1763768800/new-webhooks_lhw6p2.png"
+alt="New Webhook"
 layout="responsive"
-width={1200} height={754} quality={80} />
+width={821} height={485} quality={80} />
 
 ## Setting up a Project webhook
 
 For information on how to setup webhooks, visit [this guide](/guides/webhooks).
 
-## Deployment Status
+## Platform Events
 
-When a deployment's status changes, Railway will send a notification via HTTP to the URL provided in the webhook configuration.
+Webhooks can be used to receive notifications a variety of events on the platform. This includes things like:
 
-Deployment states can be found [here](/reference/deployments#deployment-states).
-
-## Volume Usage Alerts
-
-When a volume usage breaches certain thresholds, Railway will send a notification to pro customers via HTTP to the URL provided in the webhook configuration.
-
-The thresholds that alert can be configured in the volume settings page.
+- Deployment status changes. Available deployment states can be found [here](/reference/deployments#deployment-states).
+- Volume usage alerts.
+- CPU/RAM monitor alerts.
 
 ## Muxers: Provider-specific Webhooks
 


### PR DESCRIPTION
Updates webhook documentation to reflect current payload structure and notification options.

- Update webhook payload example to match current platform event format
- Add in-app notifications to observability and production checklist docs
- Update webhook reference to describe platform events more broadly
- Update webhook UI screenshot to latest version