### PR TITLE
Add Windsurf, Cline, Devin setup to remote MCP docs

### DIFF
--- a/content/docs/ai/remote-mcp-server.md
+++ b/content/docs/ai/remote-mcp-server.md
@@ -10,7 +10,7 @@ Unlike the [local MCP server](/ai/mcp-server), which runs on your machine and de
 ## Prerequisites
 
 - A [Railway account](https://railway.com/login)
-- An MCP-compatible client (Claude, Cursor, Codex, GitHub Copilot, Droid, OpenCode, or any other client that supports remote MCP over HTTP)
+- An MCP-compatible client (Claude, Cursor, Codex, GitHub Copilot, Droid, OpenCode, Windsurf, Cline, Devin, or any other client that supports remote MCP over HTTP)
 
 ## Setup
 
@@ -87,6 +87,43 @@ Add to `opencode.json`:
     }
   }
 }
+```
+
+### Windsurf
+
+Add to `~/.codeium/windsurf/mcp_config.json` and reload Windsurf:
+
+```json
+{
+  "mcpServers": {
+    "railway": {
+      "serverUrl": "https://mcp.railway.com"
+    }
+  }
+}
+```
+
+### Cline
+
+Open the Cline extension in VS Code, choose **MCP Servers → Configure MCP Servers**, and add:
+
+```json
+{
+  "mcpServers": {
+    "railway": {
+      "type": "streamableHttp",
+      "url": "https://mcp.railway.com"
+    }
+  }
+}
+```
+
+### Devin
+
+Devin configures remote MCP servers through its web UI. In your Devin workspace, go to **Settings → Integrations → MCP** and add a new server with the URL:
+
+```text
+https://mcp.railway.com
 ```
 
 ### Other clients


### PR DESCRIPTION
## Summary
- Adds setup sections for Windsurf, Cline, and Devin to `/ai/remote-mcp-server` so every agent listed at [railway.com/agents](https://railway.com/agents) has a matching anchor in the guide.
- Extends the prerequisites line to mention the three new clients.

The mono PR links `/agents/<slug>` pages to the anchors introduced here (`#windsurf`, `#cline`, `#devin`), so this should land first.

## Test plan
- [ ] Run docs locally and confirm each new subheading gets the expected slug (`#windsurf`, `#cline`, `#devin`).
- [ ] Verify the TOC renders the three new entries under "Setup".
- [ ] Sanity-check the Windsurf/Cline/Devin config snippets against each client's latest remote-MCP docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)