### PR TITLE
Adding Initial Docs for Sandboxes

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -222,6 +222,18 @@ railway functions push          # Push function changes
 
 [functions](/cli/functions)
 
+### Sandboxes
+
+```bash
+railway sandbox create          # Create a sandbox
+railway sandbox list            # List sandboxes in the environment
+railway sandbox ssh             # SSH into the active sandbox
+railway sandbox exec -- ls -la  # Run a command in the active sandbox
+railway sandbox destroy         # Destroy a sandbox
+```
+
+[sandbox](/cli/sandbox)
+
 ### AI & agents
 
 ```bash

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -1,0 +1,156 @@
+---
+title: railway sandbox
+description: Manage ephemeral sandboxes.
+---
+
+Create, connect to, run commands in, and destroy ephemeral [sandboxes](/sandboxes) in a Railway environment.
+
+<Banner variant="info">The `sandbox` command requires sandboxes to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>.</Banner>
+
+## Usage
+
+```bash
+railway sandbox <COMMAND> [OPTIONS]
+```
+
+## Aliases
+
+- `railway sandboxes`
+- `railway sbx`
+
+## Subcommands
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `create` | `new` | Create a sandbox and set it as the active sandbox |
+| `list` | `ls` | List sandboxes in the environment |
+| `ssh` | `connect` | Connect to a sandbox over SSH |
+| `exec` | | Run a single command inside a sandbox |
+| `destroy` | `rm`, `delete` | Destroy a sandbox |
+
+## Active sandbox
+
+`create` sets the new sandbox as the active sandbox. The `ssh`, `exec`, and `destroy` commands act on the active sandbox when you don't pass an ID, so a typical session needs no IDs at all. Running `ssh` or `exec` against a specific sandbox makes that one active.
+
+Pass `--id <ID>` (or a positional ID for `destroy`) to target a specific sandbox instead. `list` marks the active sandbox with an asterisk.
+
+## Examples
+
+### Create a sandbox
+
+```bash
+railway sandbox create
+```
+
+### Create a sandbox with an idle timeout
+
+```bash
+railway sandbox create --idle-timeout-minutes 30
+```
+
+Railway auto-destroys the sandbox after it sits idle for the given number of minutes.
+
+### List sandboxes
+
+```bash
+railway sandbox list
+```
+
+### Connect to the active sandbox
+
+```bash
+railway sandbox ssh
+```
+
+### Connect to a specific sandbox
+
+```bash
+railway sandbox ssh --id sbx_abc123
+```
+
+### Run a command over SSH instead of opening a shell
+
+```bash
+railway sandbox ssh -- ls -la
+```
+
+### Run a single command
+
+```bash
+railway sandbox exec -- npm run build
+```
+
+### Run a command in a specific sandbox with a timeout
+
+```bash
+railway sandbox exec --id sbx_abc123 --timeout 120 -- npm test
+```
+
+`exec` writes the command's output to your terminal and exits with the command's exit code.
+
+### Destroy the active sandbox
+
+```bash
+railway sandbox destroy
+```
+
+### Destroy a specific sandbox
+
+```bash
+railway sandbox destroy sbx_abc123
+```
+
+## Options for `create`
+
+| Flag | Description |
+|------|-------------|
+| `--idle-timeout-minutes <N>` | Minutes the sandbox can sit idle before it is auto-destroyed |
+| `--json` | Output the created sandbox as JSON |
+
+## Options for `list`
+
+| Flag | Description |
+|------|-------------|
+| `--json` | Output in JSON format |
+
+## Options for `ssh`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `--id <ID>` | Sandbox ID to connect to. Defaults to the active sandbox |
+| `-i, --identity-file <PATH>` | Path to an identity (private key) file, like `ssh -i` |
+| `[-- COMMAND]` | Command to run instead of an interactive shell |
+
+Connecting over SSH requires an SSH key on your Railway account. See [railway ssh](/cli/ssh) for key setup, and add keys at [Account Settings -> SSH Keys](https://railway.com/account/ssh-keys).
+
+## Options for `exec`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `--id <ID>` | Sandbox ID to run in. Defaults to the active sandbox |
+| `--timeout <SECONDS>` | Per-command timeout in seconds |
+| `-- COMMAND` | Command to run, after `--`. Required |
+
+## Options for `destroy`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[ID]` | Sandbox ID to destroy. Defaults to the active sandbox |
+| `--id <ID>` | Sandbox ID to destroy, as an alternative to the positional argument |
+
+## Common options
+
+These flags apply to every subcommand.
+
+| Flag | Description |
+|------|-------------|
+| `-e, --environment <ENV>` | Environment name or ID. Defaults to the linked environment |
+| `-p, --project <PROJECT>` | Project ID. Defaults to the linked project |
+
+Without these flags, the CLI uses your linked project and environment. In an interactive shell with no link, the CLI prompts you to select a workspace, project, and environment. In a non-interactive shell with no link, pass both `--project` and `--environment`, or run [railway link](/cli/link) first.
+
+## Related
+
+- [Sandboxes](/sandboxes)
+- [railway ssh](/cli/ssh)
+- [railway link](/cli/link)

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -48,7 +48,7 @@ railway sandbox create
 railway sandbox create --idle-timeout-minutes 30
 ```
 
-Railway auto-destroys the sandbox after it sits idle for the given number of minutes.
+Railway auto-destroys the sandbox after it sits idle for the given number of minutes. The default is 30 minutes, and the value can range from 1 to 120.
 
 ### List sandboxes
 
@@ -104,7 +104,7 @@ railway sandbox destroy sbx_abc123
 
 | Flag | Description |
 |------|-------------|
-| `--idle-timeout-minutes <N>` | Minutes the sandbox can sit idle before it is auto-destroyed |
+| `--idle-timeout-minutes <N>` | Minutes the sandbox can sit idle before it is auto-destroyed (default 30, range 1 to 120) |
 | `--json` | Output the created sandbox as JSON |
 
 ## Options for `list`
@@ -128,7 +128,7 @@ Connecting over SSH requires an SSH key on your Railway account. See [railway ss
 | Argument or flag | Description |
 |------------------|-------------|
 | `--id <ID>` | Sandbox ID to run in. Defaults to the active sandbox |
-| `--timeout <SECONDS>` | Per-command timeout in seconds |
+| `--timeout <SECONDS>` | Per-command timeout in seconds (default 120, maximum 600) |
 | `-- COMMAND` | Command to run, after `--`. Required |
 
 ## Options for `destroy`

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -5,7 +5,7 @@ description: Manage ephemeral sandboxes.
 
 Create, connect to, run commands in, and destroy ephemeral [sandboxes](/sandboxes) in a Railway environment.
 
-<Banner variant="info">The `sandbox` command requires sandboxes to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>.</Banner>
+<Banner variant="info">The `sandbox` command requires sandboxes to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
 
 ## Usage
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -167,6 +167,10 @@ const sandbox = await Sandbox.create({
 
 `idleTimeoutMinutes` sets how long a sandbox can sit idle before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses the default of 30 minutes. The value can range from 1 to 120 minutes, and the timer resets each time you run a command.
 
+### Examples
+
+For complete, runnable code, see the <a href="https://github.com/railwayapp/railway-ts-sdk/tree/main/examples/sandboxes" target="_blank">sandbox examples</a> in the SDK repository.
+
 ## CLI
 
 The Railway CLI can create, connect to, run commands in, and destroy sandboxes. See [railway sandbox](/cli/sandbox) for all subcommands and options.

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -1,0 +1,174 @@
+---
+title: Sandboxes
+description: Provision ephemeral, isolated Linux environments on Railway. Create them from the dashboard, CLI, or TypeScript SDK, run commands in them, and tear them down when done.
+---
+
+<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+Sandboxes are short-lived Linux environments you can provision on demand, run commands in, and destroy.
+
+Each sandbox is scoped to a Railway [environment](/environments) and runs on Railway's VM primitive, giving you isolated, on-demand compute for anything you'd run on a VM.
+
+## How it works
+
+Each sandbox is a programmatically controllable, fully isolated container. You create one, run commands against it with `exec`, and destroy it when you're done. Sandboxes start from a clean Debian base and are ready to `exec` against once `Sandbox.create()` resolves.
+
+## Dashboard
+
+Navigate to the **Sandboxes** tab in your project to view, create, and destroy sandboxes.
+
+You can SSH into a running sandbox directly without leaving the dashboard. If you have SSH keys configured in your Railway account, you can also copy the SSH command from the dashboard to use in your terminal of choice.
+
+To add SSH keys to your account, go to [Account Settings -> SSH Keys](https://railway.com/account/ssh-keys).
+
+## TypeScript SDK
+
+The SDK is the primary interface for working with sandboxes programmatically.
+
+### Installation
+
+```bash
+bun add railway
+```
+
+Or scaffold a new project with the SDK preconfigured:
+
+```bash
+bun create railway@latest
+```
+
+### Quick start
+
+```ts
+import { Sandbox } from "railway";
+
+// reads RAILWAY_API_TOKEN + RAILWAY_ENVIRONMENT_ID from the environment
+const sandbox = await Sandbox.create();
+
+const { stdout } = await sandbox.exec("echo hello");
+console.log(stdout);
+
+await sandbox.destroy();
+```
+
+`Sandbox.create()` resolves once the sandbox is `RUNNING` and ready to accept commands.
+
+### Creating a sandbox
+
+Four static methods cover every way to get a `Sandbox`:
+
+```ts
+// Provision a new sandbox
+const sandbox = await Sandbox.create();
+
+// Provision from a template (see Templates below)
+const sandbox = await Sandbox.create(template);
+
+// Reattach to an existing sandbox by id
+const sandbox = await Sandbox.connect("sbx_abc123");
+// throws `SandboxNotFoundError` if the sandbox does not exist in the environment.
+
+// List all sandboxes in the environment
+const sandboxes = await Sandbox.list();
+```
+
+### Running commands
+
+`exec` runs a command to completion and returns its result. It doesn't throw on a non-zero exit code. Inspect `exitCode` instead.
+
+```ts
+const result = await sandbox.exec("npm run build", { timeoutSec: 120 });
+
+result.exitCode;  // number
+result.stdout;    // string
+result.stderr;    // string
+result.truncated; // true if output exceeded the capture limit
+result.timedOut;  // true if the command hit timeoutSec
+```
+
+### Destroying a sandbox
+
+Use `destroy()` for explicit teardown, or `await using` to destroy automatically when the scope exits, even on throw.
+
+```ts
+// Explicit
+await sandbox.destroy();
+
+// Automatic via await using (requires Node.js 22+)
+await using sandbox = await Sandbox.create();
+await sandbox.exec("pytest");
+// destroyed automatically here
+```
+
+### Reconnecting
+
+A sandbox outlives the process that created it. Reattaching by id is useful in serverless and multi-step workflows.
+
+```ts
+const sandbox = await Sandbox.connect("sbx_abc123");
+await sandbox.exec("cat /tmp/state.json");
+```
+
+Call `sandbox.refresh()` to re-read the sandbox and update its `status` and other fields in place.
+
+### Templates
+
+A template is a reusable base: an ordered list of build steps that Railway builds once, content-addresses, and caches. Creating a sandbox from a template forks that cached build instead of starting from scratch.
+
+This lets you start a sandbox from a pre-built base, saving spin-up time.
+
+```ts
+const base = Sandbox.template()
+  .withPackages("ffmpeg", "git")
+  .withEnv({ NODE_ENV: "production" })
+  .workdir("/app")
+  .run("npm install");
+
+const sandbox = await Sandbox.create(base);
+await sandbox.exec("ffmpeg -version");
+```
+
+`SandboxTemplate` is immutable. Every method returns a new template, so a base can branch into variants without mutation.
+
+The template builder exposes these methods:
+
+| Method | Effect |
+|--------|--------|
+| `.run(command)` | Add a raw build step |
+| `.withPackages(...names)` | Install Debian packages via `apt-get` |
+| `.withEnv({ KEY: "value" })` | Set environment variables for subsequent steps |
+| `.workdir(dir)` | Set the working directory for subsequent steps |
+| `.build(options?)` | Build and cache the template ahead of time |
+
+`Sandbox.create(template)` builds the template automatically. Call `.build()` explicitly only to pre-warm the cache before the first `create`.
+
+### Configuration
+
+`token` and `environmentId` each resolve in order: an explicit option in the configuration object, then an environment variable.
+
+| Option | Environment variable |
+|--------|---------------------|
+| `token` | `RAILWAY_API_TOKEN` |
+| `environmentId` | `RAILWAY_ENVIRONMENT_ID` |
+
+Pass explicit values to override:
+
+```ts
+const sandbox = await Sandbox.create({
+  token: process.env.MY_TOKEN,
+  environmentId: process.env.MY_ENV_ID,
+  idleTimeoutMinutes: 30,
+});
+```
+
+`idleTimeoutMinutes` sets how long a sandbox can sit idle before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses Railway's default idle timeout.
+
+The SDK is safe to import in the browser and edge runtimes. Environment variables are only read where a runtime exposes them. Provide credentials explicitly in those contexts.
+
+## CLI
+
+The Railway CLI can create, connect to, run commands in, and destroy sandboxes. See [railway sandbox](/cli/sandbox) for all subcommands and options.
+
+## Caveats
+
+File access (`sandbox.files.*`), port exposure (`sandbox.expose()`), streaming `exec`, and background processes are not yet available.

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -7,11 +7,11 @@ description: Provision ephemeral, isolated Linux environments on Railway. Create
 
 Sandboxes are short-lived Linux environments you can provision on demand, run commands in, and destroy.
 
-Each sandbox is scoped to a Railway [environment](/environments) and runs on Railway's VM primitive, giving you isolated, on-demand compute for anything you'd run on a VM.
+Each sandbox is scoped to a Railway [environment](/environments) and runs on Railway's virtual machine primitive, giving you isolated, on-demand compute for anything you'd run on a VM.
 
 ## How it works
 
-Each sandbox is a programmatically controllable, fully isolated container. You create one, run commands against it with `exec`, and destroy it when you're done. Sandboxes start from a clean Debian base and are ready to `exec` against once `Sandbox.create()` resolves.
+Each sandbox is a programmatically controllable, fully isolated virtual machine. You create one, run commands against it with `exec`, and destroy it when you're done. Sandboxes start from a clean Debian base and are ready to `exec` against once `Sandbox.create()` resolves.
 
 ## Dashboard
 
@@ -85,6 +85,8 @@ result.stderr;    // string
 result.truncated; // true if output exceeded the capture limit
 result.timedOut;  // true if the command hit timeoutSec
 ```
