### PR TITLE
feat(middleware): detect AI agent user-agents and serve markdown

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -11,6 +11,14 @@ function prefersMarkdown(acceptHeader: string): boolean {
   return mdIdx !== -1 && (htmlIdx === -1 || mdIdx < htmlIdx);
 }
 
+// Known AI agent / crawler user-agent patterns
+const AI_UA_RE =
+  /claudebot|claude-web|anthropic|gptbot|chatgpt|oai-searchbot|openai|perplexitybot|perplexity|cohere|gemini|googlebot-richsnippets|meta-externalagent|bingbot.*ai|bingpreview|duckassistbot/i;
+
+function isAIAgent(uaHeader: string): boolean {
+  return AI_UA_RE.test(uaHeader);
+}
+
 export function middleware(request: NextRequest) {
   const { pathname, searchParams } = request.nextUrl;
 
@@ -28,7 +36,8 @@ export function middleware(request: NextRequest) {
   const wantsMarkdown =
     hasMdExtension ||
     searchParams.get("format") === "md" ||
-    prefersMarkdown(request.headers.get("accept") || "");
+    prefersMarkdown(request.headers.get("accept") || "") ||
+    isAIAgent(request.headers.get("user-agent") || "");
 
   const url = request.nextUrl.clone();
   url.pathname = "/dynamic" + pagePath;


### PR DESCRIPTION
## What

Adds AI bot/crawler user-agent detection to the Next.js middleware so known AI agents automatically receive the markdown version of any doc page.

## Why

AI crawlers (ClaudeBot, GPTBot, Perplexity, etc.) send distinct `User-Agent` strings but don't necessarily send `Accept: text/markdown`. Without UA detection they get the full HTML/JS page, which isn't useful for ingestion. The markdown path already exists — this just routes bots to it automatically.

## How

Added `isAIAgent()` with a regex covering known crawlers:
- Anthropic: `claudebot`, `claude-web`, `anthropic`
- OpenAI: `gptbot`, `chatgpt`, `oai-searchbot`, `openai`
- Perplexity: `perplexitybot`, `perplexity`
- Others: `cohere`, `gemini`, `meta-externalagent`, `bingbot.*ai`, `bingpreview`, `duckassistbot`

Hooks into the existing `wantsMarkdown` check alongside the `Accept: text/markdown` and `.md` URL extension paths — no new rewrite logic needed.