### PR TITLE
Add screen reader text to mobile docs home link

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -54,6 +54,7 @@ export const MobileNav: React.FC = () => {
       >
         <Link href="/">
           <Logo tw="w-10 h-10" />
+          <span tw="sr-only">Docs</span>
         </Link>
 
         <div tw="w-full block">


### PR DESCRIPTION
This PR adds an screen reader-only `<span>` with "Docs" (it could also be something like "Home" if you prefer, I went with "Docs" so it matches the desktop link) so that the mobile Railway logo link has descriptive text for assistive technologies to use, making it compliant with [Success Criterion 1.1.1 (Non-text content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html).

The accessibility was manually tested using NVDA on Windows. NVDA announces the base URL for the case of links without accompanying text, but that does not happen for every assistive technology, therefore the need to add the extra text.

P.S.: sorry for the many one-line PRs, I am doing so to keep them focused and avoid merge conflicts in case someone merges something else in the components/content changed in one my PRs. Done for today, but I'll be pushing some improvements to the hamburger menu and content next.