+
+Without `timeoutSec`, a command times out after 2 minutes, and the maximum is 10 minutes. If `stdout` or `stderr` exceeds the [capture limit](#timeouts-and-output), the result is truncated and `result.truncated` is `true`.
 
 ### Destroying a sandbox
 
@@ -161,13 +163,51 @@ const sandbox = await Sandbox.create({
 });
 ```
 
-`idleTimeoutMinutes` sets how long a sandbox can sit idle before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses Railway's default idle timeout.
+`idleTimeoutMinutes` sets how long a sandbox can sit idle before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses the default of 30 minutes. The value can range from 1 to 120 minutes, and the timer resets each time you run a command.
 
 The SDK is safe to import in the browser and edge runtimes. Environment variables are only read where a runtime exposes them. Provide credentials explicitly in those contexts.
 
 ## CLI
 
 The Railway CLI can create, connect to, run commands in, and destroy sandboxes. See [railway sandbox](/cli/sandbox) for all subcommands and options.
+
+## Sandbox limits per environment
+
+Each environment can run a fixed number of sandboxes at once, based on your workspace's [plan](/pricing/plans). The cap applies per environment, not per project or workspace.
+
+| Plan | Sandboxes per environment |
+|------|---------------------------|
+| Trial | 10 |
+| Free | 10 |
+| Hobby | 50 |
+| Pro | 100 |
+
+Only sandboxes that are pending or running count toward the cap. Destroyed sandboxes don't. Creating a sandbox past the cap fails with an error.
+
+## Resource limits
+
+Each sandbox runs with 1 vCPU and 768 MB of memory. These are ceilings: the workload uses anywhere from zero up to them on demand, and you're billed for actual usage. A sandbox's resources are fixed for its lifetime. To run with different resources, create a new sandbox.
+
+## Timeouts and output
+
+A sandbox enforces two timeouts: how long a single command can run, and how long the sandbox can sit idle before Railway destroys it.
+
+| Limit | Default | Maximum |
+|-------|---------|---------|
+| Idle timeout | 30 minutes | 120 minutes |
+| Command timeout | 2 minutes | 10 minutes |
+
+The idle timeout can be set as low as 1 minute and resets each time you run a command. Set it with `idleTimeoutMinutes` in the SDK or `--idle-timeout-minutes` in the CLI. Set the per-command timeout with `timeoutSec` in the SDK or `--timeout` in the CLI.
+
+Each command captures up to 16,000 bytes each of `stdout` and `stderr`. Output beyond that is truncated.
+
+## Networking
+
+A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox. To run commands or move data in and out of a sandbox, use `exec` or SSH.
+
+## Pricing
+
+Sandboxes don't have a separate charge. A sandbox consumes the same metered resources as a service (CPU, memory, and network egress), billed at the standard [resource usage rates](/pricing/plans#resource-usage-pricing). You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down.
 
 ## Caveats
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -23,7 +23,7 @@ To add SSH keys to your account, go to [Account Settings -> SSH Keys](https://ra
 
 ## TypeScript SDK
 
-The SDK is the primary interface for working with sandboxes programmatically.
+The SDK is the primary interface for working with sandboxes programmatically. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>.
 
 ### Installation
 
@@ -164,8 +164,6 @@ const sandbox = await Sandbox.create({
 ```
 
 `idleTimeoutMinutes` sets how long a sandbox can sit idle before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses the default of 30 minutes. The value can range from 1 to 120 minutes, and the timer resets each time you run a command.
-
-The SDK is safe to import in the browser and edge runtimes. Environment variables are only read where a runtime exposes them. Provide credentials explicitly in those contexts.
 
 ## CLI
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -65,7 +65,7 @@ const sandbox = await Sandbox.create();
 const sandbox = await Sandbox.create(template);
 
 // Reattach to an existing sandbox by id
-const sandbox = await Sandbox.connect("sbx_abc123");
+const sandbox = await Sandbox.connect(sandbox.id);
 // throws `SandboxNotFoundError` if the sandbox does not exist in the environment.
 
 // List all sandboxes in the environment
@@ -107,7 +107,7 @@ await sandbox.exec("pytest");
 A sandbox outlives the process that created it. Reattaching by id is useful in serverless and multi-step workflows.
 
 ```ts
-const sandbox = await Sandbox.connect("sbx_abc123");
+const sandbox = await Sandbox.connect(idString);
 await sandbox.exec("cat /tmp/state.json");
 ```
 
@@ -195,11 +195,9 @@ A sandbox enforces two timeouts: how long a single command can run, and how long
 
 The idle timeout can be set as low as 1 minute and resets each time you run a command. Set it with `idleTimeoutMinutes` in the SDK or `--idle-timeout-minutes` in the CLI. Set the per-command timeout with `timeoutSec` in the SDK or `--timeout` in the CLI.
 
-Each command captures up to 16,000 bytes each of `stdout` and `stderr`. Output beyond that is truncated.
-
 ## Networking
 
-A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox. 
+A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox.
 
 To run commands or move data in and out of a sandbox, use `exec` or SSH.
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -184,10 +184,6 @@ Each environment can run a fixed number of sandboxes at once, based on your work
 
 Only sandboxes that are pending or running count toward the cap. Destroyed sandboxes don't. Creating a sandbox past the cap fails with an error.
 
-## Resource limits
-
-Each sandbox runs with 1 vCPU and 768 MB of memory. These are ceilings: the workload uses anywhere from zero up to them on demand, and you're billed for actual usage. A sandbox's resources are fixed for its lifetime. To run with different resources, create a new sandbox.
-
 ## Timeouts and output
 
 A sandbox enforces two timeouts: how long a single command can run, and how long the sandbox can sit idle before Railway destroys it.
@@ -203,12 +199,10 @@ Each command captures up to 16,000 bytes each of `stdout` and `stderr`. Output b
 
 ## Networking
 
-A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox. To run commands or move data in and out of a sandbox, use `exec` or SSH.
+A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox. 
+
+To run commands or move data in and out of a sandbox, use `exec` or SSH.
 
 ## Pricing
 
 Sandboxes don't have a separate charge. A sandbox consumes the same metered resources as a service (CPU, memory, and network egress), billed at the standard [resource usage rates](/pricing/plans#resource-usage-pricing). You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down.
-
-## Caveats
-
-File access (`sandbox.files.*`), port exposure (`sandbox.expose()`), streaming `exec`, and background processes are not yet available.

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -25,6 +25,8 @@ To add SSH keys to your account, go to [Account Settings -> SSH Keys](https://ra
 
 The SDK is the primary interface for working with sandboxes programmatically. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>.
 
+**Note:** The SDK is under active development while sandboxes are in Priority Boarding, and its API may change in breaking ways between releases.
+
 ### Installation
 
 ```bash
@@ -179,6 +181,8 @@ Each environment can run a fixed number of sandboxes at once, based on your work
 | Free | 10 |
 | Hobby | 50 |
 | Pro | 100 |
+
+Enterprise workspaces share the Pro cap of 100 sandboxes per environment.
 
 Only sandboxes that are pending or running count toward the cap. Destroyed sandboxes don't. Creating a sandbox past the cap fails with an error.
 

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -257,6 +257,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("redeploy"),
       makeCliCommand("restart"),
       makeCliCommand("run"),
+      makeCliCommand("sandbox"),
       makeCliCommand("scale"),
       makeCliCommand("service"),
       makeCliCommand("setup"),
@@ -295,6 +296,7 @@ export const sidebarContent: ISidebarContent = [
       },
       makePage("Cron jobs", undefined, "/cron-jobs"),
       makePage("Functions", undefined, "/functions"),
+      makePage("Sandboxes", undefined, "/sandboxes"),
       {
         subTitle: makePage("Config as code", undefined, "/config-as-code"),
         pages: [makePage("Reference", "config-as-code")],


### PR DESCRIPTION
## Summary of changes 

Adding sandbox documentation while we put it through priority boarding. This adds in a dedicated page for sandbox documentation and pushes in some basic CLI documentation as well. 
