### PR TITLE
Document railway skills CLI command

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -41,10 +41,10 @@ If the Railway CLI is already installed, you can run the agent setup directly:
 railway setup agent
 ```
 
-To install only the agent skills:
+To install only the agent skills, use the [`railway skills`](/cli/skills) command:
 
 ```bash
-curl -fsSL railway.com/skills.sh | bash
+railway skills install
 ```
 
 You can also install via <a href="https://skills.sh" target="_blank">skills.sh</a>:

--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -19,8 +19,6 @@ When you ask your AI assistant something like "deploy to Railway" or "check my p
 ### Supported tools
 
 - <a href="https://claude.ai/code" target="_blank">Claude Code</a>
-- <a href="https://docs.factory.ai/cli" target="_blank">Factory Droid</a>
-- <a href="https://docs.github.com/en/copilot" target="_blank">GitHub Copilot</a>
 - <a href="https://openai.com/codex" target="_blank">OpenAI Codex</a>
 - <a href="https://opencode.ai" target="_blank">OpenCode</a>
 - <a href="https://cursor.com" target="_blank">Cursor</a>
@@ -53,7 +51,7 @@ You can also install via <a href="https://skills.sh" target="_blank">skills.sh</
 npx skills add railwayapp/railway-skills
 ```
 
-Supports Claude Code, Factory Droid, GitHub Copilot, OpenAI Codex, OpenCode, and Cursor. Re-run to update.
+Supports Claude Code, OpenAI Codex, OpenCode, and Cursor. Re-run to update.
 
 **Note:** For Claude Code, you can also install through the [Claude Code plugin marketplace](/ai/claude-code-plugin).
 

--- a/content/docs/ai/claude-code-plugin.md
+++ b/content/docs/ai/claude-code-plugin.md
@@ -56,10 +56,10 @@ The plugin installs the following components:
 
 ## Alternative installation
 
-If you prefer to install the agent skill without the Claude Code plugin system, you can use the general-purpose installer that works across multiple AI coding assistants:
+If you prefer to install the agent skill without the Claude Code plugin system, use the [`railway skills`](/cli/skills) command, which works across multiple AI coding assistants:
 
 ```bash
-curl -fsSL railway.com/skills.sh | bash
+railway skills install
 ```
 
 See [Agent Skills](/ai/agent-skills) for more details.

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -115,10 +115,11 @@ railway deploy --template postgres # Deploy a template
 railway redeploy                # Redeploy latest deployment
 railway restart                 # Restart a service
 railway down                    # Remove latest deployment
+railway deployment list         # List deployments
 railway templates search        # Search published templates
 ```
 
-[up](/cli/up) · [deploy](/cli/deploy) · [redeploy](/cli/redeploy) · [restart](/cli/restart) · [down](/cli/down) · [templates](/cli/templates) · [Deploying Guide](/cli/deploying)
+[up](/cli/up) · [deploy](/cli/deploy) · [redeploy](/cli/redeploy) · [restart](/cli/restart) · [down](/cli/down) · [deployment](/cli/deployment) · [templates](/cli/templates) · [Deploying Guide](/cli/deploying)
 
 ### Services
 
@@ -224,9 +225,10 @@ railway agent                   # Chat with the Railway Agent
 railway agent -p "..."          # Send a single prompt
 railway setup agent             # Configure Railway agent tooling
 railway mcp install             # Configure MCP for AI coding tools
+railway skills install          # Install Railway agent skills
 ```
 
-[agent](/cli/agent) · [setup](/cli/setup) · [mcp](/cli/mcp)
+[agent](/cli/agent) · [setup](/cli/setup) · [mcp](/cli/mcp) · [skills](/cli/skills)
 
 ### Utilities
 

--- a/content/docs/cli/setup.md
+++ b/content/docs/cli/setup.md
@@ -54,7 +54,7 @@ This configures supported editors to use Railway's hosted MCP server.
 
 `railway setup agent` installs the `use-railway` skill for supported coding tools, configures the Railway MCP server where supported, and checks your Railway authentication.
 
