### PR TITLE
Fix psycopg typo in Django guide

### DIFF
--- a/content/guides/django.md
+++ b/content/guides/django.md
@@ -70,7 +70,7 @@ python -m pip install gunicorn whitenoise psycopg[binary,pool]
 
 [gunicorn](https://gunicorn.org) is a production ready web server.
 
-[pyscog](https://www.psycopg.org/psycopg3/docs) is python package that allows Django work with Postgresql.
+[psycopg](https://www.psycopg.org/psycopg3/docs) is a Python package that allows Django to work with PostgreSQL.
 
 2. Import the `os` module:
 


### PR DESCRIPTION
## Summary

- Corrects the Django guide typo from `pyscog` to `psycopg`.
- Tightens the surrounding sentence grammar and PostgreSQL capitalization.

## Verification

- `git diff --check`

Related Central Station report: https://station.railway.com/questions/correction-needed-in-documentation-typo-1cbf8564