### PR TITLE
Fix link to public bucket feedback thread

### DIFF
--- a/src/docs/guides/storage-buckets.md
+++ b/src/docs/guides/storage-buckets.md
@@ -337,6 +337,6 @@ Upvote these feature requests on our feedback page if these features sound usefu
 
 - [Native file explorer](https://station.railway.com/feedback/railway-storage-buckets-native-file-expl-e0bc1a5a)
 - [Snapshots and backups](https://station.railway.com/feedback/railway-storage-buckets-native-file-expl-e0bc1a5a)
-- [Publicly-accessible buckets](https://station.railway.com/feedback/railway-storage-buckets-backup-feature-8c44e697)
+- [Publicly-accessible buckets](https://station.railway.com/feedback/public-railway-storage-buckets-1e3bdac8)
 
 If you have an idea for other features, let us know on [this feedback page](https://station.railway.com/feedback/object-storage-tell-us-what-you-need-924b88fc).


### PR DESCRIPTION
Fixes the link to public buckets feedback, which mistakenly pointed to bucket backups