### PR TITLE
Add CLI file management docs

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -128,6 +128,8 @@ railway add                     # Add a service (interactive)
 railway add --database postgres # Add PostgreSQL
 railway add --repo user/repo    # Add from GitHub repo
 railway service                 # Link a service
+railway service files browse /app # Browse service files in a TUI
+railway service files download /app/data.db ./data.db # Download from a service
 railway scale                   # Scale a service
 railway delete                  # Delete a project
 ```
@@ -191,6 +193,8 @@ railway domain example.com      # Add custom domain
 ```bash
 railway volume list             # List volumes
 railway volume add              # Add a volume
+railway volume browse /         # Browse volume files in a TUI
+railway volume files download /backup.tar ./backup.tar # Download from a volume
 railway volume delete           # Delete a volume
 ```
 

--- a/content/docs/cli/service.md
+++ b/content/docs/cli/service.md
@@ -23,6 +23,7 @@ railway service [SERVICE] [COMMAND]
 | `redeploy` | | Redeploy the latest deployment |
 | `restart` | | Restart the latest deployment |
 | `scale` | | Scale a service across regions |
+| `files` | `file` | Manage files in a service filesystem |
 
 ## Examples
 
@@ -76,6 +77,44 @@ railway service restart
 railway service scale us-west=2
 ```
 
+### Browse service files
+
+```bash
+railway service files browse /app
+```
+
+Opens an interactive TUI for browsing, downloading, uploading, editing, renaming, and deleting files in the service filesystem.
+
+### List service files
+
+```bash
+railway service files list /app
+```
+
+### Download a file from a service
+
+```bash
+railway service files download /app/data.db ./data.db
+```
+
+### Upload a file to a service
+
+```bash
+railway service files upload ./seed.db /app/seed.db
+```
+
+### Rename a file in a service
+
+```bash
+railway service files rename /app/data.db /app/data-old.db
+```
+
+### Delete a file from a service
+
+```bash
+railway service files delete /app/data.db
+```
+
 ## Options for `status`
 
 | Flag | Description |
@@ -123,6 +162,80 @@ See [railway logs](/cli/logs) for detailed usage and examples.
 | `--json` | Output in JSON format |
 
 See [railway scale](/cli/scale) for available regions and detailed usage.
+
+## Manage files
+
+Use `railway service files` to manage files in a running service filesystem. The command uses the linked service by default. Pass `--service`, `--environment`, or `--project` to select a different target.
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `list` | `ls` | List files in a directory |
+| `browse` | `browser` | Browse files interactively |
+| `download` | | Download a file or directory |
+| `upload` | | Upload a file or directory |
+| `delete` | `rm`, `remove` | Delete a file |
+| `rename` | `mv` | Rename a file |
+
+### Options for `files`
+
+| Flag | Description |
+|------|-------------|
+| `-s, --service <SERVICE>` | Service name or ID |
+| `-e, --environment <ENVIRONMENT>` | Environment to use |
+| `-p, --project <PROJECT_ID>` | Project ID to use |
+
+### Options for `files list`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[REMOTE_PATH]` | Directory path to list. Defaults to `/` |
+| `--json` | Output in JSON format |
+
+### Options for `files download`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<REMOTE_PATH>` | Remote file or directory to download |
+| `[LOCAL_PATH]` | Local destination. Defaults to the current directory |
+| `--overwrite`, `--override` | Replace the local path if it already exists |
+| `--concurrency <N>` | Concurrent file downloads when downloading a directory. Defaults to `32` |
+| `--json` | Output in JSON format |
+
+### Options for `files upload`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<LOCAL_PATH>` | Local file or directory to upload |
+| `<REMOTE_PATH>` | Remote destination path |
+| `--overwrite` | Replace the remote path if it already exists |
+| `--concurrency <N>` | Concurrent file uploads when uploading a directory. Defaults to `32` |
+| `--json` | Output in JSON format |
+
+### Options for `files delete`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<REMOTE_PATH>` | Remote file to delete |
+| `-y, --yes` | Skip confirmation |
+| `--json` | Output in JSON format |
+
+`railway service files delete` refuses to run when invoked by an AI agent and must be run by a human.
+
+### Options for `files rename`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<OLD_REMOTE_PATH>` | Existing remote path |
+| `<NEW_REMOTE_PATH>` | New remote path |
+| `--json` | Output in JSON format |
+
+### Options for `files browse`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[REMOTE_PATH]` | Directory path to open. Defaults to `/` |
+| `--editor <COMMAND>` | Editor command to use when editing files |
+| `--concurrency <N>` | Concurrent file downloads. Defaults to `32` |
 
 ## Related
 

