### PR TITLE
docs(sandboxes): forking, private networking, templates, and create variables

### DIFF
--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -231,7 +231,7 @@ railway sandbox create --variable NODE_ENV=production,PORT=8080
 
 A comma splits the value only when every segment is its own `KEY=VALUE` pair, so values that contain commas stay intact.
 
-Load variables from a `.env` file with `--env-file`, which is also repeatable. When the same key is set in both places, `--variable` flags win.
+Load variables from a `.env` file with `--env-file`, which is also repeatable. When the same key is set in both places, `--variable` flags take precedence.
 
 ```bash
 railway sandbox create --env-file .env

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -23,6 +23,8 @@ railway sandbox <COMMAND> [OPTIONS]
 | Subcommand | Aliases | Description |
 |------------|---------|-------------|
 | `create` | `new` | Create a sandbox and set it as the active sandbox |
+| `fork` | | Fork a sandbox into a new one and set it as the active sandbox |
+| `template` | | Build and manage sandbox templates |
 | `list` | `ls` | List sandboxes in the environment |
 | `ssh` | `connect` | Connect to a sandbox over SSH |
 | `exec` | | Run a single command inside a sandbox |
@@ -30,9 +32,9 @@ railway sandbox <COMMAND> [OPTIONS]
 
 ## Active sandbox
 
-`create` sets the new sandbox as the active sandbox. The `ssh`, `exec`, and `destroy` commands act on the active sandbox when you don't pass an ID, so a typical session needs no IDs at all. Running `ssh` or `exec` against a specific sandbox makes that one active.
+`create` and `fork` set the new sandbox as the active sandbox. The `ssh`, `exec`, `fork`, and `destroy` commands act on the active sandbox when you don't pass an ID, so a typical session needs no IDs at all. Running `ssh` or `exec` against a specific sandbox makes that one active.
 
-Pass `--id <ID>` (or a positional ID for `destroy`) to target a specific sandbox instead. `list` marks the active sandbox with an asterisk.
+Pass `--id <ID>` (or a positional ID for `fork` and `destroy`) to target a specific sandbox instead. `list` marks the active sandbox with an asterisk.
 
 ## Examples
 
@@ -49,6 +51,26 @@ railway sandbox create --idle-timeout-minutes 30
 ```
 
 Railway auto-destroys the sandbox after it sits [idle](/sandboxes#idle-timeout) for the given number of minutes. The default is 30 minutes, and the value can range from 1 to 120.
+
+### Create a sandbox on the private network
+
+```bash
+railway sandbox create --private-network
+```
+
+The sandbox joins the environment's private network and can reach your other services. See [Private networking](#private-networking).
+
+### Fork a sandbox
+
+```bash
+railway sandbox fork
+```
+
+This forks the active sandbox. The new sandbox becomes active, so a following `ssh` or `exec` targets the fork. Pass an ID to fork a specific sandbox.
+
+```bash
+railway sandbox fork sbx_abc123
+```
 
 ### List sandboxes
 
@@ -105,7 +127,25 @@ railway sandbox destroy sbx_abc123
 | Flag | Description |
 |------|-------------|
 | `--idle-timeout-minutes <N>` | Minutes the sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed (default 30, range 1 to 120) |
+| `--variable <KEY=VALUE>` | Set a variable on the sandbox. Repeatable and comma-separable. See [Variables](#variables) |
+| `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
+| `--template <NAME_OR_ID>` | Create from a built template, by local name or template ID. See [Templates](#templates) |
+| `--private-network` | Join the environment's private network instead of the default isolated mode |
 | `--json` | Output the created sandbox as JSON |
+
+## Options for `fork`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `[ID]` | Source sandbox ID to fork. Defaults to the active sandbox |
+| `--id <ID>` | Source sandbox ID, as an alternative to the positional argument |
+| `--idle-timeout-minutes <N>` | Minutes the new sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed (default 30, range 1 to 120) |
+| `--variable <KEY=VALUE>` | Set a variable on the fork. Repeatable and comma-separable. The fork doesn't inherit the source's variables |
+| `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
+| `--private-network` | Join the environment's private network. The fork doesn't inherit the source's network mode |
+| `--json` | Output the created sandbox as JSON |
+
+The source sandbox must be running. The fork clones its filesystem into a new sandbox in the same environment and boots fresh, so files are preserved but running processes are not.
 
 ## Options for `list`
 
@@ -137,6 +177,79 @@ Connecting over SSH requires an SSH key on your Railway account. See [railway ss
 |------------------|-------------|
 | `[ID]` | Sandbox ID to destroy. Defaults to the active sandbox |
 | `--id <ID>` | Sandbox ID to destroy, as an alternative to the positional argument |
+
+## Templates
+
+A template is a pre-built filesystem snapshot you can boot sandboxes from, which saves setup time. You build one from an ordered list of shell instructions. Railway content-addresses each template by the hash of its instructions and caches the snapshot for about 7 days, so rebuilding an identical template is an instant cache hit.
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `template build` | `create`, `new` | Build a template from shell instructions |
+| `template status` | | Show the build status of a template |
+| `template list` | `ls` | List templates this CLI has built |
+
+The CLI stores the templates it builds locally, so you can reference one by a name you assign with `--name` or by its template ID.
+
+### Build a template
+
+```bash
+railway sandbox template build --name dev -c "npm i -g pnpm" --wait
+```
+
+Pass `-c` once per build step. Steps run in order, and each must exit 0 within 10 minutes. The `--wait` flag polls until the build reports `READY` or `FAILED`.
+
+### Create a sandbox from a template
+
+```bash
+railway sandbox create --template dev
+```
+
+Reference the template by the local name you gave it or by its template ID.
+
+### Options for `template build`
+
+| Flag | Description |
+|------|-------------|
+| `-c, --command <SHELL_COMMAND>` | Shell instruction to run while building. Repeatable, runs in order. Required |
+| `--name <NAME>` | Local name for the template, usable with `create --template <NAME>` |
+| `--base-image-digest <DIGEST>` | Base image digest to build on. Defaults to the standard sandbox image |
+| `--wait` | Wait for the build to finish, polling until `READY` or `FAILED` |
+| `--json` | Output as JSON |
+
+`template status <ID_OR_NAME>` and `template list` each accept `--json`.
+
+## Variables
+
+`create` and `fork` can seed environment variables into a sandbox. They're available to every command, over both `exec` and SSH.
+
+Set variables inline with `--variable`. The flag is repeatable and comma-separable.
+
+```bash
+railway sandbox create --variable NODE_ENV=production --variable PORT=8080
+railway sandbox create --variable NODE_ENV=production,PORT=8080
+```
+
+A comma splits the value only when every segment is its own `KEY=VALUE` pair, so values that contain commas stay intact.
+
+Load variables from a `.env` file with `--env-file`, which is also repeatable. When the same key is set in both places, `--variable` flags win.
+
+```bash
+railway sandbox create --env-file .env
+```
+
+Values can reference other Railway variables, resolved server-side when the sandbox is created. Use the bare `Service.VARIABLE` form or the full `${{Service.VARIABLE}}` form.
+
+```bash
+railway sandbox create \
+  --variable DATABASE_URL=Postgres.DATABASE_URL \
+  --private-network
+```
+
+Resolving a reference to a service's internal address requires the private network, so pair internal-URL references with `--private-network`.
+
+## Private networking
+
+By default a sandbox is isolated: it has outbound internet access but can't reach other services in your environment over private networking. Pass `--private-network` to `create` or `fork` to place the sandbox on the environment's private network, so it can reach services like `postgres.railway.internal` and they can reach it. See [Networking](/sandboxes#networking) for the full description of both modes.
 
 ## Common options
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -57,7 +57,7 @@ await sandbox.destroy();
 
 ### Creating a sandbox
 
-Four static methods cover every way to get a `Sandbox`:
+These static methods cover every way to get a `Sandbox`:
 
 ```ts
 // Provision a new sandbox
@@ -65,6 +65,9 @@ const sandbox = await Sandbox.create();
 
 // Provision from a template (see Templates below)
 const sandbox = await Sandbox.create(template);
+
+// Fork a running sandbox (see Forking below)
+const sandbox = await Sandbox.create(source);
 
 // Reattach to an existing sandbox by id
 const sandbox = await Sandbox.connect(sandbox.id);
@@ -146,6 +149,20 @@ The template builder exposes these methods:
 
 `Sandbox.create(template)` builds the template automatically. Call `.build()` explicitly only to pre-warm the cache before the first `create`.
 
+### Forking
+
+Forking clones a running sandbox's filesystem into a new, independent sandbox. The fork boots fresh from a copy of the source's disk, so files are preserved but running processes and memory are not. Use it to branch a sandbox after expensive setup, for example installing dependencies once and forking per task.
+
+```ts
+const base = await Sandbox.create();
+await base.exec("npm install");
+
+const fork = await base.fork();
+await fork.exec("npm test"); // sees the installed dependencies, isolated from base
+```
+
+`Sandbox.create(source)` does the same thing as `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes` or `networkIsolation` to set them on the fork, which doesn't inherit them from the source.
+
 ### Configuration
 
 `token` and `environmentId` each resolve in order: an explicit option in the configuration object, then an environment variable.
@@ -173,7 +190,7 @@ For complete, runnable code, see the <a href="https://github.com/railwayapp/rail
 
 ## CLI
 
-The Railway CLI can create, connect to, run commands in, and destroy sandboxes. See [railway sandbox](/cli/sandbox) for all subcommands and options.
+The Railway CLI can create, fork, connect to, run commands in, and destroy sandboxes, build templates, and seed variables at create time. See [railway sandbox](/cli/sandbox) for all subcommands and options.
 
 ## Sandbox limits per environment
 
@@ -211,9 +228,25 @@ Set the idle timeout with `idleTimeoutMinutes` in the SDK or `--idle-timeout-min
 
 ## Networking
 
-A sandbox has outbound internet access but runs isolated from your project's [private network](/private-networking). It can't reach your project's other services over private networking, and those services can't reach the sandbox.
+Every sandbox has outbound internet access through a NAT gateway. Whether it can reach the rest of your environment over the [private network](/private-networking) depends on its network isolation mode, set when you create or fork it.
 
-To run commands or move data in and out of a sandbox, use `exec` or SSH.
+| Mode | Behavior |
+|------|----------|
+| `ISOLATED` | Default. Outbound internet access only. The sandbox can't reach other services in the environment over private networking, and they can't reach it. |
+| `PRIVATE` | The sandbox joins the environment's private network and keeps outbound internet access. It can reach other services over private networking, for example `postgres.railway.internal`, and they can reach it. |
+
+A sandbox is `ISOLATED` unless you opt into `PRIVATE`, so existing sandboxes are unaffected.
+
+In the SDK, pass `networkIsolation` when you create or fork a sandbox, and read it back from `sandbox.networkIsolation`:
+
+```ts
+const sandbox = await Sandbox.create({ networkIsolation: "PRIVATE" });
+sandbox.networkIsolation; // "ISOLATED" | "PRIVATE"
+```
+
+In the CLI, pass `--private-network` to `railway sandbox create` or `railway sandbox fork`.
+
+To run commands or move data in and out of a sandbox in either mode, use `exec` or SSH.
 
 ## Pricing
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -250,4 +250,4 @@ To run commands or move data in and out of a sandbox in either mode, use `exec` 
 
 ## Pricing
 
-Sandboxes are billed by resources (CPU, memory, network egress) consumed. You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down. Railway hasn't announced sandbox pricing yet.
+Sandboxes are billed by resources (CPU, memory, network egress) consumed. You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down. The actual price of sandboxes will be announced soon.

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -161,7 +161,7 @@ const fork = await base.fork();
 await fork.exec("npm test"); // sees the installed dependencies, isolated from base
 ```
 
-`Sandbox.create(source)` does the same thing as `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes` or `networkIsolation` to set them on the fork, which doesn't inherit them from the source.
+`Sandbox.create(source)` is equivalent to `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes` or `networkIsolation` to set them on the fork, which doesn't inherit them from the source.
 
 ### Configuration
 
@@ -250,4 +250,4 @@ To run commands or move data in and out of a sandbox in either mode, use `exec` 
 
 ## Pricing
 
-Sandboxes are billed by resources (CPU, memory, network egress) consumed. You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down. The actual price of sandboxes will be announced soon.
+Sandboxes are billed by resources (CPU, memory, network egress) consumed. You pay only for what a sandbox uses while it runs, so destroying sandboxes when you're done, or setting a short idle timeout, keeps costs down. Railway hasn't announced sandbox pricing yet.


### PR DESCRIPTION
## What

Documents the sandbox capabilities that landed in the last day, across the platform, the CLI (`railwayapp/cli` #933), and the TypeScript SDK. Surfaces only the user-facing changes; internal work (tombstoning, slow-activity heartbeating) is intentionally omitted.

### `sandboxes.md`
- **Networking** rewritten from "always isolated" to the two isolation modes: `ISOLATED` (default) and `PRIVATE`, with SDK and CLI snippets.
- **Forking** SDK subsection (`source.fork()` / `Sandbox.create(source)`), plus a line in the create-methods list.
- CLI blurb updated to mention fork, templates, and variables.

### `cli/sandbox.md`
- New `fork` and `template` subcommands (examples + option tables).
- New **Templates**, **Variables**, and **Private networking** sections.
- `--variable`, `--env-file`, `--template`, `--private-network` added to `create`; full **Options for `fork`**.

## Notes

- Runtime variables (`--variable` / `--env-file`) are documented under the **CLI only**. The SDK's `create`/`fork` options expose `idleTimeoutMinutes` and `networkIsolation` but not runtime variables, so they aren't claimed for the SDK.
- Reconciled with the idle-timeout definition that landed on main (#1181): the new fork option reuses the `/sandboxes#idle-timeout` link for consistency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)