### PR TITLE
Update Pro volume self-serve limit from 250 GB to 1 TB

### DIFF
--- a/content/docs/pricing/plans.md
+++ b/content/docs/pricing/plans.md
@@ -45,7 +45,7 @@ Depending on the plan you are on, you are allowed to use up these resources per 
 
 Note that these are maximum values and include replica multiplication.
 
-\* For Volumes, Pro users and above can self-serve to increase their volume up to 250 GB. Check out [this guide](/volumes#live-resizing-the-volume) for information.
+\* For Volumes, Pro users and above can self-serve to increase their volume up to 1 TB. Check out [this guide](/volumes#live-resizing-the-volume) for information.
 
 ### Resource usage pricing
 

--- a/content/docs/volumes/reference.md
+++ b/content/docs/volumes/reference.md
@@ -19,9 +19,9 @@ Volumes have a default size based on the [subscription plan](/pricing/plans#plan
 
 Volumes can be resized on all paid plans (Hobby and Pro), including via live resize with zero downtime.
 
-Pro users and above can self-serve to increase their volume up to 250 GB.
+Pro users and above can self-serve to increase their volume up to 1 TB.
 
-For Pro and above users, please reach out to us on [Central Station](https://station.railway.com/questions) if you need more than 250GB. Enterprise users with $2,000/month committed spend can also use [Slack](/platform/support#slack).
+For storage needs beyond 1TB, an [Enterprise plan](/pricing/plans) is required. Enterprise users with $2,000/month committed spend can also use [Slack](/platform/support#slack).
 
 ## Volume limits per project
 


### PR DESCRIPTION
## Summary
- Updates the Pro plan self-serve volume limit from 250 GB to 1 TB across pricing and volume reference docs
- Clarifies that storage beyond 1TB requires an Enterprise plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)