### PR TITLE
Improve mobile menu accessibility

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -62,8 +62,14 @@ export const MobileNav: React.FC = () => {
         </div>
 
         <div tw="flex items-center space-x-4 md:space-x-4">
+          <div tw="flex items-center">
+            <ThemeSwitcher />
+          </div>
+
           <button
-            tw=" w-6 h-6 md:w-4 md:h-4 cursor-pointer focus:outline-none"
+            tw="w-6 h-6 md:w-4 md:h-4 cursor-pointer outline-offset-4"
+            aria-label="Menu"
+            aria-expanded={isNavOpen}
             onClick={() => setIsNavOpen(!isNavOpen)}
           >
             {isNavOpen ? (
@@ -72,10 +78,6 @@ export const MobileNav: React.FC = () => {
               <Menu width="100%" height="100%" />
             )}
           </button>
-
-          <div tw="flex items-center">
-            <ThemeSwitcher />
-          </div>
         </div>
       </header>
 


### PR DESCRIPTION
This PR makes a few improvements to the mobile menu that didn't meet some WCAG criterias:

- The mobile menu didn't have a visible outline, so users using keyboard navigation couldn't know they're selecting the menu. [Success Criterion 2.4.7 (Focus Visible)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/navigation-mechanisms-focus-visible.html).

	| Before (focused) | After (focused) |
	| -------- | ----- |
	| <img width="531" height="63" alt="image" src="https://github.com/user-attachments/assets/ee656f71-9d2d-4f3d-b413-5b3285275c3d" /> | <img width="531" height="70" alt="image" src="https://github.com/user-attachments/assets/7937db19-196d-4d2c-a113-7045175bebbe" />  |

	Solution: removed the `focus:outline-none` and added `outline-offset-4` to add some breathing space for the icons.
	
- The mobile menu didn't have any text indication of what it does, so for example, users with impaired vision that depend screen readers couldn't know what the button does. Additionally, there's no indication of its state. [Success Criterion 1.1.1 (Non-text Content)](https://www.w3.org/WAI/WCAG21/Understanding/non-text-content.html) and [Success Criterion 4.1.2 (Name, Role, Value)](https://www.w3.org/WAI/WCAG21/Understanding/name-role-value.html).

	Solution: added `aria-label="Menu"` to indicate its a menu to assistive technologies and added `aria-expanded` to indicate its open/closed state. I've also changed the order of the theme switcher and mobile menu (see image above), so that the sidebar is the next focusable element right after the menu without the need to manually change the focus when the button is expanded.
	
	The changes were manually tested using NVDA on Windows. For reference, before the announcement would be "button" and now (assuming the menu is closed), "menu, button, collected", and after being clicked, "menu, button, expanded".
