### PR TITLE
Update info about priority boarding

### DIFF
--- a/src/docs/guides/join-priority-boarding.md
+++ b/src/docs/guides/join-priority-boarding.md
@@ -3,36 +3,20 @@ title: Join Priority Boarding!
 description: Priority Boarding is Railway's beta program for getting access early to new features. Learn how to be a part of it.
 ---
 
-Priority Boarding is Railway's **beta program** and is available to users who have connected their Railway account to Discord.
+Priority Boarding is Railway's **beta program** and is available to all Railway users.
 
-## Connect Railway to Discord
+## Enable Priority Boarding
 
-Visit <a href="https://railway.com/account" target="_blank">General Settings</a>, scroll down to Account Settings, and connect your account to the Railway Discord server.
+Visit the <a href="https://railway.com/account/feature-flags" target="_blank">Feature Flags page</a> in your account settings and flip the "Priority Boarding" switch to enable it.
 
-<Image src="https://res.cloudinary.com/railway/image/upload/v1666373029/docs/discord-connect_ok03jw.png"
-alt="Screenshot of Account Settings - Priority Boarding"
-layout="responsive"
-width={992} height={422} quality={80} />
+Once enabled, any new features we release to Priority Boarding will automatically be enabled for your account.
 
-## Let Percy Know
-
-Once connected to Discord, you'll need to let Percy, the Railway Discord bot, know that you'd like to be a part of priority boarding.
-
-In Discord, open up any channel, enter `/beta`, and follow the prompts.
-
-Alternatively, you can open the command palette using `CMD + K` or `Ctrl + K`, then scroll down to `Utilities`, and select the join Priority Boarding button.
-
-You should now have access to the `#priority-boarding` channel. You should also see that your Account Settings now display a new Priority Boarding status.
-
-<Image src="https://res.cloudinary.com/railway/image/upload/v1666372408/docs/priority-boarding-settings_wvvza4.png"
-alt="Screenshot of Account Settings - Priority Boarding"
-layout="responsive"
-width={1004} height={468} quality={80} />
+**Use Priority Boarding with caution if you have production workloads running**, as beta features may have unexpected behavior.
 
 ## Keep Us Posted
 
 From this point forward, you'll have Priority Boarding features automatically enabled for your account. We'll notify you of any new features via the [Changelog](https://railway.com/changelog).
 
-We kindly request that you report any issues you encounter in the <a href="https://discord.com/channels/713503345364697088/921233523719946260" target="_blank">Priority Boarding Discord channel</a>.
+We kindly request that you report any issues you encounter on <a href="https://station.railway.com/" target="_blank">Central Station</a>.
 
 That's all there is to it! Thanks for helping improve Railway, and we'll see you in Priority Boarding.

--- a/src/docs/reference/accounts.md
+++ b/src/docs/reference/accounts.md
@@ -82,4 +82,4 @@ Discord users can access the <a href="https://discord.gg/railway" target="_blank
 
 ### Priority Boarding Enrollment
 
-For the most adventurous, we offer a beta program called Priority Boarding. Integration with Discord is required. To learn more, visit [Priority Boarding](/reference/priority-boarding).
+For the most adventurous, we offer a beta program called Priority Boarding. You can join by flipping the "Priority Boarding" switch on the <a href="https://railway.com/account/feature-flags" target="_blank">Feature Flags page</a>. To learn more, visit [Priority Boarding](/reference/priority-boarding).

--- a/src/docs/reference/priority-boarding.md
+++ b/src/docs/reference/priority-boarding.md
@@ -3,8 +3,8 @@ title: Priority Boarding
 description: Priority Boarding is Railway's beta program for getting access early to new features. Learn how to be a part of it.
 ---
 
-Priority Boarding is Railway's beta program. The Railway team is always working on pushing new beta features out to priority boarding. We also offer a Discord channel dedicated to this, allowing you to submit feedback.
+Priority Boarding is Railway's beta program. The Railway team is always working on pushing new beta features out to priority boarding. You can submit feedback on <a href="https://station.railway.com/" target="_blank">Central Station</a>.
 
 To read more about Priority Boarding, check out <a href="https://blog.railway.com/p/building-the-beta" target="_blank">Priority Boarding: The Journey to Get There</a>.
 
-Learn how to join Priority Boarding [here](/guides/join-priority-boarding).
+You can join Priority Boarding by flipping the "Priority Boarding" switch on the <a href="https://railway.com/account/feature-flags" target="_blank">Feature Flags page</a>. Learn more [here](/guides/join-priority-boarding).


### PR DESCRIPTION
It's no longer joined via Discord; it's now a switch in your Railway account settings.