### PR TITLE
Fix "About Railway" heading structure

### DIFF
--- a/src/docs/overview/about-railway.md
+++ b/src/docs/overview/about-railway.md
@@ -9,12 +9,12 @@ Railway is a deployment platform designed to streamline the software development
 
 Point Railway to your deployment source and let the platform handle the rest.
 
-#### Flexible Deployment Sources
+**Flexible Deployment Sources**
 
 - **Code Repositories**: With or without Dockerfiles. Railway will build an [OCI compliant image](https://opencontainers.org/) based on what you provide.
 - **Docker Images**: Directly from Docker Hub, GitHub Container Registry, GitLab Container Registry, Microsoft Container Registry, or Quay.io. We support public and private image registries.
 
-#### Hassle-Free Setup
+**Hassle-Free Setup**
 
 - **Sane Defaults**: Out of the box, your project is deployed with sane defaults to get you up and running as fast as possible.
 - **Configuration Tuning**: When you're ready, there are plenty of knobs and switches to optimize as needed.
@@ -23,16 +23,16 @@ Point Railway to your deployment source and let the platform handle the rest.
 
 Software development extends far beyond code deployment. Railway's feature set is tailor-made, and continuously evolving, to provide the best developer experience we can imagine.
 
-#### Configuration Management
+**Configuration Management**
 
 - **Variables & Secrets**: Easily manage configuration values and sensitive data with variable management tools.
 
-#### Environment and Workflow
+**Environment and Workflow**
 
 - **Environment Management**: Create both static and ephemeral environments to create workflows that complement your processes.
 - **Orchestration & Tooling**: Build Railway into any workflow using our CLI or API.
 
-#### Deployment Monitoring
+**Deployment Monitoring**
 
 - **Observability**: Keep a pulse on your deployments with Railway's built-in observability tools.
 


### PR DESCRIPTION
This PR fixes the heading structure of the "About Railway" docs page. The content was jumping from an `h2` to `h4` which breaks the content hierarchy, can confuse assistive technologies and AI, etc.

I have changed the `h4` for bold paragraphs, which keeps the same styling. Of course, these won't appear in the "On This Page" as headings anymore. If there are strong feelings about having them do appear as headings, the best solution would be manual `h3` elements styled to the same font size as an `h4`.

| Before | After  |
| -------- | ----- |
| <img width="1377" height="1031" alt="image" src="https://github.com/user-attachments/assets/65374e48-a45e-4c2f-9a65-4bcec4a15385" /> | <img width="1425" height="1025" alt="image" src="https://github.com/user-attachments/assets/a00e137d-c22c-4e59-83ac-d19ff82a4388" />  |

This issue is also present in a few other pages and I plan to do a PR fixing all occurances if there are no objections about doing so.