### PR TITLE
docs: remove BYOC, VPC peering, and AWS/GCP deployment claims

### DIFF
--- a/content/docs/enterprise.md
+++ b/content/docs/enterprise.md
@@ -48,8 +48,6 @@ Railway can be deployed globally, with availability across the Americas, EMEA, a
 
 **Railway-managed dedicated VMs**: Your workloads run on dedicated Railway hosts for complete resource isolation. Continue to benefit from Railway-managed infrastructure with added security.
 
-**Bring your own cloud**: Deploy Railway within your VPC for ultimate compliance within your infrastructure. By using your existing cloud account, consume credits or use existing commercial commitments and EDP minimums while experiencing Railway's world-class developer experience.
-
 ## Support SLOs
 
 Enterprise support for reliable uptime and and performance, with:

--- a/content/docs/platform/railway-metal.md
+++ b/content/docs/platform/railway-metal.md
@@ -235,7 +235,7 @@ See [Manual rollback](#manual-rollback) for instructions.
 
 ### Will Railway stay on gcp?
 
-No. We are migrating completely onto Railway managed hardware. For customers who would like Railway to deploy into their public cloud, you can contact sales via the [AWS Marketplace listing.](https://aws.amazon.com/marketplace/pp/prodview-cnib4vbrfgs5a)
+No. We are migrating completely onto Railway managed hardware.
 
 ### Help! After migrating, why do I have increased latency?
 

--- a/content/docs/pricing/aws-marketplace.md
+++ b/content/docs/pricing/aws-marketplace.md
@@ -7,7 +7,7 @@ Railway is available through the AWS Marketplace, allowing you to purchase and m
 
 ## Offering
 
-Railway offers solutions, peering templates and deployment to AWS- while using your AWS vendor relationship. For large Enterprises, Railway can be an option for large engineering teams to significantly reduce operational overhead.
+For large Enterprises, Railway can be an option for large engineering teams to significantly reduce operational overhead.
 
 ## Pricing structure
 

--- a/content/docs/pricing/committed-spend.md
+++ b/content/docs/pricing/committed-spend.md
@@ -11,8 +11,8 @@ Railway offers committed spend tiers for customers with consistent usage needs. 
 | -------------------- | ------------------------------------------------------------------------------------ |
 | $1000                | 90-day log history, HIPAA BAAs                                                       |
 | $2000                | Single Sign-On, Role-based access control, 18 month Audit Logs retention             |
-| $5000                | Slack Connect channels,  Critical level support tickets, Railway owned cloud regions, Enterprise Resource Limits |
-| $10000               | Dedicated instances, Bring your own cloud                                            |
+| $5000                | Slack Connect channels,  Critical level support tickets, Enterprise Resource Limits |
+| $10000               | Dedicated instances                                                                  |
 
 ## How to subscribe
 
@@ -53,14 +53,8 @@ A private channel with the solutions team at Railway on Slack to facilitate bett
 ### Critical level support tickets
 Critical tickets allow you to page our support on-call directly for an immediate response.
 
-### Railway owned cloud regions
-Deploy to AWS and GCP via Railway for better availability zone selection.
-
 ### Dedicated instances
 Custom dedicated infrastructure for enhanced performance and control.
-
-### Bring your own cloud
-Deploy Railway within your VPC for ultimate compliance within your infrastructure.
 
 
 ## FAQs


### PR DESCRIPTION
## Summary

Railway does not offer bring-your-own-cloud, VPC peering, or deployment to AWS/GCP at any tier. The docs were advertising all three. This PR removes those claims — no new content is added, only false statements are deleted.


Made with [Cursor](https://cursor.com)