### PR TITLE
docs: add free tier peak hours restriction

### DIFF
--- a/content/docs/deployments/reference.md
+++ b/content/docs/deployments/reference.md
@@ -150,6 +150,28 @@ We perform these migrations when implementing security patches or platform upgra
 
 These Railway-initiated deployments will display with a banner above the Active deployment to clearly identify them.
 
+## Free tier peak hours restriction
+
+To ensure platform reliability during high-demand periods, free-tier deployments are restricted during peak hours in each region's local timezone.
+
+### Peak hours by region
+
+| Region              | Timezone             | Peak Hours        |
+| ------------------- | -------------------- | ----------------- |
+| **US West**         | America/Los_Angeles  | 8 AM – 8 PM PT   |
+| **US East**         | America/New_York     | 8 AM – 8 PM ET   |
+| **EU West**         | Europe/Amsterdam     | 8 AM – 8 PM CET  |
+| **Southeast Asia**  | Asia/Singapore       | 8 AM – 8 PM SGT  |
+
+During these windows, deploys from free-tier users to the affected region will be rejected. You will see an error message indicating the restriction and the region's timezone.
+
+Hobby, Pro, and Enterprise plans are not affected by this restriction and can deploy at any time.
+
+### Options during peak hours
+
+- **Wait** — deploy outside of peak hours for your target region.
+- **Upgrade** — upgrade to the Hobby plan or above to remove the restriction entirely.
+
 ## Deployments paused - limited access
 
 Railway's core offering is dynamic, allowing you to vertically or horizontally scale with little-to-no-notice. To offer this flexibility to customers, Railway takes the stance that Pro/Enterprise tiers may, in rare occasions, be prioritized above Free/Hobby tiers.


### PR DESCRIPTION
## Summary
- Documents the new free-tier peak hours deploy restriction on the deployments reference page
- Adds a table showing peak hours (8 AM – 8 PM) per region with local timezones
- Lists options for users affected by the restriction (wait or upgrade)
- Placed above the existing "Deployments paused - limited access" section since both cover free-tier limitations

Companion to railwayapp/mono#27379.

## Test plan
- [ ] Verify the page renders correctly with the new table
- [ ] Confirm section anchors work for direct linking

🤖 Generated with [Claude Code](https://claude.com/claude-code)