### PR TITLE
Announce "copy as Markdown" button state change

### DIFF
--- a/src/layouts/DocsLayout.tsx
+++ b/src/layouts/DocsLayout.tsx
@@ -141,7 +141,7 @@ export const DocsLayout: React.FC<PropsWithChildren<Props>> = ({
                 type="button"
               >
                 <Icon icon={copied ? CheckCircle : Copy} size="sm" />
-                <span>{copied ? "Copied!" : "Copy as Markdown"}</span>
+                <span aria-live="polite">{copied ? "Copied!" : "Copy as Markdown"}</span>
               </button>
             </div>
             {children}


### PR DESCRIPTION
This PR adds an `aria-live="polite"` to the inner content of the "copy as Markdown" button to announce the state change and success in copying the content to assistive technologies.

The changes were tested manually with NVDA on Windows.