### PR TITLE
Fix: Update manage-projects API query to use workspace parameter (#867)

### DIFF
--- a/src/docs/guides/manage-projects.md
+++ b/src/docs/guides/manage-projects.md
@@ -9,20 +9,22 @@ Note: Authenticate your requests with your workspace token by setting the Author
 
 ### Fetch All Your Projects
 
-The query below will fetch all your personal projects along with all the services and environments for them.
+The query below will fetch all projects in a workspace along with their services and environments.
 
 ```graphql
 query Projects {
-  projects {
-    edges {
-      node {
-        id
-        name
-        services {
-          edges {
-            node {
-              id
-              name
+  workspace(workspaceId: "<workspace_id>") {
+    projects {
+      edges {
+        node {
+          id
+          name
+          services {
+            edges {
+              node {
+                id
+                name
+              }
             }
           }
           environments {
@@ -39,6 +41,13 @@ query Projects {
   }
 }
 ```
+
+Replace `<workspace_id>` with your active workspace ID.
+
+You can find your current workspace's ID by:
+
+1. Pressing `Cmd/Ctrl + K` in the Railway dashboard
+2. Searching for and selecting the "Copy Active Workspace ID" option
 
 ### Delete a Project
 


### PR DESCRIPTION
## Summary of changes

Fixes #867. Updates the "Fetch All Your Projects" query in the `manage-projects.md` guide to use the correct `workspace(workspaceId:)` parameter instead of the outdated direct `projects` query.

This was a pretty simple fix. Not much to change! Let me know if there's anything else I can clean up.

## Testing completed 

I validated the new query with my own account token and a workspace/team token. 