### PR TITLE
docs: clarify dockerfilePath is relative to service Root directory

### DIFF
--- a/src/docs/reference/config-as-code.md
+++ b/src/docs/reference/config-as-code.md
@@ -103,6 +103,10 @@ Location of non-standard Dockerfile.
 }
 ```
 
+**Path resolution:** `dockerfilePath` is resolved relative to the service’s Root Directory (Service Settings → Root Directory). If Root Directory is not set, it’s relative to the repository root.
+
+**Build context:** The Docker build context is the same Root Directory used for the service build.
+
 This field can be set to `null`.
 
 More about building from a Dockerfile [here](/reference/dockerfiles).


### PR DESCRIPTION
Fixes #960

Clarifies that dockerfilePath is resolved relative to the service Root Directory (or repo root if unset), and that build context matches Root Directory.