### PR TITLE
fix restartPolicyType in CAC JSON example

### DIFF
--- a/content/docs/config-as-code.md
+++ b/content/docs/config-as-code.md
@@ -29,7 +29,7 @@ preDeployCommand = ["npm run db:migrate"]
 startCommand = "echo starting!"
 healthcheckPath = "/"
 healthcheckTimeout = 100
-restartPolicyType = "never"`}
+restartPolicyType = "NEVER"`}
   </CodeTab>
   <CodeTab label="railway.json" lang="json">
 {`{


### PR DESCRIPTION
`restartPolicyType` in config-as-code for `railway.json` only accepts the following:

- `ON_FAILURE`
- `ALWAYS`
- `NEVER`

instead of `never`