### PR TITLE
Update Instatus link to railway status page

### DIFF
--- a/content/docs/platform/incident-management.md
+++ b/content/docs/platform/incident-management.md
@@ -15,7 +15,7 @@ However, it's important to note that while we strive to stay ahead of incidents,
 
 ## Status page + uptime
 
-Railway's uptime and incident retrospective can be accessed on the Railway Instatus page at https://railway.instatus.com/. On this page, you can view the historical uptime of Railway's systems and services. Additionally, you can find detailed information about past incidents, including retrospectives that provide insights into how incidents were handled and what measures were taken to prevent similar issues in the future.
+Railway's uptime and incident retrospective can be accessed on the Railway status page at https://status.railway.com/. On this page, you can view the historical uptime of Railway's systems and services. Additionally, you can find detailed information about past incidents, including retrospectives that provide insights into how incidents were handled and what measures were taken to prevent similar issues in the future.
 
 For Enterprise customers, we offer SLOs and guarantees of service that may not be represented on the uptime dashboard.
 


### PR DESCRIPTION
## Summary

Railway cut over from Instatus to its own status service hosted at `status.railway.com`. The incident management doc still points at `railway.instatus.com`, which is stale. Updates the URL.

Companion mono PR (which also fixes stale "Instatus" copy in the dashboard admin UI and changes the incident banner behavior to handle multiple simultaneous incidents): https://github.com/railwayapp/mono/pull/28372