### PR TITLE
Fix "Foundations" pages heading structure

### DIFF
--- a/src/docs/guides/environments.md
+++ b/src/docs/guides/environments.md
@@ -49,11 +49,11 @@ width={1622} height={506} quality={80} />
 
 When enabled, a temporary environment is spun up to support the Pull Request deploy. These environments are deleted as soon as these PRs are merged or closed.
 
-#### How Come my GitHub PR Won't Deploy?
+**How Come my GitHub PR Won't Deploy?**
 
 Railway will not deploy a PR branch from a user who is not in your team or invited to your project without their associated GitHub account.
 
-#### Domains in PR Environments
+**Domains in PR Environments**
 
 To enable automatic domain provisioning in PR environments, ensure that services in your base environment use Railway-provided domains. Services in PR environments will only receive domains automatically when their corresponding base environment services have Railway-provided domains.
 

--- a/src/docs/guides/foundations.md
+++ b/src/docs/guides/foundations.md
@@ -7,16 +7,13 @@ Welcome! Let's get started building in Railway!
 
 To start, you should be familiar with the core components and features of the platform. Therefore, the goal of this section is to guide you through the steps of laying a solid foundation on which to iterate.
 
-#### Core Components
-
-|                  |                                                                                                                                                                                                                                                                         |
-| ---------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **Projects**     | A Project is like an application stack, or a system of related components. Everything needed by the components in the system are encapsulated in a Project, including environments and variables.                                                                       |
-| **Services**     | Services are components that make up the Project - frontend web servers, backend APIs, message queues, databases, etc. Services can be configured with [variables](/guides/variables), start and run commands, restart policies, [volume mounts](/guides/volumes), etc. |
-| **Variables**    | Variable management is an essential part of development operations. Variables can be scoped to both Services and Environments in Railway.                                                                                                                               |
-| **Environments** | Environments exist within a Project and are useful for maintaining separation between Production and Development environments.                                                                                                                                          |
-| **CLI**          | The CLI is handy for local development, used for things like running services locally using variables stored in Railway, deploying local code repositories, etc.                                                                                                        |
-|                  |                                                                                                                                                                                                                                                                         |
+| Concept | Description |
+| :------ | :---------- |
+| **Projects** | A Project is like an application stack, or a system of related components. Everything needed by the components in the system are encapsulated in a Project, including environments and variables. |
+| **Services** | Services are components that make up the Project - frontend web servers, backend APIs, message queues, databases, etc. Services can be configured with [variables](/guides/variables), start and run commands, restart policies, [volume mounts](/guides/volumes), etc. |
+| **Variables** | Variable management is an essential part of development operations. Variables can be scoped to both Services and Environments in Railway. |
+| **Environments** | Environments exist within a Project and are useful for maintaining separation between Production and Development environments. |
+| **CLI** | The CLI is handy for local development, used for things like running services locally using variables stored in Railway, deploying local code repositories, etc. |
 
 The next pages will go through how to create and manage your Projects, Services, Variables, and Environments. They will also explain how to use Volumes to persist your data and how to install and use the CLI.
 

--- a/src/docs/guides/projects.md
+++ b/src/docs/guides/projects.md
@@ -51,7 +51,7 @@ Each project generates a project invite link. To invite someone via a link:
 
 Depending on your plan, you can transfer Projects to other users or Teams.
 
-#### Hobby User to Hobby User
+**Hobby User to Hobby User**
 
 To transfer a project from one Hobby User to another Hobby User, you must first [add the user as a member](#inviting-members) in the project.
 
@@ -64,7 +64,7 @@ width={411} height={253} quality={80} />
 
 The transferee receives an email requesting to transfer the project.
 
-#### Hobby User to Team || Team to Team
+**Hobby User to Team or Team to Team**
 
 You can transfer a Project in your Hobby workspace to a Team (or between Teams) in which you are an Admin. Inside your project, visit the `Settings` page and click the `Transfer Project` button to view the project transfer modal.
 

--- a/src/docs/guides/staged-changes.md
+++ b/src/docs/guides/staged-changes.md
@@ -7,7 +7,7 @@ Changes made in your Railway project, like adding, removing, or making changes t
 
 It is important to be familiar with this flow as you explore the upcoming guides.
 
-### What to Expect
+## What to Expect
 
 As you create or update components within your project:
 
@@ -19,7 +19,7 @@ As you create or update components within your project:
             layout="responsive"
             width={1400} height={720} quality={100} />
 
-### Review and Deploy Changes
+## Review and Deploy Changes
 
 To review the staged changes, click the "Details" button in the banner. Here, you will see a diff of old and new values. You can discard a change by clicking the "x" to the right of the change.
 
@@ -34,7 +34,7 @@ Clicking "Deploy" will deploy all of the changes at once. Any services that are 
 
 Holding the "Alt" key while clicking the "Deploy" button allows you to commit the changes without triggering a redeploy.
 
-### Caveats
+## Caveats
 
 - Networking changes are not yet staged and are applied immediately
 - Adding databases or templates will only affect the current environment. However, they do not yet create a commit in the history

--- a/src/docs/guides/variables.md
+++ b/src/docs/guides/variables.md
@@ -25,7 +25,7 @@ alt="Screenshot of Variables Pane"
 layout="responsive"
 width={2026} height={933} quality={100} />
 
-#### Define a Service Variable
+**Define a Service Variable**
 
 From a service's variables tab, click on `New Variable` to enter your variable into a form field, or use the `RAW Editor` to paste the contents of your `.env` or json-formatted file.
 
@@ -53,11 +53,11 @@ alt="Screenshot of Shared Variables Settings"
 layout="responsive"
 width={2402} height={1388} quality={100} />
 
-#### Define a Shared Variable
+**Define a Shared Variable**
 
 From your Project Settings -> Shared Variables page, choose the Environment, enter the variable name and value, and click `Add`.
 
-#### Use a Shared Variable
+**Use a Shared Variable**
 
 To use a shared variable, either click the Share button from the Project Settings -> Shared Variables menu and select the services with which to share, or visit the Variables tab within the service itself and click "Shared Variable".
 
@@ -174,7 +174,7 @@ For example, in a node app -
 process.env.VARIABLE_NAME;
 ```
 
-#### Local Development
+**Local Development**
 
 Using the Railway CLI, you can run your code locally with the environment variables configured in your Railway project.
 


### PR DESCRIPTION
This PR fixes the heading structure of pages under "Foundations". The content was jumping from an h2 to h4 which breaks the content hierarchy, can confuse assistive technologies and AI, etc. 

This is a follow-up to https://github.com/railwayapp/docs/pull/991 and will be split into a couple PRs to simplify reviewing.