### PR TITLE
docs: fix CodeTabs typo breaking build

### DIFF
--- a/content/docs/integrations/api/manage-services.md
+++ b/content/docs/integrations/api/manage-services.md
@@ -152,7 +152,7 @@ Trigger a new deployment for a service. Returns the deployment ID.
 
 By default this deploys the commit currently associated with the service (the same commit `serviceInstanceRedeploy` would use). To deploy a specific commit — for example, the latest HEAD of a connected GitHub branch — pass `commitSha`:
 
-<CodeTabs query={`mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!, $commitSha: String!) {
+<GraphQLCodeTabs query={`mutation serviceInstanceDeployV2($serviceId: String!, $environmentId: String!, $commitSha: String!) {
   serviceInstanceDeployV2(serviceId: $serviceId, environmentId: $environmentId, commitSha: $commitSha)
 }`} variables={{ serviceId: "service-id", environmentId: "environment-id", commitSha: "abc123..." }} />
 


### PR DESCRIPTION
## Summary
- Line 155 of `content/docs/integrations/api/manage-services.md` used `<CodeTabs>` instead of `<GraphQLCodeTabs>` — every other tabbed example in the file uses the latter.
- The static prerender fails on `/integrations/api/manage-services` with `Expected component CodeTabs to be defined`, breaking CI on main and on every open branch.
- Typo was introduced in #1163 (commit `74ce438`).

## Test plan
- [ ] CI passes on this PR
- [ ] `commitSha` example renders correctly on the manage-services docs page