### PR TITLE
Document Dockerfile build secret limitations

### DIFF
--- a/content/docs/builds/dockerfiles.md
+++ b/content/docs/builds/dockerfiles.md
@@ -62,6 +62,15 @@ FROM node
 ARG RAILWAY_ENVIRONMENT
 ```
 
+<Banner variant="warning">
+Railway does not bind service variables as Docker BuildKit secrets for
+`RUN --mount=type=secret`. Use `ARG` for build-time values in Dockerfile
+builds, and avoid expanding secrets directly in `RUN` commands because the
+expanded command can appear in build logs. Sealed variables hide values in the
+Railway UI and API, but they do not prevent a Docker build step from printing a
+secret after it has been expanded.
+</Banner>
+
 ## Cache mounts
 
 Railway supports cache mounts in your Dockerfile in the following format:


### PR DESCRIPTION
## Summary
- document that Dockerfile builds do not bind Railway service variables as BuildKit `type=secret` mounts
- warn that sealed variables can still be printed if a Docker `RUN` command expands them
- keep the existing `ARG` guidance but make the secret-handling limitation explicit

Related Central Station question: https://station.railway.com/questions/does-railway-support-run-mount-type-se-aa6a8782

## Verification
- `git diff --check`
- `pnpm exec content-collections build`