### PR TITLE
Fix GitLab capitalization

### DIFF
--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -216,10 +216,10 @@ export const sidebarContent: ISidebarContent = [
         ],
       },
       {
-        subTitle: "Gitlab",
+        subTitle: "GitLab",
         pages: [
           {
-            title: "Gitlab CI/CD with Railway",
+            title: "GitLab CI/CD with Railway",
             url: "https://blog.railway.com/p/gitlab-ci-cd",
           },
         ],

--- a/src/docs/maturity/philosophy.md
+++ b/src/docs/maturity/philosophy.md
@@ -46,7 +46,7 @@ That's why we've designed the platform for flexibility, wherever you need it.
 
 On Railway, you can use the default pattern for deployment or opt to use vendor. In fact, we will even support you in your effort to integrate Railway in a unique way. Here are a couple of use cases we've helped customers take advantage of -
 
-- Deploying to Railway from Gitlab CI/CD
+- Deploying to Railway from GitLab CI/CD
 - Supporting the development of a Terraform provider
 - Region based routing to workloads via Cloudflare
 


### PR DESCRIPTION
This PR fixes the capitalization of "GitLab" in a few places, from `Gitlab` -> `GitLab`, which is the official way it's written.