### PR TITLE
skills(docs-writing): verify docs against upstream source

### DIFF
--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -129,6 +129,9 @@ Follow these four phases for every documentation task.
 - Read the existing page (if editing) and any related pages that link to it.
 - Check `CONTRIBUTING.md` for frontmatter format and repo structure.
 - Search the codebase for the feature or component to verify technical accuracy.
+- Identify the source repository that implements the feature and, if the change
+  makes any technical claim, clone it to verify against the real code (see
+  [Verifying against source code](#verifying-against-source-code)).
 - For new pages, determine the content type (see content types above).
 - Check `src/data/sidebar.ts` if the page needs a navigation entry.
 
@@ -156,7 +159,9 @@ Follow these four phases for every documentation task.
 
 ### Phase 4: Verify
 
-- Confirm technical accuracy against the codebase and product behavior.
+- Confirm technical accuracy against the codebase and product behavior, and
+  against the upstream source repository when one exists (see
+  [Verifying against source code](#verifying-against-source-code)).
 - Verify all internal links resolve (use relative paths like `/variables`).
 - Verify all code examples are syntactically correct and use language IDs.
 - Check that frontmatter matches the format in `CONTRIBUTING.md`.
@@ -165,6 +170,21 @@ Follow these four phases for every documentation task.
 - Run the formatter if one is configured for the project.
 - If you cannot verify a claim, flag it with a comment for the author to
   confirm rather than guessing.
+
+## Verifying against source code
+
+Documentation drifts from the code it describes. For any change that makes a
+technical claim — command names, flags, configuration keys, default values, API
+fields, SDK methods, environment variable names, behavior — verify the docs
+against the real implementation in Railway's source before finishing. Treat this
+as a default step, not an optional one. Skip it only when a change is purely
+editorial (voice, typos, links, formatting) with no technical claims.
+
+When verification applies, follow
+[verifying-against-source.md](verifying-against-source.md). It maps each doc area
+to its public `railwayapp` repository, shows how to clone the repo into `/tmp`
+and check claims against the code, and covers the rules for referencing private
+repositories without leaking anything internal.
 
 ## Formatting
 

--- a/.claude/skills/docs-writing/SKILL.md
+++ b/.claude/skills/docs-writing/SKILL.md
@@ -182,9 +182,8 @@ editorial (voice, typos, links, formatting) with no technical claims.
 
 When verification applies, follow
 [verifying-against-source.md](verifying-against-source.md). It maps each doc area
-to its public `railwayapp` repository, shows how to clone the repo into `/tmp`
-and check claims against the code, and covers the rules for referencing private
-repositories without leaking anything internal.
+to its public `railwayapp` repository and shows how to clone the repo into
+`/tmp` and check claims against the code.
 
 ## Formatting
 

--- a/.claude/skills/docs-writing/verifying-against-source.md
+++ b/.claude/skills/docs-writing/verifying-against-source.md
@@ -1,0 +1,55 @@
+# Verifying against source code
+
+Load this when a documentation change makes a technical claim and you need to
+verify it against Railway's real implementation. See the gating rule in
+`SKILL.md` under "Verifying against source code" for when this applies.
+
+## Find the source repository
+
+Most documented behavior lives in a public `railwayapp` repository. Map the doc
+area to its repository:
+
+| Doc area | Repository |
+|----------|------------|
+| CLI (`content/docs/cli/`, `cli.md`) | `railwayapp/cli` (Rust) |
+| Builds and Railpack (`content/docs/builds/`, `build-deploy.md`) | `railwayapp/railpack` |
+| TypeScript SDK, sandbox SDK examples (`sandboxes.md`) | `railwayapp/railway-ts-sdk` |
+| MCP server and agent tooling (`content/docs/integrations/`, `agents.md`) | `railwayapp/railway-mcp-server` |
+| Agent skills (`agents.md`) | `railwayapp/railway-skills` |
+| Network diagnostics troubleshooting (`networking/`) | `railwayapp/netdiag` |
+
+For the public GraphQL API (`content/docs/integrations/api/`), there is no
+public source repo — verify against the live schema by introspecting
+`https://backboard.railway.com/graphql/v2`.
+
+If the change touches something not in this table, infer the most likely repo
+and confirm it exists before cloning:
+
+```bash
+gh repo view railwayapp/<name> --json visibility,description
+```
+
+If you can't find a public source for a claim, say so in your summary rather
+than guessing — flag the unverified claim for the author.
+
+## Clone and verify
+
+Shallow-clone the repo into `/tmp` (reuse the clone if it already exists from
+this session):
+
+```bash
+DEST=/tmp/railway-src/cli
+gh repo clone railwayapp/cli "$DEST" -- --depth=1 2>/dev/null \
+  || git -C "$DEST" pull --ff-only
+```
+
+Then check each technical claim in the docs against the code: command and
+subcommand names, flag spellings and defaults, config keys, API field names and
+types, SDK method signatures, environment variable names. Explore the repo to
+find where the behavior is defined (for example, the CLI defines its commands
+under `src/commands/`).
+
+Flag every mismatch — outdated flags, renamed commands, removed options, changed
+defaults — for the author. Only "fix" the docs to match the code when the
+correction is obvious and unambiguous; when intent is unclear, surface the
+discrepancy instead of silently rewriting.


### PR DESCRIPTION
## Summary of changes

Adds a verification step to the `docs-writing` skill so that, by default, doc changes making a technical claim are checked against the real implementation in Railway's public source repos before they ship — catching drift like renamed CLI commands, changed flags, or outdated config keys.

Follows the skill spec's progressive-disclosure pattern:

- `SKILL.md` carries only the gating rule (when verification applies, and the editorial-only exemption) plus Phase 1 / Phase 4 hooks. This stays in the always-loaded file.
- The how-to detail lives in a new one-level-deep reference file, `verifying-against-source.md`, loaded only when verification actually applies: a doc-area → public `railwayapp` repo mapping, the shallow-clone-into-`/tmp` procedure, and what claims to check.

The skill is shared across tools via the `.agents/skills` symlink, so this applies to Claude and Codex alike.

## Docs

Repo mapping covers CLI, Railpack, TS SDK, MCP server, skills, and netdiag; the public GraphQL API verifies against the live schema at `backboard.railway.com/graphql/v2`.