### PR TITLE
Document required TXT record for custom domain setup

### DIFF
--- a/content/docs/cli/domain.md
+++ b/content/docs/cli/domain.md
@@ -51,14 +51,9 @@ railway domain example.com --service api
 
 ## Custom domain setup
 
-When adding a custom domain, the CLI displays the required DNS records:
+When adding a custom domain, the CLI displays the required DNS records - a `CNAME` record and a `TXT` record. Both are required: the `CNAME` routes traffic and the `TXT` verifies domain ownership. Add both to your DNS provider exactly as shown in the CLI output.
 
-```
-To finish setting up your custom domain, add the following DNS records to example.com:
-
-    Type     Name    Value
-    CNAME    @       your-service.up.railway.app
-```
+Requests to the domain will return a `404` until the `TXT` record is in place and Railway has verified ownership.
 
 DNS changes can take up to 72 hours to propagate worldwide.
 

--- a/content/docs/integrations/api/manage-domains.md
+++ b/content/docs/integrations/api/manage-domains.md
@@ -124,15 +124,15 @@ Check DNS configuration status:
 
 ## DNS configuration
 
-After adding a custom domain, you need to configure DNS records. The required records are returned in the `status.dnsRecords` field.
+After adding a custom domain, you need to configure DNS records. The required records are returned in the `status.dnsRecords` field, which includes **both** a routing record (`CNAME` / `ALIAS` / `A`) and a `TXT` record used to verify domain ownership. Both are required - without the `TXT`, the domain will not verify and requests will return a `404`.
 
 ### For root domains (example.com)
 
