### PR TITLE
Document outbound IPv6 as opt-in per-service setting

### DIFF
--- a/content/docs/networking/outbound-networking.md
+++ b/content/docs/networking/outbound-networking.md
@@ -83,8 +83,13 @@ and share the output of the command for further assistance
 
 Railway offers [Static Outbound IPs](/networking/static-outbound-ips) for Pro plan customers who need consistent IP addresses for firewall whitelisting or third-party integrations.
 
-## Outbound ipv6
-Railway does not currently support outbound IPv6. Any IPv6 request will fail showing "Network is unreachable" or `ENETUNREACH`.
+## Outbound IPv6
+
+Railway supports outbound IPv6 connections on an opt-in basis per service. Enable this when you need to reach IPv6-only destinations or services that perform better over IPv6.
+
+To enable it, open your service's **Settings** tab, scroll to the **Networking** section, and toggle **Enable Outbound IPv6**. Redeploy the service for the change to take effect.
+
+Outbound IPv6 is disabled by default. Enabling it does not affect your service's existing IPv4 outbound connectivity — both work concurrently when the toggle is on. While this setting is disabled, IPv6 connection attempts will fail with "Network is unreachable" or `ENETUNREACH`.
 
 ## Related features
 


### PR DESCRIPTION
## Summary

Replaces the stale "Railway does not currently support outbound IPv6" paragraph with accurate current behavior: outbound IPv6 is supported, opt-in per service via **Settings → Networking → Enable Outbound IPv6**, disabled by default.

## Why

Outbound IPv6 shipped to general availability today (mono#27781). Until now it was gated behind a Priority Boarding user flag, so the docs correctly said it wasn't supported. That's no longer true — any user can enable it per service.

## What changed

`src/docs/reference/outbound-networking.md` — rewrote the **Outbound IPv6** section to:
- State that IPv6 egress is supported on an opt-in basis
- Describe where to find the toggle in the service's Networking settings
- Note that the service must be redeployed after toggling
- Preserve the existing `ENETUNREACH` / "Network is unreachable" language as the error users still see when the toggle is off (common search term for this issue)