### PR TITLE
Add missing id to non-page subheadings

### DIFF
--- a/src/components/SidebarItem.tsx
+++ b/src/components/SidebarItem.tsx
@@ -102,6 +102,7 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
         typeof subTitle === "string" ? (
           <span
             onClick={onToggleSubSection}
+            id={`sidebar-subtitle-${slugify(subTitle)}`}
             css={[
               tw`text-gray-700 flex-grow`,
               tw`hover:cursor-pointer`,


### PR DESCRIPTION
This PR is a follow-up to https://github.com/railwayapp/docs/pull/983, a few of the subsection buttons were still unaccessible because I forgot to add `id` for subsections that aren't an individual page as well.