### PR TITLE
Update railway ssh docs for native SSH and ssh keys subcommand

### DIFF
--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -1,14 +1,17 @@
 ---
 title: railway ssh
-description: Connect to a service via SSH.
+description: Connect to a service via SSH and manage SSH keys.
 ---
 
-Open an interactive shell session inside a deployed Railway service container.
+Open an interactive shell session inside a deployed Railway service container, or manage the SSH keys registered with your Railway account.
+
+Railway uses your system `ssh` client to connect to `ssh.railway.com`. You must have an SSH key registered with Railway before you can connect. The CLI prompts you to register a local key the first time you run `railway ssh`.
 
 ## Usage
 
 ```bash
 railway ssh [OPTIONS] [COMMAND...]
+railway ssh keys [SUBCOMMAND] [OPTIONS]
 ```
 
 ## Options
@@ -19,7 +22,8 @@ railway ssh [OPTIONS] [COMMAND...]
 | `-s, --service <SERVICE>` | Service to connect to (defaults to linked service) |
 | `-e, --environment <ENV>` | Environment to connect to (defaults to linked environment) |
 | `-d, --deployment-instance <ID>` | Specific deployment instance ID to connect to |
-| `--session [NAME]` | Use a tmux session (installs tmux if needed) |
+| `--session [NAME]` | Connect inside a persistent tmux session that reconnects automatically. Defaults to `railway` |
+| `-i, --identity-file <PATH>` | Path to a private key to forward to ssh, like `ssh -i` |
 
 ## Examples
 
@@ -29,7 +33,7 @@ railway ssh [OPTIONS] [COMMAND...]
 railway ssh
 ```
 
-Opens a bash shell in the service container.
+Opens an interactive shell in the service container.
 
 ### Run a single command
 
@@ -37,41 +41,108 @@ Opens a bash shell in the service container.
 railway ssh -- ls -la
 ```
 
-### SSH with tmux session
+PTY allocation is autodetected. Interactive tools like `vim` or `htop` work when both stdin and stdout are terminals; piped input runs without a PTY so output stays clean for scripts and CI.
+
+### Persistent tmux session
 
 ```bash
 railway ssh --session
 ```
 
-Creates a persistent tmux session that reconnects automatically if disconnected.
-
-### SSH to specific service
+Connects inside a tmux session named `railway`. If the connection drops, the CLI reconnects and reattaches to the same session. Pass a name to use a different session:
 
 ```bash
-railway ssh --service backend
+railway ssh --session debug
 ```
+
+Railway installs tmux in the container automatically if it isn't already installed.
+
+### Connect to a specific deployment instance
+
+```bash
+railway ssh --deployment-instance <instance-id>
+```
+
+### Use a specific identity file
+
+```bash
+railway ssh -i ~/.ssh/railway_ed25519
+```
+
+When set, the CLI skips its local `~/.ssh` scan and forwards the key directly to `ssh`.
+
+## Manage SSH keys
+
+Use the `keys` subcommand to register, list, and remove SSH keys for your Railway account or workspace.
+
+```bash
+railway ssh keys [SUBCOMMAND] [OPTIONS]
+```
+
+### Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `list` | List SSH keys registered with Railway (default when no subcommand is given) |
+| `add` | Register a local SSH key with Railway |
+| `remove` | Remove a registered SSH key |
+| `github` | Import SSH keys from your linked GitHub account |
+
+### Options
+
+| Flag | Description |
+|------|-------------|
+| `--workspace <WORKSPACE_ID>` | Operate on workspace-owned keys instead of your personal keys |
+| `--key <PATH>` | Path to the public key file (for `add`) |
+| `--name <NAME>` | Name for the registered key (for `add`) |
+| `--2fa-code <CODE>` | 2FA code for verification (for `remove`) |
+
+### List registered keys
+
+```bash
+railway ssh keys
+```
+
+### Add a key
+
+```bash
+railway ssh keys add --key ~/.ssh/id_ed25519.pub --name "laptop"
+```
+
+Run without flags to pick from your local `~/.ssh` keys interactively.
+
+### Remove a key
+
+```bash
+railway ssh keys remove
+```
+
+### Import keys from GitHub
+
+```bash
+railway ssh keys github
+```
+
+GitHub keys belong to your personal account and can't be imported directly into a workspace. To register a GitHub key for a workspace, import it first, then add it with `--workspace`.
+
+### Workspace-owned keys
+
+Workspace keys grant SSH access to every service in the workspace. Adding or removing workspace keys requires workspace **Admin** access.
+
+```bash
+railway ssh keys --workspace <workspace-id>
+railway ssh keys add --workspace <workspace-id> --key ~/.ssh/id_ed25519.pub
+```
+
+When you authenticate with a workspace-scoped `RAILWAY_API_TOKEN`, the CLI operates on workspace keys automatically. SSH key management isn't supported with project tokens (`RAILWAY_TOKEN`); use a workspace API token or run `railway login`.
 
 ## Use cases
 
 - Debugging production issues
 - Running database migrations
