### PR TITLE
Clarify Dockerfile path and root directory behavior

### DIFF
--- a/content/docs/builds/dockerfiles.md
+++ b/content/docs/builds/dockerfiles.md
@@ -37,6 +37,11 @@ If your Dockerfile is in another directory, specify it like this:
 RAILWAY_DOCKERFILE_PATH=/build/Dockerfile
 ```
 
+The Dockerfile path only selects which Dockerfile Railway uses. It does not
+change the service's Root Directory or Docker build context. If the Dockerfile
+expects files relative to a subdirectory, set that subdirectory as the service's
+**Root Directory** in the service settings.
+
 ### Use config as Code
 
 You can also set your custom Dockerfile path using [config as code](/config-as-code).

--- a/content/docs/config-as-code/reference.md
+++ b/content/docs/config-as-code/reference.md
@@ -103,6 +103,11 @@ Location of non-standard Dockerfile.
 
 This field can be set to `null`.
 
+This only selects the Dockerfile. It does not set the service's Root Directory
+or change the Docker build context. If your Dockerfile is written for a
+subdirectory, set the service's **Root Directory** to that subdirectory in the
+service settings.
+
 More about building from a Dockerfile [here](/builds/dockerfiles).
 
 ### Railpack version


### PR DESCRIPTION
## Summary
- clarify that `dockerfilePath` selects the Dockerfile only
- note that it does not set the service Root Directory or Docker build context
- point subdirectory Dockerfile users to the Root Directory service setting

Related Central Station question: https://station.railway.com/questions/set-root-directory-on-railway-toml-776939f0

## Verification
- `git diff --check`
- `pnpm exec content-collections build`