### PR TITLE
Miscellaneous improvements to home page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -378,7 +378,7 @@ const Home: NextPage = () => {
             </FrameworkLinkHeading>
           </FrameworkLink>
         </div>
-        <div tw="mt-8 text-left">
+        <div tw="mt-8 text-left w-fit">
           <a
             href="/guides/languages-frameworks"
             className="group"
@@ -804,7 +804,7 @@ const Home: NextPage = () => {
           </FrameworkLink>
         </div>
 
-        <div tw="text-center mt-8">
+        <div tw="text-center mt-8 w-fit">
           <a
             href="https://railway.com/templates"
             className="group"


### PR DESCRIPTION
This PR makes a few miscellaneous improvements to the home page regarding accessibility and copy. Namely:

- Fixes the heading hierarchy from `h1 -> h3` to `h1 -> h2`, which although not a direct WCAG criteria failure, it's a best practice to do so.

- Added the missing `alt=""` to Rocket and MinIO images. Since they're only visual cues and there's text right after with the name, `alt` should be present but empty to avoid redundancy to screen readers.

- Removed redundant `alt` text from the docs sections' images, since the link already contains that same content and the images are only visual fluff, `alt` should be empty.

- Added `w-fit` to the parent container to avoid "View all" links to take the full width.

	| Before (focused) | After (focused) |
	| -------- | ----- |
	| <img width="877" height="409" alt="image" src="https://github.com/user-attachments/assets/f1f4b862-4fae-4096-8dcb-d179e7ef6cf6" /> | <img width="879" height="418" alt="image" src="https://github.com/user-attachments/assets/f4a04e1f-c486-4334-9422-9f4632412431" />  |


- Modified the copy a bit to make it more consistent:
	- Added full stops to the subheadings to match the "Railway Documentation" subheading and decapitalized "Frameworks" and "Templates" since they're not proper nouns.
		| Before | After |
		| -------- | ----- |
		| <img width="887" height="896" alt="image" src="https://github.com/user-attachments/assets/057d7881-3801-431c-b747-f4a91a15be19" /> | <img width="886" height="886" alt="image" src="https://github.com/user-attachments/assets/d36755ef-034a-4705-ae3e-4ed52110a4ba" />  |
		
	- Changed "Edit on GitHub" to "Edit this page on GitHub" to actually match the link's text and capitalized the word "markdown".
		
		| Before | After |
		| -------- | ----- |
		| <img width="514" height="111" alt="image" src="https://github.com/user-attachments/assets/4a0b5ba4-1540-4c03-ba44-5f23ef531da8" /> | <img width="517" height="117" alt="image" src="https://github.com/user-attachments/assets/623397b1-c8d7-4b37-b9bf-021ea74aeea6" />|