### PR TITLE
docs(cli): document railway agent --list and resume-with-history

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -223,6 +223,8 @@ railway functions push          # Push function changes
 ```bash
 railway agent                   # Chat with the Railway Agent
 railway agent -p "..."          # Send a single prompt
+railway agent --list            # List previous agent threads
+railway agent --thread-id <ID>  # Resume a previous thread
 railway setup agent             # Configure Railway agent tooling
 railway mcp install             # Configure MCP for AI coding tools
 railway skills install          # Install Railway agent skills

--- a/content/docs/cli/agent.md
+++ b/content/docs/cli/agent.md
@@ -17,7 +17,8 @@ railway agent [OPTIONS]
 |------|-------------|
 | `-p, --prompt <MESSAGE>` | Send a single prompt (omit for interactive mode) |
 | `--json` | Output response as JSON |
-| `--thread-id <ID>` | Continue an existing chat thread |
+| `--list` | List existing agent threads for the current environment |
+| `--thread-id <ID>` | Continue an existing chat thread (replays recent history) |
 | `-s, --service <SERVICE>` | Service to scope the conversation to (name or ID) |
 | `-e, --environment <ENV>` | Environment to use (defaults to linked environment) |
 
@@ -77,11 +78,21 @@ railway agent -p "what environment variables are set on my project?"
 railway agent -p "list my services and their status" --json
 ```
 
+### List previous conversations
+
+```bash
+railway agent --list
+```
+
+Returns the agent threads tied to the current environment, with their thread IDs, titles, and last-updated timestamps. Add `--json` for a machine-readable list.
+
 ### Continue a previous conversation
 
 ```bash
 railway agent --thread-id <THREAD_ID>
 ```
+
+When you resume a thread, the agent replays the recent message history before dropping you into interactive mode, so you can pick up where you left off. Pair with `--list` to find the thread ID you want.
 
 ## Interactive mode
 


### PR DESCRIPTION
## Summary
- Add a row in `railway agent`'s flag table for `--list`, and call out that `--thread-id` now replays history.
- Add example sections for listing threads (`railway agent --list`) and for resuming a thread, including the history-replay behavior.
- Update the AI & agents cheatsheet on `cli.md` to include the two new flags.

Pairs with railwayapp/cli#897 (shipped in CLI 4.57.5).

## Test plan
- [ ] Pull the branch, run the docs site locally, and confirm \`/cli/agent\` renders the new options row and example sections.
- [ ] Confirm the AI & agents block on \`/cli\` shows the two new lines without breaking layout.