### PR TITLE
Improve theme switch accessibility

### DIFF
--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -15,7 +15,7 @@ export const ThemeSwitcher: React.FC = () => {
     <>
       {isMounted && (
         <button
-          tw="w-5 h-5 md:w-4 md:h-4 cursor-pointer focus:outline-none"
+          tw="w-5 h-5 md:w-4 md:h-4 cursor-pointer outline-offset-4"
           onClick={toggleColorMode}
         >
           {colorMode === "dark" ? (
@@ -23,6 +23,7 @@ export const ThemeSwitcher: React.FC = () => {
           ) : (
             <Moon width="100%" height="100%" />
           )}
+          <span tw="sr-only" aria-live="polite">Toggle {colorMode === "dark" ? "light" : "dark"} mode</span>
         </button>
       )}
     </>


### PR DESCRIPTION
This PR makes a few improvements to the theme switch component that didn't meet some WCAG criterias:

- The theme switch didn't have a visible outline, so users using keyboard navigation couldn't know they're selecting the component. [Success Criterion 2.4.7 (Focus Visible)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html).

	Solution: removed the `focus:outline-none` and added `outline-offset-4` to add some breathing space for the icons.
	
	| Before (focused) | After (focused) |
	| -------- | ----- |
	| <img width="285" height="70" alt="image" src="https://github.com/user-attachments/assets/2003a67e-a4f7-4456-9752-78f8b8c6a36b" /> | <img width="283" height="61" alt="image" src="https://github.com/user-attachments/assets/fd0180e6-2b27-44eb-a28e-edb570efe502" />  |

- The theme switch didn't have any text indication of what it does, so for example, users with impaired vision that depend screen readers couldn't know what the button does. Additionally, there's no indication of its state. [Success Criterion 1.1.1 (Non-text Content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) and [Success Criterion 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

	Solution: added a screen reader-only "Toggle [mode] mode" span, that both indicates the theme switcher is a theme toggler and its state whenever clicked thanks to the added `aria-live="polite"` attribute.
	
	The changes were manually tested using NVDA on Windows. For reference, before the announcement would be "button" and now (assuming you're currently in the dark mode), "button, toggle light mode".
