### PR TITLE
Make use of pathlib.Path for static file settings

### DIFF
--- a/content/guides/django.md
+++ b/content/guides/django.md
@@ -128,8 +128,8 @@ Open `liftoff/settings.py` and configure the static files settings:
 ```python
 STATIC_URL = 'static/'
 
-STATIC_ROOT = os.path.join(BASE_DIR, "staticfiles")
-STATICFILES_DIRS = [os.path.join(BASE_DIR, "static")]
+STATIC_ROOT = BASE_DIR / "staticfiles"
+STATICFILES_DIRS = [BASE_DIR / "static"]
 ```
 
 Add the WhiteNoise middleware in the **MIDDLEWARE** section, just below the [security middleware](https://docs.djangoproject.com/en/5.1/ref/middleware/#module-django.middleware.security):


### PR DESCRIPTION
Django is using pathlib.Path for BASE_DIR since 3.1

> The settings.py generated by the startproject command now uses pathlib.Path instead of os.path for building filesystem paths.

https://docs.djangoproject.com/en/stable/releases/3.1/#miscellaneous

> The STATICFILES_DIRS setting now supports pathlib.Path.

https://docs.djangoproject.com/en/stable/releases/3.1/#django-contrib-staticfiles