### PR TITLE
Document Railway Agent and pass-through LLM billing

### DIFF
--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -11,7 +11,7 @@ Railway provides tools for integrating with AI coding assistants, letting you ma
 
 The [Railway Agent](/ai/railway-agent) is a chat-based assistant built directly into the Railway dashboard. It can manage services, diagnose failing deployments, and open pull requests to fix issues in your code.
 
-- Runs inside the Railway dashboard — no setup required
+- Runs inside the Railway dashboard with no setup required
 - Creates and configures services, variables, databases, and networking
 - Automatically diagnoses failed deployments and proposes fixes
 

--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -7,6 +7,16 @@ Railway provides tools for integrating with AI coding assistants, letting you ma
 
 ## Integration options
 
+### Railway Agent
+
+The [Railway Agent](/ai/railway-agent) is a chat-based assistant built directly into the Railway dashboard. It can manage services, diagnose failing deployments, and open pull requests to fix issues in your code.
+
+- Runs inside the Railway dashboard — no setup required
+- Creates and configures services, variables, databases, and networking
+- Automatically diagnoses failed deployments and proposes fixes
+
+[Get started with the Railway Agent →](/ai/railway-agent)
+
 ### Agent skills
 
 [Agent Skills](/ai/agent-skills) are an open format for extending AI coding assistants with specialized knowledge about Railway. The `use-railway` skill guides AI agents to perform tasks like deploying services, managing environments, and querying metrics.

--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -1,18 +1,18 @@
 ---
 title: Railway Agent
-description: Chat with the Railway Agent to manage services, diagnose failures, and ship fixes — directly from the Railway dashboard.
+description: Chat with the Railway Agent to manage services, diagnose failures, and ship fixes directly from the Railway dashboard.
 ---
 
-The Railway Agent is a chat-based AI assistant built into the Railway dashboard. It can operate the platform on your behalf: creating and configuring services, inspecting deployments, diagnosing failures, and even opening pull requests to fix broken builds.
+The Railway Agent is a chat-based AI assistant built into the Railway dashboard. It can operate the platform on your behalf: creating and configuring services, inspecting deployments, diagnosing failures, and opening pull requests to fix broken builds.
 
-## What it can do
+## What the agent can do
 
-The agent has access to the same primitives you do, which means it can act across your entire project:
+The agent has access to the same primitives you do, so it can act across your entire project. The agent can:
 
-- **Manage services** — create services, set variables, connect databases, wire up networking, and adjust resource limits.
-- **Inspect state** — list projects, environments, services, deployments, and read logs or metrics.
-- **Diagnose issues** — walk through a failing deployment, read build and runtime logs, and explain what went wrong.
-- **Fix issues** — when a deployment fails, the agent can identify the cause and open a pull request against your repository with a proposed fix.
+- Create services, set variables, connect databases, wire up networking, and adjust resource limits.
+- List projects, environments, services, and deployments, and read logs or metrics.
+- Walk through a failing deployment, read build and runtime logs, and explain what went wrong.
+- Identify the cause of a failed deployment and open a pull request against your repository with a proposed fix.
 
 ## Automatic deployment diagnosis
 
@@ -22,4 +22,4 @@ If the fix is in your code, the agent can open a pull request with the change so
 
 ## Pricing
 