--- a/content/docs/cli/volume.md
+++ b/content/docs/cli/volume.md
@@ -24,6 +24,8 @@ railway volume <COMMAND> [OPTIONS]
 | `delete` | `remove`, `rm` | Delete a volume |
 | `update` | `edit`, `rename` | Update a volume |
 | `detach` | | Detach a volume from a service |
+| `files` | `file` | Manage files in a volume |
+| `browse` | `browser` | Browse files in a volume interactively |
 | `attach` | | Attach a volume to a service |
 
 ## Examples
@@ -70,12 +72,51 @@ railway volume detach --volume my-volume
 railway volume attach --volume my-volume --service backend
 ```
 
+### Browse volume files
+
+```bash
+railway volume browse /
+```
+
+Opens an interactive TUI for browsing, downloading, uploading, editing, renaming, and deleting files in the volume.
+
+### List volume files
+
+```bash
+railway volume files list /
+```
+
+### Download a file from a volume
+
+```bash
+railway volume files download /backup.tar ./backup.tar
+```
+
+### Upload a file to a volume
+
+```bash
+railway volume files upload ./backup.tar /backup.tar
+```
+
+### Rename a file in a volume
+
+```bash
+railway volume files rename /backup.tar /backup-old.tar
+```
+
+### Delete a file from a volume
+
+```bash
+railway volume files delete /backup.tar
+```
+
 ## Common options
 
 | Flag | Description |
 |------|-------------|
 | `-s, --service <SERVICE>` | Service ID |
 | `-e, --environment <ENV>` | Environment ID |
+| `-p, --project <PROJECT_ID>` | Project ID |
 | `--json` | Output in JSON format |
 
 ## Options for `add`
@@ -115,6 +156,90 @@ railway volume attach --volume my-volume --service backend
 | `-v, --volume <VOLUME>` | Volume ID or name to attach |
 | `-y, --yes` | Skip confirmation |
 | `--json` | Output in JSON format |
+
+## Manage files
+
+Use `railway volume files` to manage files in a volume from scripts or non-interactive workflows.
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `list` | `ls` | List files in a directory |
+| `browse` | `browser` | Browse files interactively |
+| `download` | | Download a file or directory |
+| `upload` | | Upload a file or directory |
+| `delete` | `rm`, `remove` | Delete a file |
+| `rename` | `mv` | Rename a file |
+
+### Options for `files`
+
+| Flag | Description |
+|------|-------------|
+| `-v, --volume <VOLUME>` | Volume ID or name. Without this flag, the CLI prompts you to choose one |
+
+The `-v, --volume` flag must be passed before the subcommand (for example, `railway volume files --volume data browse /`).
+
+### Options for `files list`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[REMOTE_PATH]` | Directory path to list. Defaults to `/` |
+| `--json` | Output in JSON format |
+
+### Options for `files download`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<REMOTE_PATH>` | Remote file or directory to download |
+| `[LOCAL_PATH]` | Local destination. Defaults to the current directory |
+| `--overwrite`, `--override` | Replace the local path if it already exists |
+| `--concurrency <N>` | Concurrent file downloads when downloading a directory. Defaults to `32` |
+| `--json` | Output in JSON format |
+
+### Options for `files upload`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<LOCAL_PATH>` | Local file or directory to upload |
+| `<REMOTE_PATH>` | Remote destination path |
+| `--overwrite` | Replace the remote path if it already exists |
+| `--concurrency <N>` | Concurrent file uploads when uploading a directory. Defaults to `32` |
+| `--json` | Output in JSON format |
+
+### Options for `files delete`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<REMOTE_PATH>` | Remote file to delete |
+| `-y, --yes` | Skip confirmation |
+| `--json` | Output in JSON format |
+
+`railway volume files delete` refuses to run when invoked by an AI agent and must be run by a human.
+
+### Options for `files rename`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<OLD_REMOTE_PATH>` | Existing remote path |
+| `<NEW_REMOTE_PATH>` | New remote path |
+| `--json` | Output in JSON format |
+
+## Interactive file browser
+
+The volume file browser TUI can be opened with either:
+
+- `railway volume browse [REMOTE_PATH]` — top-level shortcut
+- `railway volume files browse [REMOTE_PATH]` — equivalent through the `files` group
+
+### Options for `browse`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[REMOTE_PATH]` | Directory path to open. Defaults to `/` |
+| `-v, --volume <VOLUME>` | Volume ID or name to browse |
+| `--editor <COMMAND>` | Editor command to use when editing files |
+| `--concurrency <N>` | Concurrent file downloads. Defaults to `32` |
+
+When using `railway volume files browse`, pass `--volume` on the `files` group (for example, `railway volume files --volume data browse /`). The `--editor` and `--concurrency` flags are passed on `browse` itself.
 
 ## Related
 

