### PR TITLE
Bring back focus outline to Search component

### DIFF
--- a/src/components/Search/OpenModalButton.tsx
+++ b/src/components/Search/OpenModalButton.tsx
@@ -12,7 +12,7 @@ const OpenModalButton: React.FC = () => {
           tw`flex items-center justify-between space-x-4 w-full`,
           tw`rounded border border-gray-200 cursor-pointer`,
           tw`px-2 py-2 md:py-1 text-gray-300 text-left`,
-          tw`focus:outline-none md:hover:border-pink-300`,
+          tw`md:hover:border-pink-300`,
         ]}
       >
         <div tw="flex items-center space-x-2">


### PR DESCRIPTION
This PR removes `focus:outline-none` from the Search component, making it compliant with [Sucess Criterion 2.4.7 (Focus Visible)](https://www.w3.org/WAI/WCAG21/Understanding/focus-visible.html).

| Before (focused)  | After (focused) |
| -------- | ----- |
| <img width="285" height="128" alt="image" src="https://github.com/user-attachments/assets/c1be0e0e-e74b-4cb2-9252-f0737674e3b2" /> | <img width="284" height="121" alt="image" src="https://github.com/user-attachments/assets/e54131a5-aafa-450d-9ec4-ca7460546bdd" />  |