-- Accessing language REPLs (Rails console, Django shell, etc.)
+- Accessing language REPLs (Rails console, Django shell)
 - Inspecting log files
 - Troubleshooting network issues
-
-## How it works
-
-Railway SSH uses a custom WebSocket-based protocol (not standard SSH). This means:
-
-- No SSH daemon required in your container
-- Secure communication through Railway's authentication
-- Works with any container that has a shell available
-
-## Limitations
-
-- No SCP/SFTP file transfer
-- No SSH tunneling or port forwarding
-- No IDE integration (VS Code Remote-SSH)
 
 ## Related
 

--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -136,6 +136,10 @@ railway ssh keys add --workspace <workspace-id> --key ~/.ssh/id_ed25519.pub
 
 When you authenticate with a workspace-scoped `RAILWAY_API_TOKEN`, the CLI operates on workspace keys automatically. SSH key management isn't supported with project tokens (`RAILWAY_TOKEN`); use a workspace API token or run `railway login`.
 
+## Known limitations
+
+VS Code Remote-SSH isn't supported. Connecting to a Railway service through the Remote-SSH extension fails because the Railway SSH server doesn't expose the operations Remote-SSH needs to install and run its server inside the container. Use `railway ssh` directly for shell access.
+
 ## Use cases
 
 - Debugging production issues

--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -138,7 +138,7 @@ When you authenticate with a workspace-scoped `RAILWAY_API_TOKEN`, the CLI opera
 
 ## Known limitations
 
-VS Code Remote-SSH isn't supported. Connecting to a Railway service through the Remote-SSH extension fails because the Railway SSH server doesn't expose the operations Remote-SSH needs to install and run its server inside the container. Use `railway ssh` directly for shell access.
+VS Code Remote-SSH isn't supported. Use `railway ssh` directly for shell access.
 
 ## Use cases
 


### PR DESCRIPTION
## Summary

- Replaces the outdated WebSocket-protocol description in `cli/ssh` with the current native SSH flow (Railway spawns the system `ssh` client against `ssh.railway.com`).
- Documents `--session` (tmux with auto-reconnect) and the new `-i, --identity-file` flag.
- Adds a **Manage SSH keys** section covering `railway ssh keys` (`list` / `add` / `remove` / `github`), the new `--workspace` flag, the workspace Admin requirement, `RAILWAY_API_TOKEN` auto-detection, and the project-token restriction.

Tracks CLI commit [railwayapp/cli@b28d45d](https://github.com/railwayapp/cli/commit/b28d45d562d8665dca388b5b1686b75a5291680c).

## Test plan

- [ ] Render `cli/ssh` locally and confirm tables, code blocks, and headings look right
- [ ] Verify internal links resolve (`/cli/connect`, `/cli/logs`)
- [ ] Spot-check the documented flags against `railway ssh --help` and `railway ssh keys --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)