### PR TITLE
Fix Railpack custom install command env var

### DIFF
--- a/content/docs/builds/build-configuration.md
+++ b/content/docs/builds/build-configuration.md
@@ -110,7 +110,7 @@ preferred.
 
 ## Specify a custom install command
 
-You can override the install command by setting the `RAILPACK_INSTALL_COMMAND`
+You can override the install command by setting the `RAILPACK_INSTALL_CMD`
 environment variable in your service settings.
 
 ## Disable build layer caching


### PR DESCRIPTION
## Summary

- Replaces `RAILPACK_INSTALL_COMMAND` with the documented Railpack env var `RAILPACK_INSTALL_CMD`.

## Verification

- `git diff --check`

Fixes https://github.com/railwayapp/docs/issues/1147