### PR TITLE
Add AI topic and 11 AI/agent guides

### DIFF
--- a/content/guides/ai-agent-workers.md
+++ b/content/guides/ai-agent-workers.md
@@ -7,7 +7,7 @@ tags:
   - ai
   - workers
   - agents
-topic: architecture
+topic: ai
 ---
 
 AI agents that call LLM APIs, execute tools, and manage multi-step workflows need async processing. A single HTTP request cannot stay open long enough for an agent that takes minutes to reason through a task. This guide covers how to deploy an agent architecture on Railway using an API service, Redis-backed workers, and Postgres for state.

--- a/content/guides/ai-agent-workers.md
+++ b/content/guides/ai-agent-workers.md
@@ -4,7 +4,6 @@ description: Run AI agent workflows on Railway with an API service, async worker
 date: "2026-03-30"
 tags:
   - architecture
-  - ai
   - workers
   - agents
 topic: ai

--- a/content/guides/ai-api-proxy.md
+++ b/content/guides/ai-api-proxy.md
@@ -1,0 +1,143 @@
+---
+title: Deploy an AI API Gateway
+description: Deploy LiteLLM Proxy on Railway as a unified gateway for multiple LLM providers. Covers model routing, cost tracking, API key management, caching with Redis, and private networking.
+date: "2026-04-14"
+tags:
+  - ai
+  - gateway
+  - api
+  - proxy
+  - python
+topic: ai
+---
+
+As AI applications scale, managing multiple LLM providers becomes complex. Different services may use different providers, API keys rotate, costs are hard to track, and a single provider outage can take down your entire application.
+
+An AI API gateway sits between your services and LLM providers. It provides a single endpoint with a unified API, model routing, cost tracking, rate limiting, and provider failover.
+
+[LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) is the most widely used open-source option. It exposes an OpenAI-compatible API that routes requests to 100+ LLM providers.
+
+## Architecture
+
+- **LiteLLM Proxy** runs as a Railway service with no public domain. Other services in the project call it over [private networking](/networking/private-networking).
+- **Redis** (optional) provides response caching to reduce API costs and latency.
+- **Postgres** (optional) stores request logs and cost data for analytics.
+
+Your application services send requests to the proxy's internal URL instead of directly to OpenAI, Anthropic, or other providers.
+
+## Prerequisites
+
+- A Railway account
+- API keys for one or more LLM providers
+
+## 1. Create the project and proxy service
+
+1. Create a new [project](/projects) on Railway.
+2. Click **+ New > Docker Image**.
+3. Enter `ghcr.io/berriai/litellm:main-latest` as the image name.
+
+## 2. Configure the proxy
+
+Create a `litellm_config.yaml` file in a repository or mount it via environment variables. A minimal configuration:
+
+```yaml
+model_list:
+  - model_name: gpt-4o
+    litellm_params:
+      model: openai/gpt-4o
+      api_key: os.environ/OPENAI_API_KEY
+
+  - model_name: claude-sonnet
+    litellm_params:
+      model: anthropic/claude-sonnet-4-20250514
+      api_key: os.environ/ANTHROPIC_API_KEY
+
+  - model_name: gpt-4o-mini
+    litellm_params:
+      model: openai/gpt-4o-mini
+      api_key: os.environ/OPENAI_API_KEY
+```
+
+Set the following environment variables on the proxy service:
+
+| Variable | Value |
+| --- | --- |
+| `OPENAI_API_KEY` | Your OpenAI API key |
+| `ANTHROPIC_API_KEY` | Your Anthropic API key |
+| `LITELLM_MASTER_KEY` | A secret key for proxy admin access |
+| `PORT` | `${{PORT}}` |
+
+If deploying from a repository with the config file, set the start command to:
+
+```
+litellm --config litellm_config.yaml --port $PORT --host 0.0.0.0
+```
+
+## 3. Keep the proxy internal
+
+The proxy should not be publicly accessible. Do not generate a public domain for it. Other services in the same project reach it via [private networking](/networking/private-networking) at:
+
+```
+http://litellm-proxy.railway.internal:PORT
+```
+
+Replace `litellm-proxy` with your service name and `PORT` with the port number shown in the service's networking settings.
+
+## 4. Connect your services
+
+Update your application services to point at the proxy instead of directly at LLM providers. Since LiteLLM exposes an OpenAI-compatible API, you only need to change the base URL:
+
+```python
+from openai import OpenAI
+
+client = OpenAI(
+    base_url="http://litellm-proxy.railway.internal:8000/v1",
+    api_key="your-litellm-master-key",
+)
+
+response = client.chat.completions.create(
+    model="gpt-4o",  # Routed by the proxy to the configured provider
+    messages=[{"role": "user", "content": "Hello"}],
+)
+```
+
+Any OpenAI SDK client (Python, Node.js, Go) works with the proxy by changing `base_url`.
+
+## 5. Add Redis for caching
+
+Response caching reduces costs by returning cached results for identical requests:
+
+1. Add [Redis](/databases/redis) to your project.
+2. Add the Redis connection to the proxy's environment variables:
+
+| Variable | Value |
+| --- | --- |
+| `REDIS_HOST` | `${{Redis.REDISHOST}}` |
+| `REDIS_PORT` | `${{Redis.REDISPORT}}` |
+| `REDIS_PASSWORD` | `${{Redis.REDISPASSWORD}}` |
+
+3. Enable caching in your `litellm_config.yaml`:
+
+```yaml
+litellm_settings:
+  cache: true
+  cache_params:
+    type: redis
+```
+
+## 6. Track costs
+
+LiteLLM logs request metadata including token counts and estimated costs. To persist this data, add [Postgres](/databases/postgresql) and set:
+
+| Variable | Value |
+| --- | --- |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` |
+
+LiteLLM automatically creates its logging tables on first connection. Access cost data through the LiteLLM admin UI or query the database directly.
+
+## Next steps
+
+- [Deploy an AI-Powered SaaS App](/guides/deploy-ai-saas): Build a product that uses the gateway.
+- [Private Networking](/networking/private-networking): How services communicate within a project.
+- [Redis on Railway](/databases/redis): Persistence settings and memory management.
+- [PostgreSQL on Railway](/databases/postgresql): Connection pooling, backups, and configuration.

--- a/content/guides/ai-api-proxy.md
+++ b/content/guides/ai-api-proxy.md
@@ -3,7 +3,6 @@ title: Deploy an AI API Gateway
 description: Deploy LiteLLM Proxy on Railway as a unified gateway for multiple LLM providers. Covers model routing, cost tracking, API key management, caching with Redis, and private networking.
 date: "2026-04-14"
 tags:
-  - ai
   - gateway
   - api
   - proxy

--- a/content/guides/ai-api-proxy.md
+++ b/content/guides/ai-api-proxy.md
@@ -29,15 +29,11 @@ Your application services send requests to the proxy's internal URL instead of d
 - A Railway account
 - API keys for one or more LLM providers
 
-## 1. Create the project and proxy service
+## 1. Create the proxy repository
 
-1. Create a new [project](/projects) on Railway.
-2. Click **+ New > Docker Image**.
-3. Enter `ghcr.io/berriai/litellm:main-latest` as the image name.
+Create a new repository with two files:
 
-## 2. Configure the proxy
-
-Create a `litellm_config.yaml` file in a repository or mount it via environment variables. A minimal configuration:
+**litellm_config.yaml:**
 
 ```yaml
 model_list:
@@ -57,20 +53,27 @@ model_list:
       api_key: os.environ/OPENAI_API_KEY
 ```
 
-Set the following environment variables on the proxy service:
+**Dockerfile:**
+
+```dockerfile
+FROM ghcr.io/berriai/litellm:main-latest
+COPY litellm_config.yaml /app/config.yaml
+CMD ["--config", "/app/config.yaml", "--port", "8000", "--host", "0.0.0.0"]
+```
+
+## 2. Deploy the proxy
+
+1. Create a new [project](/projects) on Railway.
+2. Click **+ New > GitHub Repo** and select your proxy repository.
+3. Set the following environment variables on the proxy service:
 
 | Variable | Value |
 | --- | --- |
 | `OPENAI_API_KEY` | Your OpenAI API key |
 | `ANTHROPIC_API_KEY` | Your Anthropic API key |
 | `LITELLM_MASTER_KEY` | A secret key for proxy admin access |
-| `PORT` | `${{PORT}}` |
 
-If deploying from a repository with the config file, set the start command to:
-
-```
-litellm --config litellm_config.yaml --port $PORT --host 0.0.0.0
-```
+4. Railway builds the Dockerfile and starts the proxy.
 
 ## 3. Keep the proxy internal
 

--- a/content/guides/ai-chatbot-streaming.md
+++ b/content/guides/ai-chatbot-streaming.md
@@ -28,7 +28,19 @@ Railway is a CPU-based platform. The chatbot calls external LLM APIs over HTTP, 
 - An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
 - A Next.js app with the AI SDK installed, or a willingness to start from the AI SDK's [chat template](https://github.com/vercel/ai-chatbot)
 
-## 1. Set up the chat API route
+## 1. Create the project
+
+If you do not already have a Next.js app, create one and install the AI SDK:
+
+```bash
+npx create-next-app@latest my-chatbot --app --typescript
+cd my-chatbot
+npm install ai @ai-sdk/openai @ai-sdk/react
+```
+
+To use Anthropic instead of OpenAI, install `@ai-sdk/anthropic` in place of `@ai-sdk/openai`.
+
+## 2. Set up the chat API route
 
 The AI SDK provides a `streamText` function that calls the LLM and returns a streaming response. Create an API route that uses it:
 
@@ -60,7 +72,7 @@ const result = streamText({
 });
 ```
 
-## 2. Set up the chat UI
+## 3. Set up the chat UI
 
 The AI SDK's `useChat` hook manages the message list, input state, and SSE connection:
 
