### PR TITLE
Fix docs homepage link width

### DIFF
--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -25,7 +25,7 @@ export const Sidebar: React.FC = ({ ...props }) => {
       <ScrollArea>
         <div tw="pt-6 pb-6 px-4 sticky top-0 bg-background z-10">
           <div tw="flex items-center justify-between">
-            <Link tw="w-full flex items-center" href="/">
+            <Link tw="flex items-center" href="/">
               <div tw="flex items-center">
                 <Logo tw="w-8 h-8 mr-4" /> <span tw="font-bold">Docs</span>
               </div>


### PR DESCRIPTION
The docs homepage link had a `w-full` class that made it span the entire width of the sidebar instead of fitting to its contents. When I was reading the docs and wanted to change the theme, I did a slight misclick and instead of changing the theme I was back to Railway Docs' homepage.

This PR fixes this by removing said `w-full` class. Here's a before and after comparision:

| Before  | After |
| -------- | ----- |
| <img width="286" height="72" alt="image" src="https://github.com/user-attachments/assets/62174562-daca-4f28-8ef2-cfe0fe44f95f" /> | <img width="285" height="70" alt="image" src="https://github.com/user-attachments/assets/3fe23fc0-c817-4ce5-a34d-bb275a3886f0" />  |