### PR TITLE
Clarify custom Railpack config file selection

### DIFF
--- a/content/docs/builds/build-configuration.md
+++ b/content/docs/builds/build-configuration.md
@@ -22,6 +22,24 @@ href="https://railpack.com/config/environment-variables"
 target="_blank">Railpack docs</a>. You can find a complete list of languages we
 support out of the box [here](/builds/railpack#supported-languages).
 
+### Use a custom Railpack config file
+
+Railway config-as-code files (`railway.toml` or `railway.json`) configure
+Railway service settings. Railpack config files (`railpack.json`) configure how
+Railpack generates the build plan.
+
+Railpack looks for `railpack.json` in the directory being built. To use a
+different Railpack config file for a service, set the `RAILPACK_CONFIG_FILE`
+service variable to a path relative to that build directory:
+
+```plaintext
+RAILPACK_CONFIG_FILE=pdf-extractor.railpack.json
+```
+
+This is separate from the **Railway Config File** setting, which selects a
+`railway.toml` or `railway.json` config-as-code file and does not select the
+Railpack config file.
+
 ## Customize the build command
 
 You can override the detected build command by setting a value in your service

--- a/content/docs/config-as-code.md
+++ b/content/docs/config-as-code.md
@@ -78,6 +78,11 @@ width={1200} height={631} quality={100} />
 You can use a custom config file by setting it on the service settings page. You should provide the absolute path to the file in your repository,
 for example: `/backend/railway.toml`
 
+This setting only selects the Railway config-as-code file (`railway.toml` or
+`railway.json`). It does not select a Railpack config file. To use a custom
+Railpack config file such as `railpack.json`, set the
+`RAILPACK_CONFIG_FILE` service variable instead.
+
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1743195631/docs/config-file_f1wf32.png"
 alt="Screenshot of Rollback Menu"


### PR DESCRIPTION
## Summary
- distinguish Railway config-as-code files from Railpack config files
- document `RAILPACK_CONFIG_FILE` for selecting a non-default Railpack config file per service
- add a note that the Railway Config File setting does not select `railpack.json`

Related Central Station question: https://station.railway.com/questions/railpack-how-to-use-a-per-service-confi-b87c4c0e

## Verification
- `git diff --check`
- `pnpm exec content-collections build`