### PR TITLE
docs: add keyboard shortcuts reference page

### DIFF
--- a/content/docs/overview/keyboard-shortcuts.md
+++ b/content/docs/overview/keyboard-shortcuts.md
@@ -1,0 +1,82 @@
+---
+title: Keyboard Shortcuts
+description: A reference of keyboard shortcuts available in the Railway dashboard, canvas, and data views.
+---
+
+The Railway dashboard supports keyboard shortcuts for common actions. This page lists the shortcuts you can use, grouped by context.
+
+Shortcuts that include `Cmd` work with `Ctrl` on Windows and Linux. For example, `Cmd+K` is `Ctrl+K` on Windows.
+
+## Global
+
+These shortcuts work anywhere in the dashboard.
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+K` | Open the command palette |
+| `Escape` | Go back, close a modal, or deselect |
+
+## Command palette
+
+Once the command palette is open, you can navigate it without leaving the keyboard.
+
+| Shortcut | Action |
+|----------|--------|
+| `Arrow Up` / `Arrow Down` | Move through results |
+| `Enter` | Run the highlighted command |
+| `Arrow Right` | Open a subcommand |
+| `Backspace` | Go back to the previous menu |
+| `Shift+Enter` | Report a missing command |
+| `Escape` | Close the palette |
+
+## Dashboard
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+/` | Create a new project |
+
+## Project canvas
+
+These shortcuts work while you have a project canvas open.
+
+| Shortcut | Action |
+|----------|--------|
+| `.` | Create a new function on the canvas |
+| `Cmd+Z` | Undo the last canvas change |
+| `Cmd+Shift+Z` | Redo |
+
+## Service view
+
+Press these from anywhere inside a service to jump to one of its tabs.
+
+| Shortcut | Action |
+|----------|--------|
+| `G` then `D` | Go to Deployments |
+| `G` then `V` | Go to Variables |
+| `G` then `M` | Go to Metrics |
+| `G` then `S` | Go to service Settings |
+| `Escape` | Close the service view and return to the project canvas |
+
+## Staged changes
+
+Staged changes group infrastructure edits into a single commit before they apply to your environment.
+
+| Shortcut | Action |
+|----------|--------|
+| `Shift+Enter` | Commit staged changes |
+| `Alt+Shift+Enter` | Commit staged changes without triggering deploys |
+| `Cmd+Enter` | Commit the current patch (inside the patch modal) |
+
+## Logs
+
+| Shortcut | Action |
+|----------|--------|
+| `/` | Focus the filter input |
+| `Enter` | Apply the filter |
+| `Escape` | Close the date or filter popover |
+
+## Service settings
+
+| Shortcut | Action |
+|----------|--------|
+| `/` | Focus the settings filter |

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -30,6 +30,7 @@ export const sidebarContent: ISidebarContent = [
       makePage("Advanced concepts", "overview"),
       makePage("Production readiness checklist", "overview"),
       makePage("Guides", undefined, "/guides"),
+      makePage("Keyboard shortcuts", "overview"),
     ],
   },
   {


### PR DESCRIPTION
## Summary of changes

Document commonly-used dashboard, canvas, service navigation, logs, staged
changes, and settings shortcuts so power users can find them in one place.
