### PR TITLE
Fix guides SEO: canonical URL default, article headline, and listing page schema

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 import { DefaultSeo, NextSeo, NextSeoProps, DefaultSeoProps } from "next-seo";
 import Head from "next/head";
+import { useRouter } from "next/router";
 import { Header } from "@/utils/seo";
 
 export interface Props extends NextSeoProps {
@@ -14,6 +15,8 @@ export interface Props extends NextSeoProps {
   lastModified?: string;
   author?: string;
   publishedTime?: string;
+  headline?: string;
+  noArticleSchema?: boolean;
 }
 
 const title = "Railway Docs";
@@ -45,12 +48,15 @@ export const SEO: React.FC<Props> = ({
   lastModified,
   author = "Railway",
   publishedTime,
+  headline,
+  noArticleSchema,
   ...props
 }) => {
+  const router = useRouter();
   const title = props.title ?? config.title;
   const twitterTitle = props.twitterTitle;
   const description = props.description;
-  const url = props.url || config.openGraph?.url;
+  const url = props.url || `${baseUrl}${router.asPath.split("?")[0].split("#")[0]}`;
 
   // Check if any headers are questions (for FAQPage schema)
   const hasQuestions = headers.some(h => h.title.trim().endsWith("?"));
@@ -102,34 +108,36 @@ export const SEO: React.FC<Props> = ({
   }
 
   // Article schema
-  const articleSchema = {
-    "@context": "https://schema.org",
-    "@type": "Article",
-    headline: title,
-    description: description,
-    url: url,
-    author: {
-      "@type": "Organization",
-      name: author,
-    },
-    publisher: {
-      "@type": "Organization",
-      name: "Railway",
-      logo: {
-        "@type": "ImageObject",
-        url: "https://docs.railway.com/railway.svg",
+  if (!noArticleSchema) {
+    const articleSchema = {
+      "@context": "https://schema.org",
+      "@type": "Article",
+      headline: headline || title,
+      description: description,
+      url: url,
+      author: {
+        "@type": "Organization",
+        name: author,
       },
-    },
-    ...(publishedTime && { datePublished: publishedTime }),
-    ...(lastModified && { dateModified: lastModified }),
-    ...(image && {
-      image: {
-        "@type": "ImageObject",
-        url: image,
+      publisher: {
+        "@type": "Organization",
+        name: "Railway",
+        logo: {
+          "@type": "ImageObject",
+          url: "https://docs.railway.com/railway.svg",
+        },
       },
-    }),
-  };
-  schemas.push(articleSchema);
+      ...(publishedTime && { datePublished: publishedTime }),
+      ...(lastModified && { dateModified: lastModified }),
+      ...(image && {
+        image: {
+          "@type": "ImageObject",
+          url: image,
+        },
+      }),
+    };
+    schemas.push(articleSchema);
+  }
 
   // FAQPage schema (if questions exist)
   if (hasQuestions && questionHeaders.length > 0) {

--- a/src/layouts/guides-layout.tsx
+++ b/src/layouts/guides-layout.tsx
@@ -85,6 +85,7 @@ export const GuidesLayout: React.FC<PropsWithChildren<GuidesLayoutProps>> = ({
         url={`${domainUrl}${frontMatter.url}`}
         image={getOGImage(frontMatter.title)}
         headers={headers}
+        headline={frontMatter.title}
         breadcrumbs={[
           { name: "Guides", url: "/guides" },
           { name: frontMatter.title },

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -415,6 +415,7 @@ const GuidesPage: NextPage<GuidesPageProps> = ({ guides }) => {
         title="Guides | Railway"
         description="In-depth guides, tutorials, and how-tos for deploying on Railway"
         url="https://docs.railway.com/guides"
+        noArticleSchema
         breadcrumbs={[
           { name: "Home", url: "/" },
           { name: "Guides", url: "/guides" },


### PR DESCRIPTION
## Summary
- Auto-derive canonical URL from router pathname when not explicitly passed to SEO component
- Add `headline` prop so Article schema uses the article title (e.g. "Deploy an Astro App"), not the suffixed page title ("Deploy an Astro App | Railway Guides")
- Add `noArticleSchema` prop; use on `/guides` listing page to emit only CollectionPage schema instead of also emitting an Article schema

## Files
- `src/components/seo.tsx`
- `src/layouts/guides-layout.tsx`
- `src/pages/guides/index.tsx`