### PR TITLE
docs: clarify serviceInstanceDeployV2 default behavior and document c…

### DIFF
--- a/content/docs/integrations/api/manage-services.md
+++ b/content/docs/integrations/api/manage-services.md
@@ -144,17 +144,23 @@ Connect an existing service to a GitHub repository:
 
 ## Deploy a service
 
-Trigger a new deployment for a service:
+Trigger a new deployment for a service. Returns the deployment ID.
 
 <GraphQLCodeTabs query={`mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!) {
   serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId)
 }`} variables={{ serviceId: "service-id", environmentId: "environment-id" }} />
 
-This returns the deployment ID.
+By default this deploys the commit currently associated with the service (the same commit `serviceInstanceRedeploy` would use). To deploy a specific commit — for example, the latest HEAD of a connected GitHub branch — pass `commitSha`:
+
+<CodeTabs query={`mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!, $commitSha: String!) {
+  serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId, commitSha: $commitSha)
+}`} variables={{ serviceId: "service-id", environmentId: "environment-id", commitSha: "abc123..." }} />
+
+The `commitSha` is validated against the connected GitHub repo; an unknown SHA returns a "Commit not found" error and no deployment is created.
 
 ## Redeploy a service
 
-Redeploy the latest deployment:
+Redeploy the service's latest deployment using its existing commit. This does not check the connected GitHub repo for new commits — use the `commitSha` argument on `serviceInstanceDeployV2` to deploy a specific commit.
 
 <GraphQLCodeTabs query={`mutation serviceInstanceRedeploy($serviceId: String!, $environmentId: String!) {
   serviceInstanceRedeploy(serviceId: $serviceId, environmentId: $environmentId)


### PR DESCRIPTION
  Clarifies that `serviceInstanceDeployV2` without `commitSha` deploys the service's currently associated commit (same as
  `serviceInstanceRedeploy`), and documents the `commitSha` parameter for deploying a specific commit (e.g. the latest HEAD of a
   connected GitHub branch).

  Prompted by customer feedback on a Slack Connect thread where the prior wording ("Trigger a new deployment" vs "Redeploy the
  latest deployment") implied a behavioral difference that doesn't exist by default.