### PR TITLE
chore: ignore all of .claude and .agents except skills

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,8 @@ public/robots.txt
 /.envrc
 /.direnv/
 .turbo
-.claude/settings.local.json
+.claude/*
+!.claude/skills
 .cursor/
+.agents/*
+!.agents/skills


### PR DESCRIPTION
## Summary of changes

Follow-up to the skill-sharing change. The `.gitignore` only kept `.claude/settings.local.json` out of git, leaving the rest of `.claude/` (and all of `.agents/`) tracked. This switches to an **ignore-everything-except-skills** policy: only `.claude/skills/` and the `.agents/skills` symlink are tracked; anything else either tool writes under those dirs stays local.

The pattern matters — `.claude/` (trailing slash) excludes the directory itself so git never descends and a negation can't re-include anything. Using `/*` excludes only the contents, so `!.claude/skills` re-includes the folder. The `.agents/skills` negation has no trailing slash because it's a symlink, not a real directory.

```
.claude/*
!.claude/skills
.cursor/
.agents/*
!.agents/skills
```

Verified with `git check-ignore`: the skill + symlink stay tracked, any other path under `.claude/`/`.agents/` is ignored.

## Docs

No docs impact — tooling/config only.