-Add an A record or ALIAS record pointing to the Railway IP.
+Add a CNAME-flattened, ALIAS, or ANAME record (depending on what your DNS provider supports) pointing to your Railway service domain, plus the `TXT` record returned in `status.dnsRecords`. Railway does not publish a static IP, so `A` records are not supported. See [Adding a root domain](/networking/domains/working-with-domains#adding-a-root-domain) for provider-specific guidance.
 
 ### For subdomains (api.example.com)
 
-Add a CNAME record pointing to your Railway service domain.
+Add a CNAME record pointing to your Railway service domain, plus the `TXT` record returned in `status.dnsRecords`.
 
 ### DNS record statuses
 

--- a/content/docs/networking/domains/working-with-domains.md
+++ b/content/docs/networking/domains/working-with-domains.md
@@ -44,9 +44,11 @@ Custom domains can be added to a Railway service and once setup we will automati
 
 3. Type in the custom domain (wildcard domains are supported, [see below](#wildcard-domains) for more details)
 
-   You will be provided with a CNAME domain to use, e.g., `g05ns7.up.railway.app`.
+   You will be provided with two records to add to your DNS - a `CNAME` record (e.g., `g05ns7.up.railway.app`) and a `TXT` record used to verify domain ownership.
 
-4. In your DNS provider (Cloudflare, DNSimple, Namecheap, etc), create a CNAME record with the CNAME value provided by Railway.
+4. In your DNS provider (Cloudflare, DNSimple, Namecheap, etc), create **both** the `CNAME` record and the `TXT` record exactly as shown in the Railway dashboard. Both records are required - the domain will not verify with only the `CNAME` in place.
+
+   **Important:** If the `TXT` record is missing, requests to your custom domain will return a `404` error even after the `CNAME` resolves. Railway uses the `TXT` record to confirm domain ownership before routing traffic, so your service will not be reachable on the custom domain until both records are in place and verified.
 
 5. Wait for Railway to verify your domain. When verified, you will see a green check mark next to the domain(s) -
 
@@ -101,7 +103,7 @@ E.g. `*.nested.example.com`
 
 - Add CNAME records for the wildcard nested subdomain.
 
-When you add a wildcard domain, you will be provided with two domains for which you should add two CNAME records -
+When you add a wildcard domain, you will be provided with two CNAME records and one TXT record -
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1679693511/wildcard_domains_zdguqs.png"
@@ -109,7 +111,7 @@ alt="Screenshot of Wildcard Domain"
 layout="responsive"
 width={1048} height={842} quality={80} />
 
-One record is for the wildcard domain, and one for the `\_acme-challenge`. The `\_acme-challenge` CNAME is required for Railway to issue the SSL Certificate for your domain.
+One CNAME is for the wildcard domain, and one is for the `\_acme-challenge`. The `\_acme-challenge` CNAME is required for Railway to issue the SSL Certificate for your domain. The `TXT` record is required to verify domain ownership and must be added in addition to the CNAME records - wildcard domains will not verify without it.
 
 #### Wildcard domains on Cloudflare
 
@@ -179,27 +181,28 @@ If your DNS provider doesn't support CNAME Flattening or dynamic ALIAS records a
 
 If you want to add your root domain (e.g., `mydomain.com`) and the `www.` subdomain to Cloudflare and redirect all `www.` traffic to the root domain:
 
-1. Create a Custom Domain in Railway for your root domain (e.g., `mydomain.com`). Copy the `value` field. This will be in the form: `abc123.up.railway.app`.
+1. Create a Custom Domain in Railway for your root domain (e.g., `mydomain.com`). You will be provided with both a `CNAME` value (e.g., `abc123.up.railway.app`) and a `TXT` record for domain verification. Both are required.
 2. Add a `CNAME` DNS record to Cloudflare:
    - `Name` → `@`.
    - `Target` → the `value` field from Railway.
    - `Proxy status` → `on`, should display an orange cloud.
    - Note: Due to domain flattening, `Name` will automatically update to your root domain (e.g., `mydomain.com`).
-3. Add another `CNAME` DNS record to Cloudflare:
+3. Add the `TXT` DNS record to Cloudflare using the `Name` and `Value` shown in the Railway dashboard. This is required to verify domain ownership - Railway will not verify the domain without it.
+4. Add another `CNAME` DNS record to Cloudflare:
    - `Name` → `www`.
    - `Target` → `@`
    - `Proxy status:` → on, should display an orange cloud.
    - Note: Cloudflare will automatically change the `Target` value to your root domain.
-4. Enable Full SSL/TLS encryption in Cloudflare:
+5. Enable Full SSL/TLS encryption in Cloudflare:
    - Go to your domain on Cloudflare.
    - Navigate to `SSL/TLS -> Overview`.
    - Select `Full`. **Not** `Full (Strict)` **Strict mode will not work as intended**.
-5. Enable Universal SSL in Cloudflare:
+6. Enable Universal SSL in Cloudflare:
    - Go to your domain on Cloudflare.
    - Navigate to `SSL/TLS -> Edge Certificates`.
    - Enable `Universal SSL`.
-6. After doing this, you should see `Cloudflare proxy detected` on your Custom Domain in Railway with a green cloud.
-7. Create a Bulk Redirect in Cloudflare:
+7. After doing this, you should see `Cloudflare proxy detected` on your Custom Domain in Railway with a green cloud.
+8. Create a Bulk Redirect in Cloudflare:
    - Go to your [Cloudflare dashboard](https://dash.cloudflare.com/).
    - Navigate to `Bulk Redirects`.
    - Click `Create Bulk Redirect List`.

--- a/content/docs/networking/public-networking.md
+++ b/content/docs/networking/public-networking.md
@@ -27,6 +27,6 @@ To expose a service to the internet:
 2. Find **Networking → Public Networking**
 3. Click **Generate Domain** to get a Railway-provided domain
 
-Or configure a custom domain by adding a CNAME record pointing to your Railway-provided domain.
+Or configure a custom domain by adding the `CNAME` and `TXT` records Railway provides to your DNS - both are required.
 
 See [Domains](/networking/domains) for complete setup instructions.

--- a/content/docs/networking/troubleshooting/ssl.md
+++ b/content/docs/networking/troubleshooting/ssl.md
@@ -62,7 +62,7 @@ If your domain shows that the Certificate Authority is validating challenges for
 
 #### Check DNS propagation
 
-Verify your DNS records have propagated using a tool like [dnschecker.org](https://dnschecker.org). Enter your domain and check that the CNAME record points to your Railway-provided value (e.g., `abc123.up.railway.app`).
+Verify your DNS records have propagated using a tool like [dnschecker.org](https://dnschecker.org). Enter your domain and check that the `CNAME` record points to your Railway-provided value (e.g., `abc123.up.railway.app`) **and** that the `TXT` record matches the value shown in the Railway dashboard. Both are required - a missing `TXT` record will prevent Railway from verifying the domain, and the domain will return a `404` instead of routing to your service.
 
 **Note:** If you are using Cloudflare Proxy (orange cloud), DNS lookup tools will show Cloudflare IP addresses instead of the Railway CNAME. This is expected behavior. In this case, verify your DNS settings directly in your Cloudflare dashboard instead.
 
@@ -215,7 +215,7 @@ If your browser shows a certificate for `*.up.railway.app` instead of your custo
 ### Solutions
 
 1. **Check domain status in Railway:** ensure it shows as verified (green checkmark)
-2. **Verify DNS configuration:** your CNAME should point to the Railway-provided value
+2. **Verify DNS configuration:** your `CNAME` should point to the Railway-provided value, and the `TXT` record shown in the Railway dashboard must also be in place - both are required
 3. **Wait for issuance:** if you just added the domain, wait up to an hour
 4. **Check for conflicting records:** ensure you don't have both A and CNAME records for the same hostname
 


### PR DESCRIPTION
## Summary

- Custom domains require both a `CNAME` and a `TXT` record for ownership verification. Without the `TXT`, the domain returns `404` even after the `CNAME` resolves. Updated the main custom domain, wildcard, and Cloudflare root+www walkthrough sections in `working-with-domains.md` to reflect this, plus the quick-start summary, SSL troubleshooting, API, and CLI docs for consistency.
- Fixed an incorrect instruction in `integrations/api/manage-domains.md` that told users to add an `A` record pointing to "the Railway IP" for root domains. Railway does not publish a static IP; the main docs recommend CNAME flattening / ALIAS / ANAME, and the API doc now matches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)