### PR TITLE
Make better use of build cache

### DIFF
--- a/src/docs/guides/gin.md
+++ b/src/docs/guides/gin.md
@@ -68,11 +68,11 @@ width={2661} height={1019} quality={100} />
    # Copy go mod and sum files
    COPY go.mod go.sum ./
 
-   # Copy local code to the container image.
-   COPY . ./
-
    # Install project dependencies
    RUN go mod download
+
+   # Copy local code to the container image.
+   COPY . ./
 
    # Build the app
    RUN go build -o app


### PR DESCRIPTION
Usually the point of copying go.mod and go.sum separately is to let `docker build` use cached `go mod download` layer. Copying in all other sources before `go mod download` defeats that purpose and would trigger a full download on every build if the code has changed.