### PR TITLE
feat: improve LLM/agent discoverability of docs

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -1,4 +1,14 @@
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_RAILWAY_DOCS_URL || "https://docs.railway.com",
   generateRobotsTxt: true,
+  robotsTxtOptions: {
+    additionalSitemaps: [],
+    policies: [
+      { userAgent: "*", allow: "/" },
+    ],
+    additionalPaths: async () => [
+      { route: "/llms.txt", changefreq: "daily", priority: 0.9 },
+      { route: "/llms-full.txt", changefreq: "daily", priority: 0.9 },
+    ],
+  },
 };

--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -224,6 +224,9 @@ export const SEO: React.FC<Props> = ({
         {/* Last modification date */}
         {lastModified && <meta name="last-modified" content={lastModified} />}
 
+        {/* Markdown alternate for LLM/agent discovery */}
+        <link rel="alternate" type="text/markdown" href={`${url}.md`} />
+
         {/* Structured data schemas */}
         {schemas.map((schema, index) => (
           <script

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -44,7 +44,10 @@ export function middleware(request: NextRequest) {
   if (wantsMarkdown) {
     url.searchParams.set("format", "md");
   }
-  return NextResponse.rewrite(url);
+  const response = NextResponse.rewrite(url);
+  // Ensure CDN/proxies cache HTML and markdown separately
+  response.headers.set("Vary", "Accept, User-Agent");
+  return response;
 }
 
 export const config = {

--- a/src/pages/api/llms-full.txt.ts
+++ b/src/pages/api/llms-full.txt.ts
@@ -106,7 +106,7 @@ const handler: NextApiHandler = (_req, res) => {
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
   res.setHeader(
     "Cache-Control",
-    "public, s-maxage=3600, stale-while-revalidate=3600",
+    "public, s-maxage=86400, stale-while-revalidate=86400",
   );
 
   const sources = buildSourceMap();

--- a/src/pages/dynamic/[...slug].tsx
+++ b/src/pages/dynamic/[...slug].tsx
@@ -117,6 +117,13 @@ export const getServerSideProps = async (
     return { props: {} };
   }
 
+  // Advertise markdown alternate via Link header for HTML responses
+  const markdownUrl = `https://docs.railway.com${page.url}.md`;
+  context.res.setHeader(
+    "Link",
+    `<${markdownUrl}>; rel="alternate"; type="text/markdown"`,
+  );
+
   return {
     props: {
       page,


### PR DESCRIPTION
## What

A set of discoverability improvements so AI crawlers and LLM pipelines can more easily find and consume the Railway docs in clean markdown.

## Changes

**`robots.txt`** — adds `/llms.txt` and `/llms-full.txt` as explicitly listed paths so crawlers that read `robots.txt` know these endpoints exist.

**`<link rel="alternate" type="text/markdown">`** — added to every page `<head>` so any crawler that parses HTML can autodiscover the markdown URL for that page.

**`Link:` HTTP response header** — every HTML doc page now returns `Link: <url.md>; rel="alternate"; type="text/markdown"` so agents reading response headers (without parsing HTML) also see it.

**`Vary: Accept, User-Agent`** — added to all middleware rewrites so CDNs/proxies cache the HTML and markdown variants separately and don't serve the wrong one.

**`llms-full.txt` cache** — bumped from 1h to 24h since the full doc dump is large and indexing jobs often run longer than an hour.