### PR TITLE
Add ParadeDB to database template marketplace list

### DIFF
--- a/content/docs/databases/build-a-database-service.md
+++ b/content/docs/databases/build-a-database-service.md
@@ -80,3 +80,4 @@ Here are some suggestions to check out -
 - <a href="https://railway.com/deploy/dragonfly" target="_blank">Dragonfly</a>
 - <a href="https://railway.com/deploy/kbvIRV" target="_blank">Chroma</a>
 - <a href="https://railway.com/deploy/elasticsearch" target="_blank">Elastic Search</a>
+- <a href="https://railway.com/deploy/paradedb" target="_blank">ParadeDB</a>


### PR DESCRIPTION
## Summary
- Adds ParadeDB to the template suggestions in the "Build a Database Service" guide

## Test plan
- [ ] Verify the link renders correctly on the docs page
- [ ] Confirm https://railway.com/deploy/paradedb resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)