### PR TITLE
feat: serve md variant of docs to ai agents

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -4,14 +4,37 @@ import { allPages } from "contentlayer/generated";
 
 const pageUrlSet = new Set(allPages.map(page => page.url));
 
-// This middleware is used to rewrite the pathname to the SSR path during runtime as middleware is not ran during build
+function prefersMarkdown(acceptHeader: string): boolean {
+  const types = acceptHeader.split(",");
+  const mdIdx = types.findIndex(t => t.includes("text/markdown") || t.includes("text/plain"));
+  const htmlIdx = types.findIndex(t => t.includes("text/html"));
+  return mdIdx !== -1 && (htmlIdx === -1 || mdIdx < htmlIdx);
+}
+
 export function middleware(request: NextRequest) {
-  if (!pageUrlSet.has(request.nextUrl.pathname)) {
+  const { pathname, searchParams } = request.nextUrl;
+
+  if (pathname.startsWith("/api/")) {
     return NextResponse.next();
   }
 
+  const hasMdExtension = pathname.endsWith(".md");
+  const pagePath = hasMdExtension ? pathname.slice(0, -3) : pathname;
+
+  if (!pageUrlSet.has(pagePath)) {
+    return NextResponse.next();
+  }
+
+  const wantsMarkdown =
+    hasMdExtension ||
+    searchParams.get("format") === "md" ||
+    prefersMarkdown(request.headers.get("accept") || "");
+
   const url = request.nextUrl.clone();
-  url.pathname = "/dynamic" + url.pathname;
+  url.pathname = "/dynamic" + pagePath;
+  if (wantsMarkdown) {
+    url.searchParams.set("format", "md");
+  }
   return NextResponse.rewrite(url);
 }
 


### PR DESCRIPTION
Previously, loading any docs page would return a massive html blob. Now agents can choose to receive markdown variants of the docs upon request. There are 3 method of receiving this.
1. Suffixing .md to the end of the path. `root/guides/variables.md` will return the variables page as markdown.
2. Suffixing ?format=md. `root/guides/deployments?format=md` will return the deployments page as markdown.
3. `accepts text/markdown` header. Agents sending this header will receive markdown variant of docs without path changes.