### PR TITLE
Add missing whitespace in `services.md`

### DIFF
--- a/src/docs/guides/services.md
+++ b/src/docs/guides/services.md
@@ -9,7 +9,7 @@ _As you create and manage your services, your changes will be collected in a set
 
 ## Creating a Service
 
-Create a service by clicking the `New` button in the top right corner of your project canvas, or by typing new service from the **command palette**, accessible via `CMD + K` (Mac) or `Ctrl + K`(Windows).
+Create a service by clicking the `New` button in the top right corner of your project canvas, or by typing new service from the **command palette**, accessible via `CMD + K` (Mac) or `Ctrl + K` (Windows).
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1656640995/docs/CleanShot_2022-06-30_at_18.17.31_cl0wlr.gif"
 alt="GIF of the Services view"


### PR DESCRIPTION
This PR adds a missing whitespace in the "Managing Services" guide:

- **Before:** "`Ctrl + K`(Windows)."
- **After:** "`Ctrl + K` (Windows)."