### PR TITLE
feat: Clarify image auto updates detection

### DIFF
--- a/src/docs/guides/image-auto-updates.md
+++ b/src/docs/guides/image-auto-updates.md
@@ -19,9 +19,30 @@ Images from other registries (ECR, GCR, ACR, private registries, etc.) do not su
 Railway periodically checks the Docker registry for new versions of your configured image. When an update is available and your maintenance window is active, Railway will:
 
 1. Create a backup of any attached volumes
-2. Update the image in your service configuration to the `:latest` tag
-3. Redeploy your service with the new image
-4. Notify workspace admins of the update
+2. Redeploy your service with the updated image
+3. Notify workspace admins of the update
+
+### Update Behavior by Tag Type
+
+How Railway handles updates depends on the type of tag you've configured:
+
+#### Semantic version tags
+
+For tags like `:v1.2.3` or `:1.0.0`, Railway checks for newer versions and updates your service configuration to the new tag (e.g., `:v1.2.3` -> `:v1.2.4`).
+
+You can choose your update preference in the auto updates settings either **patches only** or **minor updates and patches**:
+
+![Update preference setting](https://res.cloudinary.com/railway/image/upload/v1767974860/UpdateVersions_kodl8s.png)
+
+When a new version matching your preference is detected, you'll see a notification:
+
+![Patch version available](https://res.cloudinary.com/railway/image/upload/v1767971527/patchversion_nwjxpm.png)
+
+#### Non-semantic version tags
+
+For tags like `:latest`, `:canary`, or `:staging`, Railway monitors for new image pushes to that specific tag. When a new image is pushed (same tag, different SHA), Railway redeploys your service.
+
+Your configured tag is always preserved. Railway does **not** switch non-semver tags to `:latest`. If you configure `:canary`, Railway only redeploys when a new image is pushed to `:canary`.
 
 ## Configure Auto Updates
 


### PR DESCRIPTION
Some users were concerned about how semver vs regular tags would work.

Clarified how that flow works and how we would ensure nothing is overwritten.