--- a/content/docs/services.md
+++ b/content/docs/services.md
@@ -144,6 +144,28 @@ Every service deployment has access to ephemeral storage, with the limits being 
 
 If your service requires data to persist between deployments, or needs more storage, you should add a [volume](/volumes).
 
+### Manage service files
+
+Use the Railway CLI to inspect and manage files in a running service filesystem.
+
+```bash
+railway service files browse /app
+```
+
+The `browse` subcommand opens an interactive TUI where you can browse, upload, download, edit, rename, and delete files.
+
+For non-interactive workflows, use the other `railway service files` subcommands:
+
+```bash
+railway service files list /app
+railway service files download /app/data.db ./data.db
+railway service files upload ./seed.db /app/seed.db
+```
+
+Files outside a volume are part of the service's ephemeral filesystem and don't persist across deployments. Use a [volume](/volumes) for data that must persist.
+
+See [railway service](/cli/service) for the full command reference.
+
 ## Monitoring
 
 Logs, metrics, and usage information is available for services and projects. Check out the [observability guides](/observability) for information on how to track this data.

--- a/content/docs/volumes.md
+++ b/content/docs/volumes.md
@@ -68,6 +68,26 @@ You must configure the mount path of the volume in your service:
 
 The volume mount point you specify will be available in your service as a directory to which you can read/write. If you mount a volume to `/foobar`, your application will be able to access it at the absolute path `/foobar`.
 
+### Manage volume files
+
+Use the Railway CLI to inspect and manage files stored on a volume.
+
+```bash
+railway volume browse /
+```
+
+The `browse` command opens an interactive TUI where you can browse, upload, download, edit, rename, and delete files.
+
+For non-interactive workflows, use `railway volume files`:
+
+```bash
+railway volume files list /
+railway volume files download /backup.tar ./backup.tar
+railway volume files upload ./backup.tar /backup.tar
+```
+
+See [railway volume](/cli/volume) for the full command reference.
+
 ### Relative paths
 
 Railway's build system puts your application files in an `/app` folder at the root of the container. If your application writes to a directory at a relative path, and you need to persist that data on the volume, your mount path should include the app path.

--- a/content/docs/volumes/reference.md
+++ b/content/docs/volumes/reference.md
@@ -75,9 +75,8 @@ Here are some limitations of which we are currently aware:
   and mounted to the same service. This means that there will be a small amount
   of downtime when re-deploying a service that has a volume attached, even if there is a healthcheck endpoint configured
 - Down-sizing a volume is not currently supported, but increasing size is supported
-- Volume resizing is performed live without downtime - the underlying storage is expanded while your service continues running, and the filesystem automatically extends to utilize the additional space. In certain scenarios, such as when a volume reaches 100% capacity, an offline resize is automatically performed instead to run data integrity checks, which will restart your service
-- There is no file browser, or direct file download. To access your files,
-  you must do so via the attached service's mount point
+- Volume resizing is performed live without downtime. The underlying storage is expanded while your service continues running, and the filesystem automatically extends to utilize the additional space. In certain scenarios, such as when a volume reaches 100% capacity, an offline resize is automatically performed instead to run data integrity checks, which will restart your service
+- Volume files can be managed from the CLI with `railway volume browse` or `railway volume files`
 - Docker images that run as a non-root UID by default will have permissions issues when performing operations within an attached volume. If you are affected by this, you can set `RAILWAY_RUN_UID=0` environment variable in your service.
 
 ## Support


### PR DESCRIPTION
## Summary

- Adds CLI documentation for managing volume files with `railway volume files` and the interactive `railway volume browse` TUI.
- Adds CLI documentation for managing service filesystem files with `railway service files` and its interactive TUI.
- Updates the CLI overview, services page, volumes page, and volume reference caveats so they no longer imply file browsing or direct downloads are unavailable.