@@ -90,7 +102,7 @@ export default function Chat() {
 
 `useChat` sends a POST request to `/api/chat` and reads the streamed response. Tokens appear in the UI as they arrive.
 
-## 3. Deploy to Railway
+## 4. Deploy to Railway
 
 1. Push your code to a GitHub repository.
 2. Create a new [project](/projects) on Railway.

--- a/content/guides/ai-chatbot-streaming.md
+++ b/content/guides/ai-chatbot-streaming.md
@@ -1,0 +1,141 @@
+---
+title: Deploy an AI Chatbot with Streaming Responses
+description: Deploy a chatbot on Railway that streams LLM responses token by token using Server-Sent Events. Covers Next.js with the AI SDK, API key management, and optional conversation persistence with Postgres.
+date: "2026-04-14"
+tags:
+  - ai
+  - chatbot
+  - streaming
+  - sse
+  - nextjs
+topic: ai
+---
+
+This guide covers deploying a chatbot on Railway that streams responses from an LLM API (OpenAI or Anthropic) to the browser using Server-Sent Events. The chatbot uses Next.js with the [Vercel AI SDK](https://sdk.vercel.ai), which handles the streaming protocol on both the server and client.
+
+Railway is a CPU-based platform. The chatbot calls external LLM APIs over HTTP, it does not run models locally.
+
+## What you will set up
+
+- A Next.js app with a streaming chat endpoint using the AI SDK
+- An SSE connection that delivers tokens to the browser as they are generated
+- Environment variables for your LLM API key
+- A public domain for accessing the chatbot
+- Optional: Postgres for persisting conversation history
+
+## Prerequisites
+
+- A Railway account
+- An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
+- A Next.js app with the AI SDK installed, or a willingness to start from the AI SDK's [chat template](https://github.com/vercel/ai-chatbot)
+
+## 1. Set up the chat API route
+
+The AI SDK provides a `streamText` function that calls the LLM and returns a streaming response. Create an API route that uses it:
+
+```typescript
+// app/api/chat/route.ts
+import { openai } from "@ai-sdk/openai";
+import { streamText } from "ai";
+
+export async function POST(req: Request) {
+  const { messages } = await req.json();
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+
+To use Anthropic instead, swap the provider:
+
+```typescript
+import { anthropic } from "@ai-sdk/anthropic";
+
+const result = streamText({
+  model: anthropic("claude-sonnet-4-20250514"),
+  messages,
+});
+```
+
+## 2. Set up the chat UI
+
+The AI SDK's `useChat` hook manages the message list, input state, and SSE connection:
+
+```tsx
+// app/page.tsx
+"use client";
+import { useChat } from "@ai-sdk/react";
+
+export default function Chat() {
+  const { messages, input, handleInputChange, handleSubmit } = useChat();
+
+  return (
+    <div>
+      {messages.map((m) => (
+        <div key={m.id}>
+          <strong>{m.role}:</strong> {m.content}
+        </div>
+      ))}
+      <form onSubmit={handleSubmit}>
+        <input value={input} onChange={handleInputChange} />
+        <button type="submit">Send</button>
+      </form>
+    </div>
+  );
+}
+```
+
+`useChat` sends a POST request to `/api/chat` and reads the streamed response. Tokens appear in the UI as they arrive.
+
+## 3. Deploy to Railway
+
+1. Push your code to a GitHub repository.
+2. Create a new [project](/projects) on Railway.
+3. Click **+ New** and select **GitHub Repo**, then choose your repository.
+4. Add your LLM API key as an [environment variable](/variables):
+   - For OpenAI: set `OPENAI_API_KEY`
+   - For Anthropic: set `ANTHROPIC_API_KEY`
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking > Public Networking**.
+
+Railway auto-detects Next.js via [Railpack](/builds/railpack) and configures the build. The service will be live at your generated domain once the first deploy completes.
+
+## Streaming and Railway's request duration limit
+
+Railway has a [maximum HTTP request duration of 15 minutes](/networking/public-networking/specs-and-limits). SSE connections that stay open longer than 15 minutes are terminated.
+
+For a chatbot, this is rarely a problem: most LLM responses complete in seconds. If your chatbot runs multi-step agent tasks that could take longer, consider the [async workers pattern](/guides/ai-agent-workers) instead of holding an SSE connection open.
+
+The AI SDK's `useChat` hook handles reconnection automatically. If a connection drops, the client re-sends the message history on the next request, so the user does not lose context.
+
+## Optional: persist conversations with Postgres
+
+Without a database, conversation history only exists in the browser's memory. To persist conversations across sessions:
+
+1. Add [PostgreSQL](/databases/postgresql) to your project: click **+ New > Database > PostgreSQL**.
+2. [Reference](/variables#referencing-another-services-variable) the `DATABASE_URL` variable in your Next.js service.
+3. Create a table for messages:
+
+```sql
+CREATE TABLE messages (
+  id SERIAL PRIMARY KEY,
+  conversation_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_messages_conversation ON messages(conversation_id);
+```
+
+4. In your API route, load prior messages from Postgres before calling `streamText`, and save the assistant's response after the stream completes.
+
+## Next steps
+
+- [Choose Between SSE and WebSockets](/guides/sse-vs-websockets): Protocol tradeoffs for real-time applications.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): For tasks that take minutes, not seconds.
+- [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector): Add knowledge retrieval to your chatbot.
+- [PostgreSQL on Railway](/databases/postgresql): Connection pooling, backups, and configuration.

--- a/content/guides/ai-chatbot-streaming.md
+++ b/content/guides/ai-chatbot-streaming.md
@@ -3,7 +3,6 @@ title: Deploy an AI Chatbot with Streaming Responses
 description: Deploy a chatbot on Railway that streams LLM responses token by token using Server-Sent Events. Covers Next.js with the AI SDK, API key management, and optional conversation persistence with Postgres.
 date: "2026-04-14"
 tags:
-  - ai
   - chatbot
   - streaming
   - sse

--- a/content/guides/ai-chatbot-streaming.md
+++ b/content/guides/ai-chatbot-streaming.md
@@ -52,7 +52,7 @@ import { streamText } from "ai";
 export async function POST(req: Request) {
   const { messages } = await req.json();
 
-  const result = streamText({
+  const result = await streamText({
     model: openai("gpt-4o"),
     messages,
   });
@@ -66,7 +66,7 @@ To use Anthropic instead, swap the provider:
 ```typescript
 import { anthropic } from "@ai-sdk/anthropic";
 
-const result = streamText({
+const result = await streamText({
   model: anthropic("claude-sonnet-4-20250514"),
   messages,
 });

--- a/content/guides/ai-discord-telegram-bot.md
+++ b/content/guides/ai-discord-telegram-bot.md
@@ -1,0 +1,135 @@
+---
+title: Deploy an AI-Powered Bot for Discord or Telegram
+description: Deploy a Discord or Telegram bot on Railway that uses LLM APIs for conversational responses. Covers always-on deployment, API key management, conversation memory with Postgres, and rate limit handling.
+date: "2026-04-14"
+tags:
+  - ai
+  - bot
+  - discord
+  - telegram
+  - python
+topic: ai
+---
+
+This guide covers deploying a chat bot for Discord or Telegram on Railway that uses an LLM API (OpenAI, Anthropic, etc.) to generate responses. The bot runs as an always-on service, listens for messages, and replies with AI-generated text.
+
+Railway is a CPU-based platform. The bot calls external LLM APIs over HTTP. No models run locally.
+
+## Architecture
+
+The bot consists of two components:
+
+- **Bot service** runs continuously, connects to the Discord or Telegram API, listens for messages, and calls the LLM API to generate responses.
+- **Postgres** (optional) stores conversation history per user or channel so the bot can maintain context across messages.
+
+Bot services do not need a public domain. They connect outbound to the messaging platform's API and to the LLM API.
+
+## Prerequisites
+
+- A Railway account
+- A bot token from [Discord](https://discord.com/developers/applications) or [Telegram](https://core.telegram.org/bots#botfather)
+- An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
+
+## 1. Structure the bot code
+
+Here is a minimal Discord bot using discord.py and OpenAI:
+
+```python
+import os
+import discord
+from openai import OpenAI
+
+intents = discord.Intents.default()
+intents.message_content = True
+bot = discord.Client(intents=intents)
+llm = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+@bot.event
+async def on_message(message):
+    if message.author == bot.user:
+        return
+
+    response = llm.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": message.content},
+        ],
+    )
+    await message.channel.send(response.choices[0].message.content)
+
+bot.run(os.environ["DISCORD_TOKEN"])
+```
+
+For Telegram, use python-telegram-bot:
+
+```python
+import os
+from telegram.ext import ApplicationBuilder, MessageHandler, filters
+from openai import OpenAI
+
+llm = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+async def handle_message(update, context):
+    response = llm.chat.completions.create(
+        model="gpt-4o-mini",
+        messages=[
+            {"role": "system", "content": "You are a helpful assistant."},
+            {"role": "user", "content": update.message.text},
+        ],
+    )
+    await update.message.reply_text(response.choices[0].message.content)
+
+app = ApplicationBuilder().token(os.environ["TELEGRAM_TOKEN"]).build()
+app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
+app.run_polling()
+```
+
+## 2. Deploy to Railway
+
+1. Push your bot code to a GitHub repository.
+2. Create a new [project](/projects) on Railway.
+3. Click **+ New > GitHub Repo** and select your repository.
+4. Set environment variables under the **Variables** tab:
+   - `DISCORD_TOKEN` or `TELEGRAM_TOKEN`: your bot token.
+   - `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`: your LLM API key.
+5. The bot does not need a public domain. It connects outbound to Discord/Telegram servers.
+
+Deploy the bot as an always-on service, not a [cron job](/cron-jobs). Bots must stay connected to receive messages in real time.
+
+## 3. Add conversation memory with Postgres
+
+Without a database, the bot treats every message independently. To maintain conversation context:
+
+1. Add [PostgreSQL](/databases/postgresql) to your project.
+2. [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` in the bot service.
+3. Store recent messages per user or channel:
+
+```sql
+CREATE TABLE conversations (
+  id SERIAL PRIMARY KEY,
+  channel_id TEXT NOT NULL,
+  role TEXT NOT NULL,
+  content TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX idx_conversations_channel ON conversations(channel_id);
+```
+
+Before calling the LLM, load the last N messages for the channel and include them in the messages array. This gives the bot conversational context.
+
+## 4. Handle rate limits
+
+LLM APIs enforce rate limits on requests per minute and tokens per minute. When your bot is active in multiple channels simultaneously, you can hit these limits. Mitigations:
+
+- Use a smaller, faster model (GPT-4o mini, Claude Haiku) for most responses. Reserve larger models for complex queries.
+- Add a per-channel cooldown to avoid rapid-fire LLM calls.
+- Implement retry logic with exponential backoff for 429 responses.
+- Truncate conversation history to limit token usage per request.
+
+## Next steps
+
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): For bots that need to run longer tasks.
+- [PostgreSQL on Railway](/databases/postgresql): Connection pooling, backups, and configuration.
+- [Monitor your app](/observability): View logs and metrics for your bot service.

--- a/content/guides/ai-discord-telegram-bot.md
+++ b/content/guides/ai-discord-telegram-bot.md
@@ -56,19 +56,19 @@ Here is a minimal Discord bot using discord.py and OpenAI. Save this as `bot.py`
 ```python
 import os
 import discord
-from openai import OpenAI
+from openai import AsyncOpenAI
 
 intents = discord.Intents.default()
 intents.message_content = True
 bot = discord.Client(intents=intents)
-llm = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+llm = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
 @bot.event
 async def on_message(message):
     if message.author == bot.user:
         return
 
-    response = llm.chat.completions.create(
+    response = await llm.chat.completions.create(
         model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},
@@ -85,12 +85,12 @@ For Telegram, use python-telegram-bot instead. Save this as `bot.py`:
 ```python
 import os
 from telegram.ext import ApplicationBuilder, MessageHandler, filters
-from openai import OpenAI
+from openai import AsyncOpenAI
 
-llm = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+llm = AsyncOpenAI(api_key=os.environ["OPENAI_API_KEY"])
 
 async def handle_message(update, context):
-    response = llm.chat.completions.create(
+    response = await llm.chat.completions.create(
         model="gpt-4o-mini",
         messages=[
             {"role": "system", "content": "You are a helpful assistant."},

--- a/content/guides/ai-discord-telegram-bot.md
+++ b/content/guides/ai-discord-telegram-bot.md
@@ -3,7 +3,6 @@ title: Deploy an AI-Powered Bot for Discord or Telegram
 description: Deploy a Discord or Telegram bot on Railway that uses LLM APIs for conversational responses. Covers always-on deployment, API key management, conversation memory with Postgres, and rate limit handling.
 date: "2026-04-14"
 tags:
-  - ai
   - bot
   - discord
   - telegram

--- a/content/guides/ai-discord-telegram-bot.md
+++ b/content/guides/ai-discord-telegram-bot.md
@@ -29,9 +29,29 @@ Bot services do not need a public domain. They connect outbound to the messaging
 - A bot token from [Discord](https://discord.com/developers/applications) or [Telegram](https://core.telegram.org/bots#botfather)
 - An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
 
-## 1. Structure the bot code
+## 1. Set up the project
 
-Here is a minimal Discord bot using discord.py and OpenAI:
+Create a project directory with a `requirements.txt`:
+
+For a Discord bot:
+
+```
+discord.py
+openai
+```
+
+For a Telegram bot:
+
+```
+python-telegram-bot
+openai
+```
+
+Install dependencies locally with `pip install -r requirements.txt`.
+
+## 2. Write the bot code
+
+Here is a minimal Discord bot using discord.py and OpenAI. Save this as `bot.py`:
 
 ```python
 import os
@@ -60,7 +80,7 @@ async def on_message(message):
 bot.run(os.environ["DISCORD_TOKEN"])
 ```
 
-For Telegram, use python-telegram-bot:
+For Telegram, use python-telegram-bot instead. Save this as `bot.py`:
 
 ```python
 import os
@@ -84,19 +104,20 @@ app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, handle_message))
 app.run_polling()
 ```
 
-## 2. Deploy to Railway
+## 3. Deploy to Railway
 
 1. Push your bot code to a GitHub repository.
 2. Create a new [project](/projects) on Railway.
 3. Click **+ New > GitHub Repo** and select your repository.
-4. Set environment variables under the **Variables** tab:
+4. Set the [start command](/deployments/start-command) to: `python bot.py`
+5. Set environment variables under the **Variables** tab:
    - `DISCORD_TOKEN` or `TELEGRAM_TOKEN`: your bot token.
    - `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`: your LLM API key.
-5. The bot does not need a public domain. It connects outbound to Discord/Telegram servers.
+6. The bot does not need a public domain. It connects outbound to Discord/Telegram servers.
 
 Deploy the bot as an always-on service, not a [cron job](/cron-jobs). Bots must stay connected to receive messages in real time.
 
-## 3. Add conversation memory with Postgres
+## 4. Add conversation memory with Postgres
 
 Without a database, the bot treats every message independently. To maintain conversation context:
 
@@ -118,7 +139,7 @@ CREATE INDEX idx_conversations_channel ON conversations(channel_id);
 
 Before calling the LLM, load the last N messages for the channel and include them in the messages array. This gives the bot conversational context.
 
-## 4. Handle rate limits
+## 5. Handle rate limits
 
 LLM APIs enforce rate limits on requests per minute and tokens per minute. When your bot is active in multiple channels simultaneously, you can hit these limits. Mitigations:
 

--- a/content/guides/deploy-ai-saas.md
+++ b/content/guides/deploy-ai-saas.md
@@ -1,11 +1,11 @@
 ---
 title: Deploy an AI-Powered SaaS App on Railway
-description: Deploy a production AI-powered SaaS application on Railway with a FastAPI backend, Postgres database, and external LLM API integration. Covers API key management, request caching, rate limiting, and async processing for longer tasks.
+description: Deploy a production AI-powered SaaS application on Railway with an Express backend, Postgres database, and external LLM API integration. Covers API key management, request caching, rate limiting, and async processing for longer tasks.
 date: "2026-04-14"
 tags:
   - saas
-  - python
-  - fastapi
+  - nodejs
+  - express
   - postgres
 topic: ai
 ---
@@ -18,7 +18,7 @@ Railway is a CPU-based platform. Your application calls external LLM APIs (OpenA
 
 A typical AI SaaS app on Railway uses three components:
 
-- **API service** (FastAPI, Express, etc.) handles user requests, calls the LLM API, and returns results.
+- **API service** (Express, FastAPI, etc.) handles user requests, calls the LLM API, and returns results.
 - **Postgres** stores user data, cached LLM responses, and job status for async tasks.
 - **Redis** (optional) provides job queuing for tasks that take longer than a few seconds.
 
@@ -28,18 +28,15 @@ For tasks that complete in under 30 seconds, a synchronous request/response patt
 
 - A Railway account
 - An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
-- Python 3.11+ with FastAPI (the examples below use FastAPI, but the patterns apply to any framework)
+- Node.js 18+
 
-### Dependencies
+### Set up the project
 
+```bash
+mkdir ai-saas && cd ai-saas
+npm init -y
+npm install express openai pg crypto
 ```
-fastapi
-uvicorn
-openai
-psycopg2-binary
-```
-
-Install locally with `pip install -r requirements.txt`.
 
 ## 1. Create the project and database
 
@@ -51,72 +48,75 @@ Install locally with `pip install -r requirements.txt`.
 
 1. Push your code to a GitHub repository.
 2. In your project, click **+ New > GitHub Repo** and select your repository.
-3. Set the [start command](/deployments/start-command) to: `uvicorn app:app --host 0.0.0.0 --port $PORT`
+3. Set the [start command](/deployments/start-command) to: `node app.js`
 4. Set environment variables under the **Variables** tab:
    - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
    - Add your LLM API key (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
 5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking > Public Networking**.
-6. If your app uses database migrations, configure a [pre-deploy command](/deployments/pre-deploy-command).
 
 ## 3. Structure LLM API calls
 
 Wrap your LLM calls in a function that handles retries and errors. LLM APIs return rate limit errors (HTTP 429) under load:
 
-```python
-import time
-from openai import OpenAI
+```javascript
+// llm.js
+const OpenAI = require("openai");
 
-client = OpenAI()
+const client = new OpenAI();
 
-def call_llm(prompt: str, max_retries: int = 3) -> str:
-    for attempt in range(max_retries):
-        try:
-            response = client.chat.completions.create(
-                model="gpt-4o",
-                messages=[{"role": "user", "content": prompt}],
-            )
-            return response.choices[0].message.content
-        except Exception as e:
-            if "429" in str(e) and attempt < max_retries - 1:
-                time.sleep(2 ** attempt)
-                continue
-            raise
+async function callLLM(prompt, maxRetries = 3) {
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    try {
+      const response = await client.chat.completions.create({
+        model: "gpt-4o",
+        messages: [{ role: "user", content: prompt }],
+      });
+      return response.choices[0].message.content;
+    } catch (err) {
+      if (err.status === 429 && attempt < maxRetries - 1) {
+        await new Promise((r) => setTimeout(r, 2 ** attempt * 1000));
+        continue;
+      }
+      throw err;
+    }
+  }
+}
+
+module.exports = { callLLM };
 ```
 
 ## 4. Cache LLM responses
 
-LLM API calls are slow (1-10 seconds) and expensive. Cache responses for identical or similar inputs to reduce latency and cost:
+LLM API calls are slow (1-10 seconds) and expensive. Cache responses for identical inputs to reduce latency and cost:
 
-```python
-import hashlib
-import psycopg2
-import json
+```javascript
+// cache.js
+const crypto = require("crypto");
+const { Pool } = require("pg");
+const { callLLM } = require("./llm");
 
-def get_or_create_response(prompt: str, db_url: str) -> str:
-    prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-    conn = psycopg2.connect(db_url)
-    cur = conn.cursor()
+async function getOrCreateResponse(prompt) {
+  const promptHash = crypto.createHash("sha256").update(prompt).digest("hex");
 
-    cur.execute(
-        "SELECT response FROM llm_cache WHERE prompt_hash = %s",
-        (prompt_hash,),
-    )
-    row = cur.fetchone()
-    if row:
-        cur.close()
-        conn.close()
-        return row[0]
+  const cached = await pool.query(
+    "SELECT response FROM llm_cache WHERE prompt_hash = $1",
+    [promptHash]
+  );
+  if (cached.rows.length > 0) {
+    return cached.rows[0].response;
+  }
 
-    response = call_llm(prompt)
-    cur.execute(
-        "INSERT INTO llm_cache (prompt_hash, prompt, response) VALUES (%s, %s, %s)",
-        (prompt_hash, prompt, response),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
-    return response
+  const response = await callLLM(prompt);
+  await pool.query(
+    "INSERT INTO llm_cache (prompt_hash, prompt, response) VALUES ($1, $2, $3)",
+    [promptHash, prompt, response]
+  );
+  return response;
+}
+
+module.exports = { getOrCreateResponse };
 ```
 
 Create the cache table:
@@ -133,66 +133,74 @@ CREATE TABLE llm_cache (
 
 ## 5. Handle longer tasks asynchronously
 
-If some requests take more than a few seconds (batch processing, multi-step generation), return a job ID immediately and process in the background. See [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers) for the full pattern.
+If some requests take more than a few seconds (batch processing, multi-step generation), return a job ID immediately and process in the background. See [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers) for the full pattern with Redis.
 
-A simpler approach for moderate workloads: use FastAPI's `BackgroundTasks`:
+For moderate workloads, process jobs in the background within the same service:
 
-```python
-import os
-import uuid
-import psycopg2
-import json
-from fastapi import BackgroundTasks, FastAPI
+```javascript
+// app.js
+const express = require("express");
+const crypto = require("crypto");
+const { Pool } = require("pg");
+const { callLLM } = require("./llm");
+const { getOrCreateResponse } = require("./cache");
 
-app = FastAPI()
-DATABASE_URL = os.environ["DATABASE_URL"]
+const app = express();
+app.use(express.json());
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
 
-def create_job(input_text: str) -> str:
-    job_id = str(uuid.uuid4())
-    conn = psycopg2.connect(DATABASE_URL)
-    cur = conn.cursor()
-    cur.execute(
-        "INSERT INTO jobs (id, input, status) VALUES (%s, %s, 'pending')",
-        (job_id, input_text),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
-    return job_id
+// Synchronous endpoint with caching
+app.post("/generate", async (req, res) => {
+  const { prompt } = req.body;
+  const response = await getOrCreateResponse(prompt);
+  res.json({ response });
+});
 
-def process_job(job_id: str):
-    conn = psycopg2.connect(DATABASE_URL)
-    cur = conn.cursor()
-    cur.execute("SELECT input FROM jobs WHERE id = %s", (job_id,))
-    input_text = cur.fetchone()[0]
+// Async endpoint for longer tasks
+app.post("/jobs", async (req, res) => {
+  const jobId = crypto.randomUUID();
+  const { input } = req.body;
 
-    result = call_llm(input_text)
+  await pool.query(
+    "INSERT INTO jobs (id, input, status) VALUES ($1, $2, 'pending')",
+    [jobId, input]
+  );
 
-    cur.execute(
-        "UPDATE jobs SET status = 'completed', output = %s WHERE id = %s",
-        (result, job_id),
-    )
-    conn.commit()
-    cur.close()
-    conn.close()
+  // Process in background (do not await)
+  processJob(jobId).catch((err) =>
+    console.error(`Job ${jobId} failed:`, err)
+  );
 
-@app.post("/generate")
-async def generate(input: str, background_tasks: BackgroundTasks):
-    job_id = create_job(input)
-    background_tasks.add_task(process_job, job_id)
-    return {"job_id": job_id}
+  res.json({ job_id: jobId });
+});
 
-@app.get("/jobs/{job_id}")
-async def get_job(job_id: str):
-    conn = psycopg2.connect(DATABASE_URL)
-    cur = conn.cursor()
-    cur.execute("SELECT id, status, output FROM jobs WHERE id = %s", (job_id,))
-    row = cur.fetchone()
-    cur.close()
-    conn.close()
-    if not row:
-        return {"error": "not found"}
-    return {"id": row[0], "status": row[1], "output": row[2]}
+app.get("/jobs/:id", async (req, res) => {
+  const result = await pool.query(
+    "SELECT id, status, output FROM jobs WHERE id = $1",
+    [req.params.id]
+  );
+  if (result.rows.length === 0) {
+    return res.status(404).json({ error: "not found" });
+  }
+  res.json(result.rows[0]);
+});
+
+async function processJob(jobId) {
+  const result = await pool.query("SELECT input FROM jobs WHERE id = $1", [
+    jobId,
+  ]);
+  const input = result.rows[0].input;
+  const output = await callLLM(input);
+  await pool.query(
+    "UPDATE jobs SET status = 'completed', output = $1 WHERE id = $2",
+    [output, jobId]
+  );
+}
+
+const port = process.env.PORT || 3000;
+app.listen(port, "0.0.0.0", () => {
+  console.log(`Server running on port ${port}`);
+});
 ```
 
 Create the jobs table:
@@ -213,14 +221,14 @@ This works for single-replica services. For multiple replicas or heavy workloads
 
 LLM API costs scale with usage. Track spending by logging token counts per request:
 
-```python
-response = client.chat.completions.create(
-    model="gpt-4o",
-    messages=messages,
-)
+```javascript
+const response = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages,
+});
 
-tokens_used = response.usage.total_tokens
-# Log to Postgres or your analytics system
+const tokensUsed = response.usage.total_tokens;
+// Log to Postgres or your analytics system
 ```
 
 Set a per-user or per-request token budget to prevent runaway costs. Consider using smaller models (GPT-4o mini, Claude Haiku) for tasks that do not require the most capable model.

--- a/content/guides/deploy-ai-saas.md
+++ b/content/guides/deploy-ai-saas.md
@@ -35,7 +35,7 @@ For tasks that complete in under 30 seconds, a synchronous request/response patt
 ```bash
 mkdir ai-saas && cd ai-saas
 npm init -y
-npm install express openai pg crypto
+npm install express openai pg
 ```
 
 ## 1. Create the project and database

--- a/content/guides/deploy-ai-saas.md
+++ b/content/guides/deploy-ai-saas.md
@@ -28,7 +28,18 @@ For tasks that complete in under 30 seconds, a synchronous request/response patt
 
 - A Railway account
 - An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
-- Application code with a web framework (FastAPI, Express, Django, etc.)
+- Python 3.11+ with FastAPI (the examples below use FastAPI, but the patterns apply to any framework)
+
+### Dependencies
+
+```
+fastapi
+uvicorn
+openai
+psycopg2-binary
+```
+
+Install locally with `pip install -r requirements.txt`.
 
 ## 1. Create the project and database
 
@@ -40,11 +51,12 @@ For tasks that complete in under 30 seconds, a synchronous request/response patt
 
 1. Push your code to a GitHub repository.
 2. In your project, click **+ New > GitHub Repo** and select your repository.
-3. Set environment variables under the **Variables** tab:
+3. Set the [start command](/deployments/start-command) to: `uvicorn app:app --host 0.0.0.0 --port $PORT`
+4. Set environment variables under the **Variables** tab:
    - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
    - Add your LLM API key (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
-4. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking > Public Networking**.
-5. If your app uses database migrations, configure a [pre-deploy command](/deployments/pre-deploy-command).
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking > Public Networking**.
+6. If your app uses database migrations, configure a [pre-deploy command](/deployments/pre-deploy-command).
 
 ## 3. Structure LLM API calls
 
@@ -126,19 +138,73 @@ If some requests take more than a few seconds (batch processing, multi-step gene
 A simpler approach for moderate workloads: use FastAPI's `BackgroundTasks`:
 
 ```python
+import os
+import uuid
+import psycopg2
+import json
 from fastapi import BackgroundTasks, FastAPI
 
 app = FastAPI()
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+def create_job(input_text: str) -> str:
+    job_id = str(uuid.uuid4())
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    cur.execute(
+        "INSERT INTO jobs (id, input, status) VALUES (%s, %s, 'pending')",
+        (job_id, input_text),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+    return job_id
+
+def process_job(job_id: str):
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    cur.execute("SELECT input FROM jobs WHERE id = %s", (job_id,))
+    input_text = cur.fetchone()[0]
+
+    result = call_llm(input_text)
+
+    cur.execute(
+        "UPDATE jobs SET status = 'completed', output = %s WHERE id = %s",
+        (result, job_id),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
 
 @app.post("/generate")
 async def generate(input: str, background_tasks: BackgroundTasks):
-    job_id = create_job(input)  # Save to Postgres with status "pending"
+    job_id = create_job(input)
     background_tasks.add_task(process_job, job_id)
     return {"job_id": job_id}
 
 @app.get("/jobs/{job_id}")
 async def get_job(job_id: str):
-    return get_job_status(job_id)  # Read from Postgres
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    cur.execute("SELECT id, status, output FROM jobs WHERE id = %s", (job_id,))
+    row = cur.fetchone()
+    cur.close()
+    conn.close()
+    if not row:
+        return {"error": "not found"}
+    return {"id": row[0], "status": row[1], "output": row[2]}
+```
+
+Create the jobs table:
+
+```sql
+CREATE TABLE jobs (
+  id TEXT PRIMARY KEY,
+  input TEXT NOT NULL,
+  status TEXT DEFAULT 'pending',
+  output TEXT,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
 ```
 
 This works for single-replica services. For multiple replicas or heavy workloads, use Redis-backed workers instead.

--- a/content/guides/deploy-ai-saas.md
+++ b/content/guides/deploy-ai-saas.md
@@ -1,0 +1,169 @@
+---
+title: Deploy an AI-Powered SaaS App on Railway
+description: Deploy a production AI-powered SaaS application on Railway with a FastAPI backend, Postgres database, and external LLM API integration. Covers API key management, request caching, rate limiting, and async processing for longer tasks.
+date: "2026-04-14"
+tags:
+  - ai
+  - saas
+  - python
+  - fastapi
+  - postgres
+topic: ai
+---
+
+This guide covers deploying a SaaS application that integrates LLM APIs on Railway. The pattern applies to any product that takes user input, processes it through an LLM, and returns or stores the result: resume builders, content generators, code reviewers, data analyzers, and similar tools.
+
+Railway is a CPU-based platform. Your application calls external LLM APIs (OpenAI, Anthropic, etc.) over HTTP. No models run locally.
+
+## Architecture overview
+
+A typical AI SaaS app on Railway uses three components:
+
+- **API service** (FastAPI, Express, etc.) handles user requests, calls the LLM API, and returns results.
+- **Postgres** stores user data, cached LLM responses, and job status for async tasks.
+- **Redis** (optional) provides job queuing for tasks that take longer than a few seconds.
+
+For tasks that complete in under 30 seconds, a synchronous request/response pattern works well. For longer tasks, use the [async workers pattern](/guides/ai-agent-workers).
+
+## Prerequisites
+
+- A Railway account
+- An API key from [OpenAI](https://platform.openai.com/api-keys) or [Anthropic](https://console.anthropic.com/)
+- Application code with a web framework (FastAPI, Express, Django, etc.)
+
+## 1. Create the project and database
+
+1. Create a new [project](/projects) on Railway.
+2. Add [PostgreSQL](/databases/postgresql): click **+ New > Database > PostgreSQL**.
+3. The database will be accessible to all services in the project via [reference variables](/variables#referencing-another-services-variable).
+
+## 2. Deploy the API service
+
+1. Push your code to a GitHub repository.
+2. In your project, click **+ New > GitHub Repo** and select your repository.
+3. Set environment variables under the **Variables** tab:
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
+   - Add your LLM API key (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
+4. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking > Public Networking**.
+5. If your app uses database migrations, configure a [pre-deploy command](/deployments/pre-deploy-command).
+
+## 3. Structure LLM API calls
+
+Wrap your LLM calls in a function that handles retries and errors. LLM APIs return rate limit errors (HTTP 429) under load:
+
+```python
+import time
+from openai import OpenAI
+
+client = OpenAI()
+
+def call_llm(prompt: str, max_retries: int = 3) -> str:
+    for attempt in range(max_retries):
+        try:
+            response = client.chat.completions.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            return response.choices[0].message.content
+        except Exception as e:
+            if "429" in str(e) and attempt < max_retries - 1:
+                time.sleep(2 ** attempt)
+                continue
+            raise
+```
+
+## 4. Cache LLM responses
+
+LLM API calls are slow (1-10 seconds) and expensive. Cache responses for identical or similar inputs to reduce latency and cost:
+
+```python
+import hashlib
+import psycopg2
+import json
+
+def get_or_create_response(prompt: str, db_url: str) -> str:
+    prompt_hash = hashlib.sha256(prompt.encode()).hexdigest()
+
+    conn = psycopg2.connect(db_url)
+    cur = conn.cursor()
+
+    cur.execute(
+        "SELECT response FROM llm_cache WHERE prompt_hash = %s",
+        (prompt_hash,),
+    )
+    row = cur.fetchone()
+    if row:
+        cur.close()
+        conn.close()
+        return row[0]
+
+    response = call_llm(prompt)
+    cur.execute(
+        "INSERT INTO llm_cache (prompt_hash, prompt, response) VALUES (%s, %s, %s)",
+        (prompt_hash, prompt, response),
+    )
+    conn.commit()
+    cur.close()
+    conn.close()
+    return response
+```
+
+Create the cache table:
+
+```sql
+CREATE TABLE llm_cache (
+  id SERIAL PRIMARY KEY,
+  prompt_hash TEXT UNIQUE NOT NULL,
+  prompt TEXT NOT NULL,
+  response TEXT NOT NULL,
+  created_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+## 5. Handle longer tasks asynchronously
+
+If some requests take more than a few seconds (batch processing, multi-step generation), return a job ID immediately and process in the background. See [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers) for the full pattern.
+
+A simpler approach for moderate workloads: use FastAPI's `BackgroundTasks`:
+
+```python
+from fastapi import BackgroundTasks, FastAPI
+
+app = FastAPI()
+
+@app.post("/generate")
+async def generate(input: str, background_tasks: BackgroundTasks):
+    job_id = create_job(input)  # Save to Postgres with status "pending"
+    background_tasks.add_task(process_job, job_id)
+    return {"job_id": job_id}
+
+@app.get("/jobs/{job_id}")
+async def get_job(job_id: str):
+    return get_job_status(job_id)  # Read from Postgres
+```
+
+This works for single-replica services. For multiple replicas or heavy workloads, use Redis-backed workers instead.
+
+## 6. Manage costs
+
+LLM API costs scale with usage. Track spending by logging token counts per request:
+
+```python
+response = client.chat.completions.create(
+    model="gpt-4o",
+    messages=messages,
+)
+
+tokens_used = response.usage.total_tokens
+# Log to Postgres or your analytics system
+```
+
+Set a per-user or per-request token budget to prevent runaway costs. Consider using smaller models (GPT-4o mini, Claude Haiku) for tasks that do not require the most capable model.
+
+## Next steps
+
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): Full async processing pattern with Redis queues.
+- [Deploy an AI Chatbot with Streaming Responses](/guides/ai-chatbot-streaming): Add a streaming chat interface.
+- [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector): Add knowledge retrieval to your app.
+- [Scaling](/deployments/scaling): Configure horizontal and vertical scaling for your services.
+- [PostgreSQL on Railway](/databases/postgresql): Connection pooling, backups, and configuration.

--- a/content/guides/deploy-ai-saas.md
+++ b/content/guides/deploy-ai-saas.md
@@ -3,7 +3,6 @@ title: Deploy an AI-Powered SaaS App on Railway
 description: Deploy a production AI-powered SaaS application on Railway with a FastAPI backend, Postgres database, and external LLM API integration. Covers API key management, request caching, rate limiting, and async processing for longer tasks.
 date: "2026-04-14"
 tags:
-  - ai
   - saas
   - python
   - fastapi

--- a/content/guides/dify.md
+++ b/content/guides/dify.md
@@ -1,0 +1,107 @@
+---
+title: Self-Host Dify
+description: Deploy Dify on Railway with Postgres, Redis, and persistent storage. Build AI applications, RAG pipelines, and agent workflows through Dify's visual interface.
+date: "2026-04-14"
+tags:
+  - ai
+  - dify
+  - docker
+  - self-hosted
+topic: ai
+---
+
+[Dify](https://dify.ai) is an open-source platform for building LLM-powered applications. It provides a visual workflow editor, built-in RAG pipeline, agent framework, and API management through a web interface.
+
+Dify is a multi-service application that requires an API server, a worker, a web frontend, Postgres, and Redis. Railway is well-suited for this type of deployment since each component runs as a separate service with shared private networking.
+
+Dify calls external LLM APIs (OpenAI, Anthropic, etc.) for model inference. Railway is CPU-based and does not offer GPU instances.
+
+## What you will set up
+
+- Dify API server, worker, and web frontend as separate Railway services
+- PostgreSQL and Redis databases
+- Persistent storage for uploaded files
+- A public domain for the Dify web interface
+
+## One-click deploy from a template
+
+Railway has a Dify template that provisions all services and databases in one step.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/V1xiql)
+
+After deploying, skip to [Configure LLM providers](#configure-llm-providers) to connect your API keys.
+
+If you prefer to set things up manually, continue below.
+
+## Manual deployment
+
+### 1. Create the project and databases
+
+1. Create a new [project](/projects) on Railway.
+2. Add [PostgreSQL](/databases/postgresql): click **+ New > Database > PostgreSQL**.
+3. Add [Redis](/databases/redis): click **+ New > Database > Redis**.
+
+### 2. Deploy the API server
+
+1. Click **+ New > Docker Image**.
+2. Enter `langgenius/dify-api` as the image name.
+3. Add the following environment variables, using [reference variables](/variables#referencing-another-services-variable) for database connections:
+
+| Variable | Value |
+| --- | --- |
+| `MODE` | `api` |
+| `DB_HOST` | `${{Postgres.PGHOST}}` |
+| `DB_PORT` | `${{Postgres.PGPORT}}` |
+| `DB_USERNAME` | `${{Postgres.PGUSER}}` |
+| `DB_PASSWORD` | `${{Postgres.PGPASSWORD}}` |
+| `DB_DATABASE` | `${{Postgres.PGDATABASE}}` |
+| `REDIS_HOST` | `${{Redis.REDISHOST}}` |
+| `REDIS_PORT` | `${{Redis.REDISPORT}}` |
+| `REDIS_PASSWORD` | `${{Redis.REDISPASSWORD}}` |
+| `SECRET_KEY` | A random string (use `openssl rand -hex 32`) |
+| `STORAGE_TYPE` | `local` |
+| `STORAGE_LOCAL_PATH` | `/app/api/storage` |
+
+4. Attach a [Volume](/volumes) mounted at `/app/api/storage` for file uploads.
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) for the API server.
+
+### 3. Deploy the worker
+
+1. Click **+ New > Docker Image**.
+2. Enter `langgenius/dify-api` as the image name (same image, different mode).
+3. Copy the same environment variables from the API server, but change:
+
+| Variable | Value |
+| --- | --- |
+| `MODE` | `worker` |
+
+4. No public domain is needed. The worker communicates with Postgres and Redis over [private networking](/networking/private-networking).
+
+### 4. Deploy the web frontend
+
+1. Click **+ New > Docker Image**.
+2. Enter `langgenius/dify-web` as the image name.
+3. Add the following environment variable:
+
+| Variable | Value |
+| --- | --- |
+| `CONSOLE_API_URL` | The public URL of your API server (e.g., `https://dify-api-production-xxxx.up.railway.app`) |
+| `APP_API_URL` | Same as `CONSOLE_API_URL` |
+
+4. Generate a [public domain](/networking/public-networking#railway-provided-domain) for the web frontend.
+
+## Configure LLM providers
+
+1. Open the web frontend domain in your browser.
+2. Create an admin account on first access.
+3. Go to **Settings > Model Providers**.
+4. Add your LLM API keys (OpenAI, Anthropic, or others).
+
+Dify stores provider credentials encrypted in Postgres.
+
+## Next steps
+
+- [Manage Volumes](/volumes): Resize or back up your persistent storage.
+- [Set up a custom domain](/networking/domains): Use your own domain for the Dify interface.
+- [Private Networking](/networking/private-networking): How services communicate within a project.
+- [Monitor your app](/observability): View logs and metrics for your Dify services.

--- a/content/guides/dify.md
+++ b/content/guides/dify.md
@@ -3,7 +3,6 @@ title: Self-Host Dify
 description: Deploy Dify on Railway with Postgres, Redis, and persistent storage. Build AI applications, RAG pipelines, and agent workflows through Dify's visual interface.
 date: "2026-04-14"
 tags:
-  - ai
   - dify
   - docker
   - self-hosted

--- a/content/guides/flowise.md
+++ b/content/guides/flowise.md
@@ -3,7 +3,6 @@ title: Self-Host Flowise
 description: Deploy Flowise on Railway with persistent storage and authentication. Build LLM chains, agents, and chatbots through a visual drag-and-drop interface without managing servers.
 date: "2026-04-14"
 tags:
-  - ai
   - flowise
   - docker
   - self-hosted

--- a/content/guides/flowise.md
+++ b/content/guides/flowise.md
@@ -1,0 +1,91 @@
+---
+title: Self-Host Flowise
+description: Deploy Flowise on Railway with persistent storage and authentication. Build LLM chains, agents, and chatbots through a visual drag-and-drop interface without managing servers.
+date: "2026-04-14"
+tags:
+  - ai
+  - flowise
+  - docker
+  - self-hosted
+topic: ai
+---
+
+[Flowise](https://flowiseai.com) is an open-source tool for building LLM-powered applications through a visual drag-and-drop interface. You can create chatbots, RAG pipelines, and multi-step agent workflows by connecting nodes, without writing application code.
+
+Flowise runs on Railway as a CPU-based service. The LLM chains you build in Flowise call external APIs (OpenAI, Anthropic, HuggingFace Inference, etc.) for model inference. No models run locally on Railway.
+
+## What you will set up
+
+- A Flowise instance running from the official Docker image
+- Persistent storage via a Railway [Volume](/volumes)
+- Authentication to protect the Flowise editor
+- A public domain for accessing the interface
+
+## One-click deploy from a template
+
+Railway has a Flowise template that provisions the full setup in one step.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/flowise)
+
+After deploying, skip to [Configure authentication](#configure-authentication) to secure your instance.
+
+If you prefer to set things up manually, continue with the steps below.
+
+## Deploy from a Docker image
+
+1. Create a new project in Railway.
+2. Click **+ New** and select **Docker Image**.
+3. Enter `flowiseai/flowise` as the image name and press Enter.
+4. Railway will pull the image and create a service.
+
+## Configure environment variables
+
+Add the following variables to your Flowise service under the **Variables** tab:
+
+| Variable | Value | Description |
+| --- | --- | --- |
+| `PORT` | `${{PORT}}` | Binds Flowise to Railway's injected port |
+| `FLOWISE_USERNAME` | Your username | Username for editor authentication |
+| `FLOWISE_PASSWORD` | Your password | Password for editor authentication |
+| `APIKEY_PATH` | `/root/.flowise` | Path for storing API keys |
+| `SECRETKEY_ENCRYPT` | A random string | Encryption key for stored credentials |
+| `LOG_LEVEL` | `info` | Log verbosity (debug, info, warn, error) |
+
+## Attach persistent storage
+
+Flowise stores chatflow definitions, credentials, and configuration in `/root/.flowise` by default. Without a volume, this data is lost on every deployment.
+
+1. Open the Flowise service in your project.
+2. Go to the **Volumes** tab.
+3. Click **Add Volume**.
+4. Set the mount path to `/root/.flowise`.
+5. Choose a size appropriate for your usage (1 GB is a reasonable starting point).
+6. Click **Add**.
+
+## Set up a public domain
+
+1. Go to the **Settings** tab of the Flowise service.
+2. Under **Networking**, click **Generate Domain**.
+3. Open the domain in your browser to access the Flowise editor.
+
+## Configure authentication
+
+If you set `FLOWISE_USERNAME` and `FLOWISE_PASSWORD`, the editor requires authentication. Without these variables, anyone with the URL can access and modify your chatflows.
+
+After logging in, you can also generate API keys within Flowise to protect your chatflow API endpoints for external integrations.
+
+## Add LLM API keys
+
+Flowise does not include LLM models. You provide API keys for external providers within the Flowise editor:
+
+1. Open a chatflow in the editor.
+2. Add an LLM node (e.g., ChatOpenAI, ChatAnthropic).
+3. Click the node and enter your API key in the credentials section.
+
+Flowise encrypts stored credentials using `SECRETKEY_ENCRYPT`.
+
+## Next steps
+
+- [Manage Volumes](/volumes): Resize or back up your persistent storage.
+- [Set up a custom domain](/networking/domains): Use your own domain instead of the generated Railway domain.
+- [Monitor your app](/observability): View logs and metrics for your Flowise instance.

--- a/content/guides/lovable.md
+++ b/content/guides/lovable.md
@@ -5,7 +5,6 @@ date: "2026-01-30"
 tags:
   - deployment
   - lovable
-  - ai
 topic: integrations
 ---
 

--- a/content/guides/mcp-server.md
+++ b/content/guides/mcp-server.md
@@ -42,6 +42,24 @@ npm install -D typescript @types/node @types/express
 npx tsc --init
 ```
 
+Update `tsconfig.json` with the following settings:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
 Create the server with a sample tool:
 
 ```typescript
@@ -51,32 +69,53 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import express from "express";
 
 const app = express();
-const server = new McpServer({
-  name: "my-mcp-server",
-  version: "1.0.0",
-});
 
-// Define a tool
-server.tool("get_weather", "Get the current weather for a city", {
-  city: { type: "string", description: "City name" },
-}, async ({ city }) => {
-  // Replace with a real API call
-  return {
-    content: [
-      { type: "text", text: `Weather in ${city}: 72°F, sunny` },
-    ],
-  };
-});
+// Store transports by session ID so the POST handler can route messages
+const transports = new Map<string, SSEServerTransport>();
 
-// SSE transport endpoint
+function createServer() {
+  const server = new McpServer({
+    name: "my-mcp-server",
+    version: "1.0.0",
+  });
+
+  // Define a tool
+  server.tool("get_weather", "Get the current weather for a city", {
+    city: { type: "string", description: "City name" },
+  }, async ({ city }) => {
+    // Replace with a real API call
+    return {
+      content: [
+        { type: "text", text: `Weather in ${city}: 72°F, sunny` },
+      ],
+    };
+  });
+
+  return server;
+}
+
 app.get("/sse", async (req, res) => {
   const transport = new SSEServerTransport("/messages", res);
+  transports.set(transport.sessionId, transport);
+
+  res.on("close", () => {
+    transports.delete(transport.sessionId);
+  });
+
+  const server = createServer();
   await server.connect(transport);
 });
 
 app.post("/messages", express.json(), async (req, res) => {
-  // Handle incoming messages from the client
-  // The transport handles routing automatically
+  const sessionId = req.query.sessionId as string;
+  const transport = transports.get(sessionId);
+
+  if (!transport) {
+    res.status(400).send("Unknown session");
+    return;
+  }
+
+  await transport.handlePostMessage(req, res);
 });
 
 const port = process.env.PORT || 3000;
@@ -157,6 +196,9 @@ app.get("/sse", async (req, res) => {
     return res.status(401).send("Unauthorized");
   }
   const transport = new SSEServerTransport("/messages", res);
+  transports.set(transport.sessionId, transport);
+  res.on("close", () => transports.delete(transport.sessionId));
+  const server = createServer();
   await server.connect(transport);
 });
 ```

--- a/content/guides/mcp-server.md
+++ b/content/guides/mcp-server.md
@@ -1,0 +1,176 @@
+---
+title: Build and Deploy Your Own MCP Server
+description: Build a Model Context Protocol server in TypeScript and deploy it on Railway. Expose custom tools and resources that AI assistants like Claude and Cursor can call over the network.
+date: "2026-04-14"
+tags:
+  - ai
+  - mcp
+  - typescript
+  - agents
+topic: ai
+---
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI assistants to external tools and data sources. An MCP server exposes tools (functions the AI can call) and resources (data the AI can read) over a standardized protocol.
+
+This guide covers building an MCP server in TypeScript and deploying it on Railway so AI assistants like Claude Desktop and Cursor can connect to it over the network.
+
+Railway already has an [MCP server for managing Railway infrastructure](/ai/mcp-server). This guide is different: it covers building and hosting your own MCP server for your own tools and data.
+
+## How MCP transport works
+
+MCP supports two transport protocols:
+
+- **stdio**: The client launches the server as a local subprocess. Communication happens over standard input/output. This only works when the server runs on the same machine as the client.
+- **SSE (Server-Sent Events)**: The server runs as an HTTP service. The client connects over the network. This is the transport you need for a hosted MCP server.
+
+Since Railway hosts the server remotely, you must use SSE transport.
+
+## Prerequisites
+
+- A Railway account
+- Node.js 18+ for local development
+- An AI client that supports remote MCP servers (Claude Desktop, Cursor, etc.)
+
+## 1. Create the MCP server
+
+Initialize a project and install the MCP SDK:
+
+```bash
+mkdir my-mcp-server && cd my-mcp-server
+npm init -y
+npm install @modelcontextprotocol/sdk express
+npm install -D typescript @types/node @types/express
+npx tsc --init
+```
+
+Create the server with a sample tool:
+
+```typescript
+// src/index.ts
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import express from "express";
+
+const app = express();
+const server = new McpServer({
+  name: "my-mcp-server",
+  version: "1.0.0",
+});
+
+// Define a tool
+server.tool("get_weather", "Get the current weather for a city", {
+  city: { type: "string", description: "City name" },
+}, async ({ city }) => {
+  // Replace with a real API call
+  return {
+    content: [
+      { type: "text", text: `Weather in ${city}: 72°F, sunny` },
+    ],
+  };
+});
+
+// SSE transport endpoint
+app.get("/sse", async (req, res) => {
+  const transport = new SSEServerTransport("/messages", res);
+  await server.connect(transport);
+});
+
+app.post("/messages", express.json(), async (req, res) => {
+  // Handle incoming messages from the client
+  // The transport handles routing automatically
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, "0.0.0.0", () => {
+  console.log(`MCP server running on port ${port}`);
+});
+```
+
+Add a build script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  }
+}
+```
+
+## 2. Test locally
+
+```bash
+npm run build && npm start
+```
+
+The server starts on port 3000. You can test the SSE endpoint at `http://localhost:3000/sse`.
+
+## 3. Deploy to Railway
+
+1. Push your code to a GitHub repository.
+2. Create a new [project](/projects) on Railway.
+3. Click **+ New > GitHub Repo** and select your repository.
+4. Railway detects the Node.js project and builds it via [Railpack](/builds/railpack).
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
+
+Your MCP server is now reachable at `https://your-server-production-xxxx.up.railway.app/sse`.
+
+## 4. Connect from an AI assistant
+
+### Claude Desktop
+
+Add to your Claude Desktop configuration (`claude_desktop_config.json`):
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://your-server-production-xxxx.up.railway.app/sse"
+    }
+  }
+}
+```
+
+### Cursor
+
+Add to your Cursor MCP settings:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "url": "https://your-server-production-xxxx.up.railway.app/sse"
+    }
+  }
+}
+```
+
+Restart the client after updating the configuration. Your tools will appear in the AI assistant's tool list.
+
+## Adding authentication
+
+A public MCP server is accessible to anyone with the URL. To restrict access, add a simple bearer token check:
+
+```typescript
+app.get("/sse", async (req, res) => {
+  const token = req.headers.authorization?.replace("Bearer ", "");
+  if (token !== process.env.MCP_AUTH_TOKEN) {
+    return res.status(401).send("Unauthorized");
+  }
+  const transport = new SSEServerTransport("/messages", res);
+  await server.connect(transport);
+});
+```
+
+Set `MCP_AUTH_TOKEN` as an [environment variable](/variables) in your Railway service.
+
+## Adding a database
+
+If your tools need persistent state, add [Postgres](/databases/postgresql) to your project and access it via the `DATABASE_URL` [reference variable](/variables#referencing-another-services-variable). For example, a tool that queries a knowledge base or stores user preferences.
+
+## Next steps
+
+- [Railway MCP Server](/ai/mcp-server): Railway's own MCP server for managing infrastructure.
+- [Agent Skills](/ai/agent-skills): Open format for extending AI coding assistants with Railway knowledge.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): For tools that trigger long-running tasks.
+- [Public Networking](/networking/public-networking): Domain configuration and networking specs.

--- a/content/guides/mcp-server.md
+++ b/content/guides/mcp-server.md
@@ -3,7 +3,6 @@ title: Build and Deploy Your Own MCP Server
 description: Build a Model Context Protocol server in TypeScript and deploy it on Railway. Expose custom tools and resources that AI assistants like Claude and Cursor can call over the network.
 date: "2026-04-14"
 tags:
-  - ai
   - mcp
   - typescript
   - agents

--- a/content/guides/multi-agent-system.md
+++ b/content/guides/multi-agent-system.md
@@ -3,7 +3,6 @@ title: Deploy a Multi-Agent System on Railway
 description: Deploy multiple AI agents as separate Railway services that communicate via Redis and Postgres. Covers agent orchestration, inter-service communication, staggered scheduling, and independent scaling.
 date: "2026-04-14"
 tags:
-  - ai
   - agents
   - multi-agent
   - python

--- a/content/guides/multi-agent-system.md
+++ b/content/guides/multi-agent-system.md
@@ -1,0 +1,137 @@
+---
+title: Deploy a Multi-Agent System on Railway
+description: Deploy multiple AI agents as separate Railway services that communicate via Redis and Postgres. Covers agent orchestration, inter-service communication, staggered scheduling, and independent scaling.
+date: "2026-04-14"
+tags:
+  - ai
+  - agents
+  - multi-agent
+  - python
+  - workers
+topic: ai
+---
+
+A multi-agent system uses multiple specialized AI agents that collaborate on tasks. Each agent has a specific role (researcher, writer, reviewer, etc.) and calls an LLM API to reason through its part of the work. Agents communicate by reading and writing shared state in a database or message queue.
+
+This guide covers deploying a multi-agent system on Railway where each agent runs as a separate service. This architecture lets you scale agents independently, use different LLM providers per agent, and isolate failures.
+
+Railway is a CPU-based platform. All agents call external LLM APIs (OpenAI, Anthropic, etc.) over HTTP. No models run locally.
+
+## Architecture overview
+
+The system uses four types of components:
+
+- **Orchestrator service** receives tasks, breaks them into subtasks, and assigns them to agents via a Redis queue or Postgres task table.
+- **Agent services** (one per role) pull tasks from the queue, call their assigned LLM, and write results back to the shared state.
+- **Postgres** stores task definitions, agent outputs, conversation history, and final results.
+- **Redis** serves as the message queue between the orchestrator and agents.
+
+This extends the [single-agent async workers pattern](/guides/ai-agent-workers) to multiple specialized agents.
+
+## When to use this pattern
+
+- A task requires different capabilities (research, analysis, writing, review) that benefit from separate prompts and models.
+- You want to run agents concurrently to reduce total execution time.
+- Different agents need different resource allocations or scaling behavior.
+- You want to swap or update individual agents without redeploying the entire system.
+
+For simpler use cases where a single agent with tool-calling is sufficient, see [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers).
+
+## Prerequisites
+
+- A Railway account
+- API keys for one or more LLM providers (OpenAI, Anthropic, etc.)
+- Application code structured as separate agent entry points
+
+## 1. Create the project and shared infrastructure
+
+1. Create a new [project](/projects) on Railway.
+2. Add [PostgreSQL](/databases/postgresql): click **+ New > Database > PostgreSQL**.
+3. Add [Redis](/databases/redis): click **+ New > Database > Redis**.
+4. Run your schema migrations via a [pre-deploy command](/deployments/pre-deploy-command) on the orchestrator service.
+
+Create a tasks table for coordination:
+
+```sql
+CREATE TABLE tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  parent_task_id UUID REFERENCES tasks(id),
+  agent_role TEXT NOT NULL,
+  status TEXT DEFAULT 'pending',
+  input JSONB NOT NULL,
+  output JSONB,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+```
+
+## 2. Deploy the orchestrator
+
+The orchestrator receives incoming requests, creates subtasks, and dispatches them to agent queues:
+
+1. Deploy from [GitHub](/deployments/github-autodeploys) or the [CLI](/cli).
+2. Set environment variables:
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
+   - [Reference](/variables#referencing-another-services-variable) `REDIS_URL` from Redis.
+3. Generate a [public domain](/networking/public-networking#railway-provided-domain) for receiving task requests.
+
+The orchestrator pushes tasks to agent-specific Redis queues (e.g., `queue:researcher`, `queue:writer`, `queue:reviewer`).
+
+## 3. Deploy agent services
+
+Each agent is a separate Railway service pointing at the same codebase with a different start command:
+
+1. For each agent role, click **+ New > GitHub Repo** and select the same repository.
+2. Set a different start command per agent:
+   - Researcher: `python -m agents.researcher`
+   - Writer: `python -m agents.writer`
+   - Reviewer: `python -m agents.reviewer`
+3. Set environment variables on each agent service:
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` and `REDIS_URL`.
+   - Set the agent's LLM API key. Different agents can use different providers (e.g., researcher uses Anthropic, writer uses OpenAI).
+4. No public domains are needed for agent services. They communicate via Redis and Postgres over [private networking](/networking/private-networking).
+
+## 4. Handle inter-agent communication
+
+Agents communicate through shared state, not direct calls. Two common patterns:
+
+**Queue-based (Redis):** The orchestrator pushes tasks to per-agent queues. Each agent pulls from its queue, processes the task, writes the result to Postgres, and pushes downstream tasks to the next agent's queue.
+
+**State-based (Postgres):** Agents poll the tasks table for tasks matching their role with status `pending`. After processing, they update the task status and output. The orchestrator or downstream agents watch for completed upstream tasks.
+
+The queue-based approach has lower latency. The state-based approach is simpler to debug since all state is in Postgres.
+
+## 5. Stagger agent startup to avoid rate limits
+
+When multiple agents start simultaneously, they all hit the LLM API at once. This can trigger rate limits, especially with providers that enforce per-minute token caps.
+
+Add a startup delay per agent using an environment variable:
+
+```python
+import os
+import time
+
+startup_delay = int(os.environ.get("STARTUP_DELAY_SECONDS", "0"))
+time.sleep(startup_delay)
+```
+
+Set `STARTUP_DELAY_SECONDS` to `0`, `5`, `10`, etc. on each agent service.
+
+## 6. Scale agents independently
+
+Each agent is a separate Railway service with its own scaling configuration:
+
+- Add [horizontal replicas](/deployments/scaling) to high-throughput agents (e.g., 3 researcher replicas, 1 reviewer replica).
+- Adjust CPU and memory per agent under **Settings > Resources**.
+- Monitor queue depth in Redis to identify bottlenecks.
+
+## Using a framework
+
+If you prefer a framework for agent orchestration, [CrewAI](https://crewai.com) and [AutoGen](https://microsoft.github.io/autogen/) handle agent definitions, task routing, and conversation management. Deploy the framework as your orchestrator service and let it manage agent interactions internally, or split agents into separate services for independent scaling.
+
+## Next steps
+
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): The single-agent version of this pattern.
+- [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector): Give agents access to a knowledge base.
+- [Scaling](/deployments/scaling): Configure horizontal and vertical scaling.
+- [Redis on Railway](/databases/redis): Persistence settings and memory management.

--- a/content/guides/multi-agent-system.md
+++ b/content/guides/multi-agent-system.md
@@ -115,7 +115,7 @@ The orchestrator receives HTTP requests, creates tasks, and dispatches them to a
 
 ```python
 import json
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
 from shared import get_db, get_redis, create_task, get_task
 
 app = FastAPI()
@@ -138,7 +138,7 @@ async def check_task(task_id: str):
     task = get_task(conn, task_id)
     conn.close()
     if not task:
-        return {"error": "not found"}, 404
+        raise HTTPException(status_code=404, detail="not found")
     return task
 ```
 

--- a/content/guides/multi-agent-system.md
+++ b/content/guides/multi-agent-system.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy a Multi-Agent System on Railway
-description: Deploy multiple AI agents as separate Railway services that communicate via Redis and Postgres. Covers agent orchestration, inter-service communication, staggered scheduling, and independent scaling.
+description: Deploy multiple AI agents as separate Railway services that communicate via Redis and Postgres. Includes working orchestrator and agent code, inter-service communication, and independent scaling.
 date: "2026-04-14"
 tags:
   - agents
@@ -10,9 +10,9 @@ tags:
 topic: ai
 ---
 
-A multi-agent system uses multiple specialized AI agents that collaborate on tasks. Each agent has a specific role (researcher, writer, reviewer, etc.) and calls an LLM API to reason through its part of the work. Agents communicate by reading and writing shared state in a database or message queue.
+A multi-agent system uses multiple specialized AI agents that collaborate on tasks. Each agent has a specific role (researcher, writer, reviewer) and calls an LLM API to reason through its part of the work. Agents communicate by reading and writing shared state in a database and message queue.
 
-This guide covers deploying a multi-agent system on Railway where each agent runs as a separate service. This architecture lets you scale agents independently, use different LLM providers per agent, and isolate failures.
+This guide covers deploying a multi-agent system on Railway where each agent runs as a separate service. This lets you scale agents independently, use different LLM providers per agent, and isolate failures.
 
 Railway is a CPU-based platform. All agents call external LLM APIs (OpenAI, Anthropic, etc.) over HTTP. No models run locally.
 
@@ -20,107 +20,302 @@ Railway is a CPU-based platform. All agents call external LLM APIs (OpenAI, Anth
 
 The system uses four types of components:
 
-- **Orchestrator service** receives tasks, breaks them into subtasks, and assigns them to agents via a Redis queue or Postgres task table.
-- **Agent services** (one per role) pull tasks from the queue, call their assigned LLM, and write results back to the shared state.
-- **Postgres** stores task definitions, agent outputs, conversation history, and final results.
-- **Redis** serves as the message queue between the orchestrator and agents.
+- **Orchestrator service** receives tasks via HTTP, creates subtasks, and dispatches them to agent-specific Redis queues.
+- **Agent services** (one per role) pull tasks from their queue, call their assigned LLM, write results to Postgres, and push downstream tasks to the next agent's queue.
+- **Postgres** stores task state, agent outputs, and final results.
+- **Redis** serves as the message queue between services.
 
 This extends the [single-agent async workers pattern](/guides/ai-agent-workers) to multiple specialized agents.
-
-## When to use this pattern
-
-- A task requires different capabilities (research, analysis, writing, review) that benefit from separate prompts and models.
-- You want to run agents concurrently to reduce total execution time.
-- Different agents need different resource allocations or scaling behavior.
-- You want to swap or update individual agents without redeploying the entire system.
-
-For simpler use cases where a single agent with tool-calling is sufficient, see [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers).
 
 ## Prerequisites
 
 - A Railway account
 - API keys for one or more LLM providers (OpenAI, Anthropic, etc.)
-- Application code structured as separate agent entry points
+- Python 3.11+
+
+## Project structure
+
+Create a repository with the following structure:
+
+```
+multi-agent/
+├── requirements.txt
+├── shared.py
+├── orchestrator.py
+├── agents/
+│   ├── __init__.py
+│   ├── researcher.py
+│   └── writer.py
+```
+
+### requirements.txt
+
+```
+fastapi
+uvicorn
+openai
+redis
+psycopg2-binary
+```
+
+### shared.py
+
+Shared utilities for database and Redis connections used by all services:
+
+```python
+import os
+import json
+import uuid
+import psycopg2
+import redis
+
+DATABASE_URL = os.environ["DATABASE_URL"]
+REDIS_URL = os.environ["REDIS_URL"]
+
+def get_db():
+    return psycopg2.connect(DATABASE_URL)
+
+def get_redis():
+    return redis.from_url(REDIS_URL)
+
+def create_task(conn, agent_role: str, input_data: dict, parent_id: str = None) -> str:
+    task_id = str(uuid.uuid4())
+    cur = conn.cursor()
+    cur.execute(
+        """INSERT INTO tasks (id, parent_task_id, agent_role, status, input)
+           VALUES (%s, %s, %s, 'pending', %s)""",
+        (task_id, parent_id, agent_role, json.dumps(input_data)),
+    )
+    conn.commit()
+    cur.close()
+    return task_id
+
+def complete_task(conn, task_id: str, output_data: dict):
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE tasks SET status = 'completed', output = %s WHERE id = %s",
+        (json.dumps(output_data), task_id),
+    )
+    conn.commit()
+    cur.close()
+
+def get_task(conn, task_id: str) -> dict:
+    cur = conn.cursor()
+    cur.execute("SELECT id, agent_role, status, input, output FROM tasks WHERE id = %s", (task_id,))
+    row = cur.fetchone()
+    cur.close()
+    if not row:
+        return None
+    return {"id": row[0], "agent_role": row[1], "status": row[2], "input": row[3], "output": row[4]}
+```
+
+### orchestrator.py
+
+The orchestrator receives HTTP requests, creates tasks, and dispatches them to agent queues:
+
+```python
+import json
+from fastapi import FastAPI
+from shared import get_db, get_redis, create_task, get_task
+
+app = FastAPI()
+
+@app.post("/tasks")
+async def submit_task(topic: str):
+    conn = get_db()
+    r = get_redis()
+
+    # Create a research task and push it to the researcher queue
+    task_id = create_task(conn, "researcher", {"topic": topic})
+    r.lpush("queue:researcher", json.dumps({"task_id": task_id}))
+    conn.close()
+
+    return {"task_id": task_id}
+
+@app.get("/tasks/{task_id}")
+async def check_task(task_id: str):
+    conn = get_db()
+    task = get_task(conn, task_id)
+    conn.close()
+    if not task:
+        return {"error": "not found"}, 404
+    return task
+```
+
+### agents/researcher.py
+
+The researcher agent pulls tasks from its queue, calls the LLM to research a topic, then creates a follow-up task for the writer:
+
+```python
+import os
+import json
+import time
+from openai import OpenAI
+from shared import get_db, get_redis, complete_task, create_task
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+startup_delay = int(os.environ.get("STARTUP_DELAY_SECONDS", "0"))
+time.sleep(startup_delay)
+
+def run():
+    r = get_redis()
+    print("Researcher agent started, waiting for tasks...")
+
+    while True:
+        _, message = r.brpop("queue:researcher")
+        data = json.loads(message)
+        task_id = data["task_id"]
+
+        conn = get_db()
+        from shared import get_task
+        task = get_task(conn, task_id)
+        topic = task["input"]["topic"]
+
+        # Call the LLM to research the topic
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "You are a research assistant. Provide detailed findings on the given topic."},
+                {"role": "user", "content": f"Research this topic: {topic}"},
+            ],
+        )
+        research = response.choices[0].message.content
+
+        # Mark research task as complete
+        complete_task(conn, task_id, {"research": research})
+
+        # Create a writing task and push it to the writer queue
+        writer_task_id = create_task(conn, "writer", {"topic": topic, "research": research}, parent_id=task_id)
+        r.lpush("queue:writer", json.dumps({"task_id": writer_task_id}))
+        conn.close()
+
+        print(f"Research complete for task {task_id}, dispatched to writer")
+
+if __name__ == "__main__":
+    run()
+```
+
+### agents/writer.py
+
+The writer agent takes research output and produces a finished article:
+
+```python
+import os
+import json
+import time
+from openai import OpenAI
+from shared import get_db, get_redis, complete_task
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+
+startup_delay = int(os.environ.get("STARTUP_DELAY_SECONDS", "0"))
+time.sleep(startup_delay)
+
+def run():
+    r = get_redis()
+    print("Writer agent started, waiting for tasks...")
+
+    while True:
+        _, message = r.brpop("queue:writer")
+        data = json.loads(message)
+        task_id = data["task_id"]
+
+        conn = get_db()
+        from shared import get_task
+        task = get_task(conn, task_id)
+        topic = task["input"]["topic"]
+        research = task["input"]["research"]
+
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=[
+                {"role": "system", "content": "You are a writer. Turn the research into a clear, well-structured article."},
+                {"role": "user", "content": f"Topic: {topic}\n\nResearch:\n{research}"},
+            ],
+        )
+        article = response.choices[0].message.content
+
+        complete_task(conn, task_id, {"article": article})
+        conn.close()
+
+        print(f"Article written for task {task_id}")
+
+if __name__ == "__main__":
+    run()
+```
 
 ## 1. Create the project and shared infrastructure
 
 1. Create a new [project](/projects) on Railway.
 2. Add [PostgreSQL](/databases/postgresql): click **+ New > Database > PostgreSQL**.
 3. Add [Redis](/databases/redis): click **+ New > Database > Redis**.
-4. Run your schema migrations via a [pre-deploy command](/deployments/pre-deploy-command) on the orchestrator service.
 
-Create a tasks table for coordination:
+Create the tasks table by connecting to Postgres and running:
 
 ```sql
 CREATE TABLE tasks (
-  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  parent_task_id UUID REFERENCES tasks(id),
+  id TEXT PRIMARY KEY,
+  parent_task_id TEXT REFERENCES tasks(id),
   agent_role TEXT NOT NULL,
   status TEXT DEFAULT 'pending',
   input JSONB NOT NULL,
   output JSONB,
-  created_at TIMESTAMPTZ DEFAULT now(),
-  updated_at TIMESTAMPTZ DEFAULT now()
+  created_at TIMESTAMPTZ DEFAULT now()
 );
 ```
 
 ## 2. Deploy the orchestrator
 
-The orchestrator receives incoming requests, creates subtasks, and dispatches them to agent queues:
-
-1. Deploy from [GitHub](/deployments/github-autodeploys) or the [CLI](/cli).
-2. Set environment variables:
+1. Push the code above to a GitHub repository.
+2. In your project, click **+ New > GitHub Repo** and select your repository.
+3. Set the [start command](/deployments/start-command) to: `uvicorn orchestrator:app --host 0.0.0.0 --port $PORT`
+4. Set environment variables:
    - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
    - [Reference](/variables#referencing-another-services-variable) `REDIS_URL` from Redis.
-3. Generate a [public domain](/networking/public-networking#railway-provided-domain) for receiving task requests.
-
-The orchestrator pushes tasks to agent-specific Redis queues (e.g., `queue:researcher`, `queue:writer`, `queue:reviewer`).
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) for receiving task requests.
 
 ## 3. Deploy agent services
 
-Each agent is a separate Railway service pointing at the same codebase with a different start command:
+Each agent is a separate Railway service pointing at the same repository with a different start command:
 
-1. For each agent role, click **+ New > GitHub Repo** and select the same repository.
-2. Set a different start command per agent:
-   - Researcher: `python -m agents.researcher`
-   - Writer: `python -m agents.writer`
-   - Reviewer: `python -m agents.reviewer`
-3. Set environment variables on each agent service:
-   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` and `REDIS_URL`.
-   - Set the agent's LLM API key. Different agents can use different providers (e.g., researcher uses Anthropic, writer uses OpenAI).
-4. No public domains are needed for agent services. They communicate via Redis and Postgres over [private networking](/networking/private-networking).
+1. Click **+ New > GitHub Repo** and select the same repository again.
+2. Name the service `researcher`.
+3. Set the [start command](/deployments/start-command) to: `python -m agents.researcher`
+4. Set environment variables:
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` and `REDIS_URL` (same as the orchestrator).
+   - Set `OPENAI_API_KEY` to your API key.
+   - Set `STARTUP_DELAY_SECONDS` to `0`.
+5. No public domain is needed. The agent communicates via Redis and Postgres over [private networking](/networking/private-networking).
 
-## 4. Handle inter-agent communication
+Repeat for the writer agent:
 
-Agents communicate through shared state, not direct calls. Two common patterns:
+1. Click **+ New > GitHub Repo** and select the same repository.
+2. Name the service `writer`.
+3. Set the [start command](/deployments/start-command) to: `python -m agents.writer`
+4. Set the same environment variables, but set `STARTUP_DELAY_SECONDS` to `5` to stagger startup and avoid hitting LLM API rate limits.
 
-**Queue-based (Redis):** The orchestrator pushes tasks to per-agent queues. Each agent pulls from its queue, processes the task, writes the result to Postgres, and pushes downstream tasks to the next agent's queue.
+## 4. Test the system
 
-**State-based (Postgres):** Agents poll the tasks table for tasks matching their role with status `pending`. After processing, they update the task status and output. The orchestrator or downstream agents watch for completed upstream tasks.
+Send a task to the orchestrator:
 
-The queue-based approach has lower latency. The state-based approach is simpler to debug since all state is in Postgres.
-
-## 5. Stagger agent startup to avoid rate limits
-
-When multiple agents start simultaneously, they all hit the LLM API at once. This can trigger rate limits, especially with providers that enforce per-minute token caps.
-
-Add a startup delay per agent using an environment variable:
-
-```python
-import os
-import time
-
-startup_delay = int(os.environ.get("STARTUP_DELAY_SECONDS", "0"))
-time.sleep(startup_delay)
+```bash
+curl -X POST "https://your-orchestrator.up.railway.app/tasks?topic=quantum+computing"
 ```
 
-Set `STARTUP_DELAY_SECONDS` to `0`, `5`, `10`, etc. on each agent service.
+This returns a task ID. The researcher picks it up, calls the LLM, writes the research to Postgres, and dispatches a writing task. The writer picks that up and produces an article.
 
-## 6. Scale agents independently
+Check the result:
+
+```bash
+curl "https://your-orchestrator.up.railway.app/tasks/TASK_ID"
+```
+
+## 5. Scale agents independently
 
 Each agent is a separate Railway service with its own scaling configuration:
 
-- Add [horizontal replicas](/deployments/scaling) to high-throughput agents (e.g., 3 researcher replicas, 1 reviewer replica).
+- Add [horizontal replicas](/deployments/scaling) to high-throughput agents (e.g., 3 researcher replicas, 1 writer replica). All replicas pull from the same Redis queue.
 - Adjust CPU and memory per agent under **Settings > Resources**.
 - Monitor queue depth in Redis to identify bottlenecks.
 

--- a/content/guides/open-webui.md
+++ b/content/guides/open-webui.md
@@ -3,7 +3,6 @@ title: Self-Host Open WebUI
 description: Deploy Open WebUI on Railway to get a ChatGPT-like interface that connects to OpenAI, Anthropic, and other LLM providers. Includes persistent storage and authentication setup.
 date: "2026-04-14"
 tags:
-  - ai
   - open-webui
   - docker
   - self-hosted

--- a/content/guides/open-webui.md
+++ b/content/guides/open-webui.md
@@ -1,0 +1,91 @@
+---
+title: Self-Host Open WebUI
+description: Deploy Open WebUI on Railway to get a ChatGPT-like interface that connects to OpenAI, Anthropic, and other LLM providers. Includes persistent storage and authentication setup.
+date: "2026-04-14"
+tags:
+  - ai
+  - open-webui
+  - docker
+  - self-hosted
+topic: ai
+---
+
+[Open WebUI](https://openwebui.com) is an open-source chat interface for interacting with LLMs. It provides a ChatGPT-like experience that you control, with support for multiple model providers, conversation history, file uploads, and user management.
+
+Open WebUI is commonly paired with Ollama for local model inference, but Railway does not offer GPU instances. This guide configures Open WebUI to connect to external LLM APIs (OpenAI, Anthropic, etc.) instead.
+
+## What you will set up
+
+- An Open WebUI instance running from the official Docker image
+- Persistent storage for conversation history and uploaded files
+- Connection to external LLM APIs (not Ollama)
+- A public domain for accessing the chat interface
+
+## One-click deploy from a template
+
+Railway has an Open WebUI template that provisions the setup in one step.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/open-webui)
+
+After deploying, skip to [Configure LLM providers](#configure-llm-providers).
+
+If you prefer manual setup, continue below.
+
+## Deploy from a Docker image
+
+1. Create a new project in Railway.
+2. Click **+ New** and select **Docker Image**.
+3. Enter `ghcr.io/open-webui/open-webui:main` as the image name.
+4. Railway will pull the image and create a service.
+
+## Configure environment variables
+
+Add the following variables under the **Variables** tab:
+
+| Variable | Value | Description |
+| --- | --- | --- |
+| `PORT` | `8080` | Port for the web interface |
+| `OLLAMA_BASE_URL` | (leave empty) | Disables Ollama connection attempts |
+| `OPENAI_API_BASE_URL` | `https://api.openai.com/v1` | OpenAI-compatible API endpoint |
+| `OPENAI_API_KEY` | Your API key | API key for OpenAI (or compatible provider) |
+| `WEBUI_SECRET_KEY` | A random string | Secret key for session management |
+| `DATA_DIR` | `/app/backend/data` | Directory for persistent data |
+
+To use Anthropic or other providers, configure them through the Open WebUI settings after first login. Open WebUI supports multiple concurrent providers.
+
+## Attach persistent storage
+
+Open WebUI stores conversations, uploaded files, and user data in `/app/backend/data`. Without a volume, this data is lost on each deployment.
+
+1. Open the service in your project.
+2. Go to the **Volumes** tab.
+3. Click **Add Volume**.
+4. Set the mount path to `/app/backend/data`.
+5. Choose a size (2 GB is a reasonable starting point).
+6. Click **Add**.
+
+## Set up a public domain
+
+1. Go to the **Settings** tab of the service.
+2. Under **Networking**, click **Generate Domain**.
+3. Open the domain in your browser.
+
+## Configure LLM providers
+
+1. On first access, create an admin account.
+2. Go to **Settings > Connections**.
+3. Verify your OpenAI connection is active, or add additional providers.
+4. Models from connected providers will appear in the model selector dropdown.
+
+Open WebUI supports any OpenAI-compatible API endpoint. This includes providers like Anthropic (via their OpenAI-compatible endpoint), Together AI, Groq, and Fireworks.
+
+## GPU and Ollama
+
+Open WebUI is often used with Ollama for running models locally. Railway does not offer GPU instances, so running Ollama with production-sized models is not practical on Railway. If you need local inference, connect Open WebUI on Railway to an Ollama instance running on a GPU-equipped server elsewhere by setting `OLLAMA_BASE_URL` to that server's address.
+
+## Next steps
+
+- [Manage Volumes](/volumes): Resize or back up your persistent storage.
+- [Set up a custom domain](/networking/domains): Use your own domain for the interface.
+- [Monitor your app](/observability): View logs and metrics.
+- [Self-Host Flowise](/guides/flowise): A visual builder for LLM chains and workflows.

--- a/content/guides/rag-pipeline-pgvector.md
+++ b/content/guides/rag-pipeline-pgvector.md
@@ -3,7 +3,6 @@ title: Deploy a RAG Pipeline with pgvector
 description: Build a retrieval-augmented generation pipeline on Railway using Postgres with pgvector for vector storage, an external embedding API, and an LLM for generation. Covers document ingestion, similarity search, and deployment.
 date: "2026-04-14"
 tags:
-  - ai
   - rag
   - pgvector
   - embeddings

--- a/content/guides/rag-pipeline-pgvector.md
+++ b/content/guides/rag-pipeline-pgvector.md
@@ -1,0 +1,194 @@
+---
+title: Deploy a RAG Pipeline with pgvector
+description: Build a retrieval-augmented generation pipeline on Railway using Postgres with pgvector for vector storage, an external embedding API, and an LLM for generation. Covers document ingestion, similarity search, and deployment.
+date: "2026-04-14"
+tags:
+  - ai
+  - rag
+  - pgvector
+  - embeddings
+  - postgres
+  - python
+topic: ai
+---
+
+Retrieval-augmented generation (RAG) combines a vector database with an LLM to answer questions using your own data. Instead of relying only on the model's training data, the system retrieves relevant documents from a vector store and includes them in the prompt.
+
+This guide covers deploying a RAG pipeline on Railway using Postgres with the pgvector extension for vector storage, an external embedding API for generating vectors, and an external LLM API for generation.
+
+Railway is a CPU-based platform. Both embedding generation and text generation call external APIs (OpenAI, Cohere, etc.) over HTTP. No models run locally.
+
+## Architecture overview
+
+The pipeline has three components:
+
+- **Postgres with pgvector** stores document chunks and their embedding vectors. Deployed from Railway's pgvector template.
+- **API service** accepts queries, retrieves relevant documents via similarity search, and calls the LLM with the retrieved context.
+- **Ingestion script** (or endpoint) chunks documents, generates embeddings via an external API, and stores them in Postgres.
+
+## Prerequisites
+
+- A Railway account
+- An API key from [OpenAI](https://platform.openai.com/api-keys) (for both embeddings and chat completions) or separate embedding and LLM providers
+- Documents to ingest (text files, markdown, or any text content)
+
+## 1. Deploy Postgres with pgvector
+
+Railway's standard Postgres image does not include pgvector. Use the pgvector template instead:
+
+1. Click the button below to deploy Postgres with pgvector:
+
+   [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/3jJFCA)
+
+2. After the template deploys, note the `DATABASE_URL` connection string from the service's **Variables** tab.
+
+## 2. Create the vector table
+
+Connect to your pgvector Postgres instance and create a table for document chunks and their embeddings:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE documents (
+  id SERIAL PRIMARY KEY,
+  content TEXT NOT NULL,
+  metadata JSONB DEFAULT '{}',
+  embedding vector(1536)
+);
+
+CREATE INDEX idx_documents_embedding ON documents
+  USING hnsw (embedding vector_cosine_ops);
+```
+
+The `vector(1536)` type matches OpenAI's `text-embedding-3-small` output dimension. Adjust the dimension if you use a different embedding model.
+
+The HNSW index provides fast approximate nearest-neighbor search. For datasets under 100,000 rows, an IVFFlat index is also viable and uses less memory during index creation.
+
+## 3. Build the ingestion pipeline
+
+The ingestion step chunks your documents, generates embeddings, and inserts them into Postgres. Here is a minimal Python example using FastAPI and OpenAI:
+
+```python
+# ingest.py
+import os
+import psycopg2
+from openai import OpenAI
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+def chunk_text(text: str, chunk_size: int = 500) -> list[str]:
+    words = text.split()
+    return [
+        " ".join(words[i:i + chunk_size])
+        for i in range(0, len(words), chunk_size)
+    ]
+
+def embed(texts: list[str]) -> list[list[float]]:
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=texts,
+    )
+    return [item.embedding for item in response.data]
+
+def ingest(text: str, metadata: dict = None):
+    chunks = chunk_text(text)
+    embeddings = embed(chunks)
+
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    for chunk, emb in zip(chunks, embeddings):
+        cur.execute(
+            "INSERT INTO documents (content, metadata, embedding) VALUES (%s, %s, %s)",
+            (chunk, psycopg2.extras.Json(metadata or {}), emb),
+        )
+    conn.commit()
+    cur.close()
+    conn.close()
+```
+
+For large document sets, run ingestion as a one-off task using a [Railway CLI](/cli) command or as a [pre-deploy command](/deployments/pre-deploy-command). For ongoing ingestion, consider the [async workers pattern](/guides/ai-agent-workers).
+
+## 4. Build the query endpoint
+
+The query endpoint embeds the user's question, finds similar document chunks, and sends them to the LLM as context:
+
+```python
+# app.py
+import os
+import psycopg2
+from fastapi import FastAPI
+from openai import OpenAI
+
+app = FastAPI()
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+@app.post("/query")
+async def query(question: str):
+    # 1. Embed the question
+    response = client.embeddings.create(
+        model="text-embedding-3-small",
+        input=question,
+    )
+    query_embedding = response.data[0].embedding
+
+    # 2. Retrieve similar documents
+    conn = psycopg2.connect(DATABASE_URL)
+    cur = conn.cursor()
+    cur.execute(
+        """
+        SELECT content, 1 - (embedding <=> %s::vector) AS similarity
+        FROM documents
+        ORDER BY embedding <=> %s::vector
+        LIMIT 5
+        """,
+        (query_embedding, query_embedding),
+    )
+    results = cur.fetchall()
+    cur.close()
+    conn.close()
+
+    context = "\n\n".join(row[0] for row in results)
+
+    # 3. Generate a response with context
+    completion = client.chat.completions.create(
+        model="gpt-4o",
+        messages=[
+            {
+                "role": "system",
+                "content": f"Answer based on the following context:\n\n{context}",
+            },
+            {"role": "user", "content": question},
+        ],
+    )
+
+    return {
+        "answer": completion.choices[0].message.content,
+        "sources": [{"content": row[0], "similarity": row[1]} for row in results],
+    }
+```
+
+## 5. Deploy the API service
+
+1. Push your code to a GitHub repository.
+2. In your Railway project (the same one with pgvector), click **+ New > GitHub Repo** and select your repository.
+3. Add environment variables:
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from your pgvector service.
+   - Set `OPENAI_API_KEY` to your API key.
+4. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
+
+The API service communicates with Postgres over [private networking](/networking/private-networking) automatically since both services are in the same project.
+
+## Performance considerations
+
+- **Embedding API costs**: OpenAI's `text-embedding-3-small` costs $0.02 per million tokens. Cache embeddings in Postgres to avoid re-embedding the same content.
+- **Query latency**: The embedding API call adds 100-300ms per query. The pgvector similarity search is fast (single-digit milliseconds for datasets under 1M rows with an HNSW index).
+- **Scaling**: For high query volume, add [horizontal replicas](/deployments/scaling) to the API service. All replicas share the same Postgres instance.
+
+## Next steps
+
+- [Deploy an AI Chatbot with Streaming Responses](/guides/ai-chatbot-streaming): Add a chat UI with streaming on top of your RAG pipeline.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): Process large document ingestion jobs asynchronously.
+- [PostgreSQL on Railway](/databases/postgresql): Connection pooling, backups, and configuration.
+- [Scaling](/deployments/scaling): Configure horizontal and vertical scaling for your services.

--- a/content/guides/rag-pipeline-pgvector.md
+++ b/content/guides/rag-pipeline-pgvector.md
@@ -63,14 +63,30 @@ The `vector(1536)` type matches OpenAI's `text-embedding-3-small` output dimensi
 
 The HNSW index provides fast approximate nearest-neighbor search. For datasets under 100,000 rows, an IVFFlat index is also viable and uses less memory during index creation.
 
-## 3. Build the ingestion pipeline
+## 3. Set up the project
 
-The ingestion step chunks your documents, generates embeddings, and inserts them into Postgres. Here is a minimal Python example using FastAPI and OpenAI:
+Create a project directory with the following files:
+
+### requirements.txt
+
+```
+fastapi
+uvicorn
+openai
+psycopg2-binary
+```
+
+Install dependencies locally with `pip install -r requirements.txt`.
+
+## 4. Build the ingestion pipeline
+
+The ingestion step chunks your documents, generates embeddings, and inserts them into Postgres:
 
 ```python
 # ingest.py
 import os
 import psycopg2
+import psycopg2.extras
 from openai import OpenAI
 
 client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
@@ -104,11 +120,20 @@ def ingest(text: str, metadata: dict = None):
     conn.commit()
     cur.close()
     conn.close()
+
+if __name__ == "__main__":
+    import sys
+    if len(sys.argv) < 2:
+        print("Usage: python ingest.py <file_path>")
+        sys.exit(1)
+    with open(sys.argv[1]) as f:
+        ingest(f.read(), {"source": sys.argv[1]})
+    print(f"Ingested {sys.argv[1]}")
 ```
 
-For large document sets, run ingestion as a one-off task using a [Railway CLI](/cli) command or as a [pre-deploy command](/deployments/pre-deploy-command). For ongoing ingestion, consider the [async workers pattern](/guides/ai-agent-workers).
+Run locally with `python ingest.py my_document.txt`, or run it on Railway using the [CLI](/cli): `railway run python ingest.py my_document.txt`. For ongoing ingestion at scale, consider the [async workers pattern](/guides/ai-agent-workers).
 
-## 4. Build the query endpoint
+## 5. Build the query endpoint
 
 The query endpoint embeds the user's question, finds similar document chunks, and sends them to the LLM as context:
 
@@ -168,14 +193,15 @@ async def query(question: str):
     }
 ```
 
-## 5. Deploy the API service
+## 6. Deploy the API service
 
 1. Push your code to a GitHub repository.
 2. In your Railway project (the same one with pgvector), click **+ New > GitHub Repo** and select your repository.
-3. Add environment variables:
+3. Set the [start command](/deployments/start-command) to: `uvicorn app:app --host 0.0.0.0 --port $PORT`
+4. Add environment variables:
    - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from your pgvector service.
    - Set `OPENAI_API_KEY` to your API key.
-4. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
 
 The API service communicates with Postgres over [private networking](/networking/private-networking) automatically since both services are in the same project.
 

--- a/content/guides/rag-pipeline-pgvector.md
+++ b/content/guides/rag-pipeline-pgvector.md
@@ -115,7 +115,7 @@ def ingest(text: str, metadata: dict = None):
     for chunk, emb in zip(chunks, embeddings):
         cur.execute(
             "INSERT INTO documents (content, metadata, embedding) VALUES (%s, %s, %s)",
-            (chunk, psycopg2.extras.Json(metadata or {}), emb),
+            (chunk, psycopg2.extras.Json(metadata or {}), str(emb)),
         )
     conn.commit()
     cur.close()
@@ -155,7 +155,7 @@ async def query(question: str):
         model="text-embedding-3-small",
         input=question,
     )
-    query_embedding = response.data[0].embedding
+    query_embedding = str(response.data[0].embedding)
 
     # 2. Retrieve similar documents
     conn = psycopg2.connect(DATABASE_URL)

--- a/content/guides/vibe-coding-deploy.md
+++ b/content/guides/vibe-coding-deploy.md
@@ -3,7 +3,6 @@ title: Deploy a Vibe-Coded App on Railway
 description: Deploy an application built with AI coding tools like Cursor, Claude Code, Bolt, or Lovable on Railway. Covers common deployment issues with AI-generated code and how to fix them.
 date: "2026-04-14"
 tags:
-  - ai
   - deployment
   - docker
 topic: ai

--- a/content/guides/vibe-coding-deploy.md
+++ b/content/guides/vibe-coding-deploy.md
@@ -1,0 +1,118 @@
+---
+title: Deploy a Vibe-Coded App on Railway
+description: Deploy an application built with AI coding tools like Cursor, Claude Code, Bolt, or Lovable on Railway. Covers common deployment issues with AI-generated code and how to fix them.
+date: "2026-04-14"
+tags:
+  - ai
+  - deployment
+  - docker
+topic: ai
+---
+
+AI coding tools like Cursor, Claude Code, Bolt, and Lovable generate working applications quickly. Deploying that code to production often surfaces issues that did not appear in local development. This guide covers how to deploy AI-generated code on Railway and fix the most common problems.
+
+For Lovable-specific deployment, see the dedicated [Lovable guide](/guides/lovable).
+
+## How Railway detects your app
+
+When you deploy code to Railway, [Railpack](/builds/railpack) (or [Nixpacks](/builds/nixpacks)) analyzes your repository to detect the language and framework. It then installs dependencies, runs the build, and starts the application.
+
+For most AI-generated projects, auto-detection works without extra configuration. If it fails, you can add a [Dockerfile](/builds/dockerfiles) for full control over the build.
+
+## Deploy from GitHub
+
+1. Push your AI-generated code to a GitHub repository.
+2. Create a new [project](/projects) on Railway.
+3. Click **+ New > GitHub Repo** and select your repository.
+4. Railway auto-detects the framework and starts the first build.
+5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
+
+If the build fails, check the build logs for errors and see the troubleshooting section below.
+
+## Deploy from the CLI
+
+If your code is not on GitHub, deploy directly from your local machine:
+
+```bash
+npm install -g @railway/cli
+railway login
+railway init
+railway up
+```
+
+The CLI uploads your code, builds it on Railway, and deploys the result.
+
+## Common issues with AI-generated code
+
+### Hardcoded ports
+
+AI tools often hardcode the port number (e.g., `app.listen(3000)`). Railway injects the port via the `PORT` environment variable. Your app must read it:
+
+```javascript
+// Wrong
+app.listen(3000);
+
+// Correct
+const port = process.env.PORT || 3000;
+app.listen(port, "0.0.0.0");
+```
+
+Also ensure the app binds to `0.0.0.0`, not `localhost` or `127.0.0.1`. Binding to localhost makes the app unreachable from outside the container.
+
+### Missing environment variables
+
+AI-generated code may reference environment variables that exist in a local `.env` file but are not set on Railway. Check your code for references to `process.env.*` or `os.environ` and add each variable in the Railway [Variables](/variables) tab.
+
+Do not commit `.env` files to your repository. Add sensitive values directly in the Railway dashboard.
+
+### Missing start command
+
+If Railway cannot detect how to start your app, add a [start command](/deployments/start-command) in the service settings. Common examples:
+
+| Framework | Start command |
+| --- | --- |
+| Next.js | `npm start` |
+| Express | `node server.js` |
+| FastAPI | `uvicorn main:app --host 0.0.0.0 --port $PORT` |
+| Flask | `gunicorn app:app --bind 0.0.0.0:$PORT` |
+
+### No build step configured
+
+Some AI-generated projects have build steps that are not captured in `package.json` scripts. Verify that `npm run build` (or the equivalent for your framework) produces the expected output. If your project needs a custom build command, set it under **Settings > Build > Build Command**.
+
+### Database connection issues
+
+If your app expects a database, AI tools sometimes generate connection strings that point to `localhost`. On Railway, databases run as separate services. Add a database to your project and [reference its connection URL](/variables#referencing-another-services-variable) as an environment variable.
+
+### Health check failures
+
+Railway checks that your service responds on its assigned port. If your app takes a long time to start or does not respond to HTTP requests, the deploy may fail. Check that:
+
+1. The app binds to `0.0.0.0` and the `PORT` variable.
+2. The app responds to requests within the [health check timeout](/deployments/healthchecks).
+3. There are no startup errors in the [deployment logs](/observability/logs).
+
+## Adding a Dockerfile
+
+If auto-detection does not work for your project, add a `Dockerfile` to the repository root. Here is a generic Node.js example:
+
+```dockerfile
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+EXPOSE ${PORT}
+CMD ["npm", "start"]
+```
+
+Railway automatically uses the Dockerfile when present.
+
+## Next steps
+
+- [Railpack](/builds/railpack): How Railway auto-detects and builds your app.
+- [Environment Variables](/variables): Configure secrets and connection strings.
+- [Deployments](/deployments): Build settings, start commands, and deploy triggers.
+- [Deploy a Lovable App](/guides/lovable): Lovable-specific deployment guide.
+- [Troubleshooting Builds](/builds/build-configuration): Fix common build failures.

--- a/content/guides/vibe-coding-deploy.md
+++ b/content/guides/vibe-coding-deploy.md
@@ -14,7 +14,7 @@ For Lovable-specific deployment, see the dedicated [Lovable guide](/guides/lovab
 
 ## How Railway detects your app
 
-When you deploy code to Railway, [Railpack](/builds/railpack) (or [Nixpacks](/builds/nixpacks)) analyzes your repository to detect the language and framework. It then installs dependencies, runs the build, and starts the application.
+When you deploy code to Railway, [Railpack](/builds/railpack) analyzes your repository to detect the language and framework. It then installs dependencies, runs the build, and starts the application.
 
 For most AI-generated projects, auto-detection works without extra configuration. If it fails, you can add a [Dockerfile](/builds/dockerfiles) for full control over the build.
 

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -10,6 +10,7 @@ import { cn } from "@/lib/cn";
 
 // Shared topic IDs
 const TOPIC_IDS = {
+  AI: "ai",
   FRAMEWORKS: "frameworks",
   ARCHITECTURE: "architecture",
   INTEGRATIONS: "integrations",
@@ -19,6 +20,12 @@ const TOPIC_IDS = {
 type TopicId = (typeof TOPIC_IDS)[keyof typeof TOPIC_IDS];
 
 const TOPICS: { name: string; id: TopicId; description: string; color: string }[] = [
+  {
+    name: "AI",
+    id: TOPIC_IDS.AI,
+    description: "Deploy AI apps and agents",
+    color: "bg-danger-element text-danger-base",
+  },
   {
     name: "Frameworks",
     id: TOPIC_IDS.FRAMEWORKS,


### PR DESCRIPTION
## Summary
- Adds a new "AI" topic to the guides index page (first position, `bg-danger-element` color)
- Re-tags `ai-agent-workers.md` from `topic: architecture` to `topic: ai`
- Adds 11 new guides covering AI app deployment patterns on Railway

All guides are honest about Railway being CPU-only (no GPU). Every guide makes clear that LLM inference calls external APIs.

## New guides

| Guide | File |
|-------|------|
| Deploy an AI Chatbot with Streaming Responses | `ai-chatbot-streaming.md` |
| Deploy a RAG Pipeline with pgvector | `rag-pipeline-pgvector.md` |
| Deploy an AI-Powered SaaS App | `deploy-ai-saas.md` |
| Self-Host Flowise | `flowise.md` |
| Self-Host Dify | `dify.md` |
| Self-Host Open WebUI | `open-webui.md` |
| Build and Deploy Your Own MCP Server | `mcp-server.md` |
| Deploy a Multi-Agent System | `multi-agent-system.md` |
| Deploy a Vibe-Coded App | `vibe-coding-deploy.md` |
| Deploy an AI-Powered Bot for Discord or Telegram | `ai-discord-telegram-bot.md` |
| Deploy an AI API Gateway | `ai-api-proxy.md` |

## Infrastructure changes
- `src/pages/guides/index.tsx`: Added `AI` to `TOPIC_IDS` and `TOPICS` array (first position)
- `content/guides/ai-agent-workers.md`: Changed `topic: architecture` → `topic: ai`