### PR TITLE
nit: updating volume limits per project to match the pricing page

### DIFF
--- a/content/docs/volumes/reference.md
+++ b/content/docs/volumes/reference.md
@@ -32,7 +32,7 @@ Each project has a maximum number of volumes that can be created, based on your 
 | **Free** | **1** |
 | **Trial** | **3** |
 | **Hobby** | **10** |
-| **Pro** | **20, can be increased; see below** |
+| **Pro** | **20, can be increased** |
 | **Enterprise** | **Unlimited** |
 
 Volumes created for the same service in another environment do not count towards this limit.

--- a/content/docs/volumes/reference.md
+++ b/content/docs/volumes/reference.md
@@ -32,7 +32,8 @@ Each project has a maximum number of volumes that can be created, based on your 
 | **Free** | **1** |
 | **Trial** | **3** |
 | **Hobby** | **10** |
-| **Pro** | **20** |
+| **Pro** | **20, can be increased; see below** |
+| **Enterprise** | **Unlimited** |
 
 Volumes created for the same service in another environment do not count towards this limit.
 


### PR DESCRIPTION
## Summary of changes 

Saw [this tweet](https://x.com/SivaramPg/status/2039185873917644881) and thought it would be worth updating the docs to match [the pricing page](https://railway.com/pricing) *exactly*. After checking, the pricing page already reflects the same limit as the docs, so no changes were needed there.

The only substantive changes here are:
- updating the pro plan to match the pricing page and reflect a soft-limit.
- adding the unlimited volumes-per-project row for users on the enterprise plan.