-Supported agent targets include Claude Code, Cursor, Factory Droid, GitHub Copilot, OpenAI Codex, OpenCode, and the universal `.agents` skills directory.
+Skills are installed for Claude Code, Cursor, OpenAI Codex, OpenCode, and the universal `.agents` skills directory. MCP is additionally configured for Factory Droid and GitHub Copilot. See [`railway skills`](/cli/skills) and [`railway mcp`](/cli/mcp) for the per-command target lists.
 
 The setup is idempotent. Re-running it updates Railway-owned skill directories and merges Railway MCP entries into existing tool configs without removing other MCP servers.
 

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -1,0 +1,89 @@
+---
+title: railway skills
+description: Install or remove Railway agent skills for AI coding tools.
+---
+
+Install or remove the Railway [agent skills](/ai/agent-skills) for AI coding tools such as Claude Code, Cursor, Factory Droid, GitHub Copilot, OpenAI Codex, and OpenCode.
+
+Skills are always installed to `~/.agents/skills` (the universal `.agents` directory). They are also installed to any detected tool directories (for example `~/.claude/skills`, `~/.cursor/skills`). Use `--agent` to target specific tools instead of auto-detection.
+
+## Usage
+
+```bash
+railway skills [COMMAND] [OPTIONS]
+```
+
+Running `railway skills` with no subcommand is equivalent to `railway skills install`.
+
+## Subcommands
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `install` | `add`, `update` | Install or update Railway agent skills |
+| `remove` | `rm`, `uninstall` | Remove Railway agent skills |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `--agent <AGENT>` | Target specific agent(s) instead of auto-detection. Can be passed multiple times |
+
+## Supported agents
+
+| Agent | Value | Install location |
+|-------|-------|------------------|
+| Universal (`.agents`) | `universal` | `~/.agents/skills` |
+| Claude Code | `claude-code` | `~/.claude/skills` |
+| Cursor | `cursor` | `~/.cursor/skills` |
+| Factory Droid | `factory-droid` | `~/.factory/skills` |
+| GitHub Copilot | `copilot` | `~/.copilot/skills` |
+| OpenAI Codex | `codex` | `~/.codex/skills` |
+| OpenCode | `opencode` | `~/.config/opencode/skills` |
+
+When run without `--agent`, the universal `.agents` directory is always included, and other tools are added when their config directory exists on disk.
+
+## Examples
+
+### Install skills for detected tools
+
+```bash
+railway skills install
+```
+
+### Install skills for a specific tool
+
+```bash
+railway skills install --agent cursor
+```
+
+### Install skills for multiple tools
+
+```bash
+railway skills install --agent claude-code --agent copilot
+```
+
+### Update existing skills
+
+```bash
+railway skills update
+```
+
+`update` is an alias for `install` and re-downloads the latest skills from the upstream repository.
+
+### Remove skills
+
+```bash
+railway skills remove
+```
+
+### Remove skills from a specific tool
+
+```bash
+railway skills remove --agent cursor
+```
+
+## Related
+
+- [Agent Skills](/ai/agent-skills)
+- [railway setup](/cli/setup)
+- [railway mcp](/cli/mcp)

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -3,7 +3,7 @@ title: railway skills
 description: Install or remove Railway agent skills for AI coding tools.
 ---
 
-Install or remove the Railway [agent skills](/ai/agent-skills) for AI coding tools such as Claude Code, Cursor, Factory Droid, GitHub Copilot, OpenAI Codex, and OpenCode.
+Install or remove the Railway [agent skills](/ai/agent-skills) for AI coding tools such as Claude Code, Cursor, OpenAI Codex, and OpenCode.
 
 Skills are always installed to `~/.agents/skills` (the universal `.agents` directory). They are also installed to any detected tool directories (for example `~/.claude/skills`, `~/.cursor/skills`). Use `--agent` to target specific tools instead of auto-detection.
 
@@ -35,8 +35,6 @@ Running `railway skills` with no subcommand is equivalent to `railway skills ins
 | Universal (`.agents`) | `universal` | `~/.agents/skills` |
 | Claude Code | `claude-code` | `~/.claude/skills` |
 | Cursor | `cursor` | `~/.cursor/skills` |
-| Factory Droid | `factory-droid` | `~/.factory/skills` |
-| GitHub Copilot | `copilot` | `~/.copilot/skills` |
 | OpenAI Codex | `codex` | `~/.codex/skills` |
 | OpenCode | `opencode` | `~/.config/opencode/skills` |
 

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -260,6 +260,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("service"),
       makeCliCommand("setup"),
       makeCliCommand("shell"),
+      makeCliCommand("skills"),
       makeCliCommand("ssh"),
       makeCliCommand("starship"),
       makeCliCommand("status"),


### PR DESCRIPTION
## Summary
- Adds a new CLI reference page at `/cli/skills` for the `railway skills install`/`remove` command, including subcommands, options, supported agents, and examples
- Replaces references to the legacy `curl -fsSL railway.com/skills.sh | bash` installer in `agent-skills.md` and `claude-code-plugin.md` with `railway skills install`
- Adds `railway skills install` to the AI & agents section on the CLI overview page and adds `railway deployment list` to the Deployment section (the `deployment` command had a docs page but wasn't surfaced on `/cli`)
- Adds the new page to the CLI sidebar entries in `src/data/sidebar.ts`

## Test plan
- [ ] Verify `/cli/skills` renders correctly with sidebar navigation
- [ ] Confirm internal links from `/ai/agent-skills` and `/ai/claude-code-plugin` to `/cli/skills` resolve
- [ ] Confirm the new entries on the `/cli` overview link to the correct pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)