-Usage of the Railway Agent is billed based on the underlying LLM tokens consumed, at the exact per-token rates published on <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a> — no markup. See [Pricing → Railway Agent](/pricing#railway-agent) for details.
+Usage of the Railway Agent is billed based on the underlying LLM tokens consumed, at the exact per-token rates published on <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>, with no markup. See [Pricing](/pricing#railway-agent) for details.

--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -20,16 +20,6 @@ When a deployment fails, the agent can automatically investigate. It reads the b
 
 If the fix is in your code, the agent can open a pull request with the change so you can review and merge it.
 
-## Using the agent
-
-Open the agent panel from the Railway dashboard and describe what you want in natural language. Examples:
-
-- "Add a Postgres database to this service and wire up `DATABASE_URL`."
-- "Why did the last deployment on `api` fail?"
-- "Set up a staging environment that mirrors production."
-
-The agent will explain what it's about to do before making changes that affect your infrastructure.
-
 ## Pricing
 
 Usage of the Railway Agent is billed based on the underlying LLM tokens consumed, at the exact per-token rates published on <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a> — no markup. See [Pricing → Railway Agent](/pricing#railway-agent) for details.

--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -1,0 +1,41 @@
+---
+title: Railway Agent
+description: Chat with the Railway Agent to manage services, diagnose failures, and ship fixes — directly from the Railway dashboard.
+---
+
+The Railway Agent is a chat-based AI assistant built into the Railway dashboard. It can operate the platform on your behalf: creating and configuring services, inspecting deployments, diagnosing failures, and even opening pull requests to fix broken builds.
+
+<!-- screenshot: Railway Agent chat panel open in the dashboard -->
+
+## What it can do
+
+The agent has access to the same primitives you do, which means it can act across your entire project:
+
+- **Manage services** — create services, set variables, connect databases, wire up networking, and adjust resource limits.
+- **Inspect state** — list projects, environments, services, deployments, and read logs or metrics.
+- **Diagnose issues** — walk through a failing deployment, read build and runtime logs, and explain what went wrong.
+- **Fix issues** — when a deployment fails, the agent can identify the cause and open a pull request against your repository with a proposed fix.
+
+## Automatic deployment diagnosis
+
+When a deployment fails, the agent can automatically investigate. It reads the build and runtime logs, correlates them with your service configuration and recent code changes, and produces a short explanation of the failure.
+
+If the fix is in your code, the agent can open a pull request with the change so you can review and merge it.
+
+<!-- screenshot: Agent-authored PR fixing a failed deployment -->
+
+## Using the agent
+
+Open the agent panel from the Railway dashboard and describe what you want in natural language. Examples:
+
+- "Add a Postgres database to this service and wire up `DATABASE_URL`."
+- "Why did the last deployment on `api` fail?"
+- "Set up a staging environment that mirrors production."
+
+The agent will explain what it's about to do before making changes that affect your infrastructure.
+
+<!-- screenshot: Agent proposing a change with a confirm step -->
+
+## Pricing
+
+Usage of the Railway Agent is billed based on the underlying LLM tokens consumed, at the exact per-token rates published on <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a> — no markup. See [Pricing → Railway Agent](/pricing#railway-agent) for details.

--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -5,8 +5,6 @@ description: Chat with the Railway Agent to manage services, diagnose failures, 
 
 The Railway Agent is a chat-based AI assistant built into the Railway dashboard. It can operate the platform on your behalf: creating and configuring services, inspecting deployments, diagnosing failures, and even opening pull requests to fix broken builds.
 
-<!-- screenshot: Railway Agent chat panel open in the dashboard -->
-
 ## What it can do
 
 The agent has access to the same primitives you do, which means it can act across your entire project:
@@ -22,8 +20,6 @@ When a deployment fails, the agent can automatically investigate. It reads the b
 
 If the fix is in your code, the agent can open a pull request with the change so you can review and merge it.
 
-<!-- screenshot: Agent-authored PR fixing a failed deployment -->
-
 ## Using the agent
 
 Open the agent panel from the Railway dashboard and describe what you want in natural language. Examples:
@@ -33,8 +29,6 @@ Open the agent panel from the Railway dashboard and describe what you want in na
 - "Set up a staging environment that mirrors production."
 
 The agent will explain what it's about to do before making changes that affect your infrastructure.
-
-<!-- screenshot: Agent proposing a change with a confirm step -->
 
 ## Pricing
 

--- a/content/docs/pricing.md
+++ b/content/docs/pricing.md
@@ -38,6 +38,24 @@ All paid plans include generous resource allowances, with the subscription fee c
 
 You're billed by the minute for compute resources, so you only pay for what you use.
 
+## Railway Agent
+
+The [Railway Agent](/ai/railway-agent) is billed separately, based on the LLM tokens it uses on your behalf.
+
+We pass through the exact cost of the underlying models with no markup. Pricing is based on input and output tokens, priced per the model used for each step:
+
+| Model | Used for |
+| --- | --- |
+| **Claude Opus 4.6** | Complex reasoning, multi-step diagnosis, code changes |
+| **Claude Sonnet 4.6** | Most general agent tasks |
+| **Claude Haiku 4.5** | Lightweight lookups and quick actions |
+
+The agent routes each request to the smallest model that can handle it, so costs stay proportional to the difficulty of the task. Agent usage appears as a separate line item on your invoice, and you can see a per-request token breakdown in the dashboard.
+
+Per-token rates for each model are published on Anthropic's pricing page: <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>.
+
+<!-- screenshot: Agent usage breakdown on the billing page -->
+
 ## Learn more
 
 - [Plans](/pricing/plans) - Detailed breakdown of each plan's features and limits

--- a/content/docs/pricing.md
+++ b/content/docs/pricing.md
@@ -42,7 +42,7 @@ You're billed by the minute for compute resources, so you only pay for what you 
 
 The [Railway Agent](/ai/railway-agent) is billed separately, based on the LLM tokens it uses on your behalf.
 
-We pass through the exact cost of the underlying models with no markup. Pricing is based on input and output tokens, priced per the model used for each step:
+Railway passes through the exact cost of the underlying models with no markup. Pricing is based on input and output tokens, priced per the model used for each step:
 
 | Model | Used for |
 | --- | --- |
@@ -52,7 +52,7 @@ We pass through the exact cost of the underlying models with no markup. Pricing 
 
 The agent routes each request to the smallest model that can handle it, so costs stay proportional to the difficulty of the task. Total agent usage appears as a separate line item on your invoice.
 
-Agent usage draws from the same included credit as the rest of your plan — the $5 on Hobby and $20 on Pro that already covers your compute also covers your agent usage. You're only charged beyond that once your combined compute and agent spend exceeds what your subscription includes.
+Agent usage draws from the same included credit as the rest of your plan. The $5 on Hobby and $20 on Pro that already covers your compute also covers your agent usage. You're only charged beyond that once your combined compute and agent spend exceeds what your subscription includes.
 
 Per-token rates for each model are published on Anthropic's pricing page: <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>.
 

--- a/content/docs/pricing.md
+++ b/content/docs/pricing.md
@@ -50,7 +50,7 @@ We pass through the exact cost of the underlying models with no markup. Pricing 
 | **Claude Sonnet 4.6** | Most general agent tasks |
 | **Claude Haiku 4.5** | Lightweight lookups and quick actions |
 
-The agent routes each request to the smallest model that can handle it, so costs stay proportional to the difficulty of the task. Agent usage appears as a separate line item on your invoice, and you can see a per-request token breakdown in the dashboard.
+The agent routes each request to the smallest model that can handle it, so costs stay proportional to the difficulty of the task. Total agent usage appears as a separate line item on your invoice.
 
 Per-token rates for each model are published on Anthropic's pricing page: <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>.
 

--- a/content/docs/pricing.md
+++ b/content/docs/pricing.md
@@ -54,8 +54,6 @@ The agent routes each request to the smallest model that can handle it, so costs
 
 Per-token rates for each model are published on Anthropic's pricing page: <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>.
 
-<!-- screenshot: Agent usage breakdown on the billing page -->
-
 ## Learn more
 
 - [Plans](/pricing/plans) - Detailed breakdown of each plan's features and limits

--- a/content/docs/pricing.md
+++ b/content/docs/pricing.md
@@ -52,6 +52,8 @@ We pass through the exact cost of the underlying models with no markup. Pricing 
 
 The agent routes each request to the smallest model that can handle it, so costs stay proportional to the difficulty of the task. Total agent usage appears as a separate line item on your invoice.
 
+Agent usage draws from the same included credit as the rest of your plan — the $5 on Hobby and $20 on Pro that already covers your compute also covers your agent usage. You're only charged beyond that once your combined compute and agent spend exceeds what your subscription includes.
+
 Per-token rates for each model are published on Anthropic's pricing page: <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>.
 
 ## Learn more

--- a/content/docs/pricing/cost-control.md
+++ b/content/docs/pricing/cost-control.md
@@ -13,9 +13,20 @@ Usage Limits allow you to set a maximum limit on your usage for a billing cycle.
 
 <Image src="https://res.cloudinary.com/railway/image/upload/v1743193518/docs/usage-limits_pqlot9.png" alt="Usage Limits Modal" layout="responsive" width={1200} height={1075} />
 
-Visit the <a href="https://railway.com/workspace/usage" target="_blank">Workspace Usage page</a> to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd>.
+Visit the <a href="https://railway.com/workspace/usage" target="_blank">Workspace Usage page</a> to set the usage limits. Once you click the <kbd>Set Usage Limits</kbd> button, you will see a modal where you can set a <kbd>Custom email alert</kbd> and a <kbd>Hard limit</kbd> separately for **Compute Usage** and **Agent Usage**.
 
 <Banner variant="info">The link above takes you to the usage page for your personal account. If you want to set a usage limit for your workspace, you can use the account switcher in the top left corner of your dashboard to access the workspace's usage page. You must be a workspace admin to configure usage limits.</Banner>
+
+### Compute vs. Agent usage limits
+
+Compute and Agent usage are tracked and limited independently:
+
+- **Compute Usage** covers CPU, memory, storage, and network egress for your services.
+- **Agent Usage** covers [Railway Agent](/ai/railway-agent) LLM consumption.
+
+Hitting the Compute hard limit takes your workloads offline but leaves the agent available. Hitting the Agent hard limit disables the agent but leaves your workloads running.
+
+By default, Agent Usage has a hard limit of **$5 on the Hobby plan** and **$20 on the Pro plan**. You can raise, lower, or remove this limit at any time from the Workspace Usage page.
 
 ### Custom email alert
 

--- a/content/docs/pricing/cost-control.md
+++ b/content/docs/pricing/cost-control.md
@@ -26,7 +26,7 @@ Compute and Agent usage are tracked and limited independently:
 
 Hitting the Compute hard limit takes your workloads offline but leaves the agent available. Hitting the Agent hard limit disables the agent but leaves your workloads running.
 
-By default, Agent Usage has a hard limit of **$5 on the Hobby plan** and **$20 on the Pro plan**. You can raise, lower, or remove this limit at any time from the Workspace Usage page.
+By default, Agent Usage has a hard limit of **$5 on the Hobby plan** and **$20 on the Pro plan**. You can raise or lower this limit at any time from the Workspace Usage page, but unlike the Compute limit, the Agent limit cannot be removed.
 
 ### Custom email alert
 

--- a/content/docs/pricing/cost-control.md
+++ b/content/docs/pricing/cost-control.md
@@ -21,12 +21,12 @@ Visit the <a href="https://railway.com/workspace/usage" target="_blank">Workspac
 
 Compute and Agent usage are tracked and limited independently:
 
-- **Compute Usage** covers CPU, memory, storage, and network egress for your services.
-- **Agent Usage** covers [Railway Agent](/ai/railway-agent) LLM consumption.
+- Compute Usage covers CPU, memory, storage, and network egress for your services.
+- Agent Usage covers [Railway Agent](/ai/railway-agent) LLM consumption.
 
 Hitting the Compute hard limit takes your workloads offline but leaves the agent available. Hitting the Agent hard limit disables the agent but leaves your workloads running.
 
-By default, Agent Usage has a hard limit of **$5 on the Hobby plan** and **$20 on the Pro plan**. You can raise or lower this limit at any time from the Workspace Usage page, but unlike the Compute limit, the Agent limit cannot be removed.
+By default, Agent Usage has a hard limit of $5 on the Hobby plan and $20 on the Pro plan. You can raise or lower this limit at any time from the Workspace Usage page, but unlike the Compute limit, the Agent limit cannot be removed.
 
 ### Custom email alert
 

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -100,7 +100,7 @@ export const sidebarContent: ISidebarContent = [
   {
     title: "AI",
     slug: "/ai",
-    content: [makePage("Agent skills", "ai"), makePage("Claude Code plugin", "ai"), makePage("MCP server", "ai"), makePage("Remote MCP server", "ai")],
+    content: [makePage("Railway Agent", "ai"), makePage("Agent skills", "ai"), makePage("Claude Code plugin", "ai"), makePage("MCP server", "ai"), makePage("Remote MCP server", "ai")],
   },
   {
     title: "Templates & open source",


### PR DESCRIPTION
## Summary
- Add a dedicated Railway Agent page under `/ai/railway-agent` covering chat-based platform control, service/deployment management, automatic failure diagnosis, and auto-PR fixes.
- Surface Railway Agent as the first entry on the AI landing page.
- Add a Railway Agent section to the pricing page explaining pass-through LLM billing (Opus 4.6 / Sonnet 4.6 / Haiku 4.5), with a link to [anthropic.com/pricing](https://www.anthropic.com/pricing) for per-token rates.

Screenshot placeholders are marked with HTML comments for the team to fill in.

## Test plan
- [ ] Preview `/ai` and `/ai/railway-agent` render correctly
- [ ] Preview `/pricing` renders the new Railway Agent section
- [ ] Internal links (`/ai/railway-agent`, `/pricing#railway-agent`) resolve