### PR TITLE
docs(cli): signup-aware railway up + login — new flags and first-run behavior

### DIFF
--- a/content/docs/cli/login.md
+++ b/content/docs/cli/login.md
@@ -5,6 +5,10 @@ description: Login to your Railway account.
 
 Login to your Railway account to authenticate the CLI.
 
+Sign-in and sign-up are the same flow: if you don't have a Railway account yet, `railway login` creates one on the fly — there is no separate signup command. New users accept the Terms of Service and Fair Use Policy as part of authorizing the CLI.
+
+**Tip:** if your goal is to deploy, you can skip this step entirely — [`railway up`](/cli/up) signs you in (or up) as part of the deploy.
+
 ## Usage
 
 ```bash
@@ -27,6 +31,8 @@ Opens your default browser to authenticate:
 railway login
 ```
 
+If no local browser can open — over SSH, in a container, or with no display — the CLI automatically falls back to the browserless device-code flow. `railway login` also works from non-interactive shells (such as an agent's terminal): it prints the sign-in URL and waits for you to finish in the browser.
+
 ### Browserless login
 
 Use this in environments without a browser (e.g., SSH sessions):
@@ -35,7 +41,7 @@ Use this in environments without a browser (e.g., SSH sessions):
 railway login --browserless
 ```
 
-This displays a pairing code and URL. Visit the URL and enter the code to authenticate.
+This displays a pairing code and URL. Visit the URL and enter the code on any device to authenticate.
 
 ## Environment variables
 
@@ -60,6 +66,7 @@ See [Tokens](/cli#tokens) for how to generate each token type.
 
 ## Related
 
+- [railway up](/cli/up) — deploy and sign up/in in one step
 - [railway logout](/cli/logout)
 - [railway whoami](/cli/whoami)
 - [Global Options](/cli/global-options)

--- a/content/docs/cli/up.md
+++ b/content/docs/cli/up.md
@@ -5,6 +5,8 @@ description: Upload and deploy project from the current directory.
 
 Upload and deploy your project from the current directory to Railway.
 
+If you aren't signed in, `railway up` signs you in first — or creates a Railway account on the fly — then continues with the deploy. If no project is linked, it can create a new project and service from the current directory. See [First run: sign up and deploy](#first-run-sign-up-and-deploy).
+
 **Note:** This command uploads and deploys your local code. To deploy pre-built templates (like databases), use [railway deploy](/cli/deploy) instead.
 
 ## Usage
@@ -17,15 +19,30 @@ railway up [PATH] [OPTIONS]
 
 | Flag | Description |
 |------|-------------|
-| `-d, --detach` | Don't attach to the log stream |
+| `-d, --detach, --no-wait` | Don't attach to the log stream — start the deploy and return once the build is queued |
+| `-y, --yes` | Accept all defaults — skip the sign-in confirmation and the project-name prompt when creating a new project |
+| `--new` | Create a new project + service from this directory and deploy it, even if one is already linked |
+| `--name <NAME>` | Name for a newly created project (defaults to the directory name) |
+| `-w, --workspace <WORKSPACE>` | Workspace to create a new project in (auto-selected when you only have one) |
 | `-c, --ci` | Stream build logs only, then exit (CI mode) |
+| `-m, --message <MESSAGE>` | Message to attach to the deployment |
 | `-s, --service <SERVICE>` | Service to deploy to (defaults to linked service) |
 | `-e, --environment <ENV>` | Environment to deploy to (defaults to linked environment) |
 | `-p, --project <ID>` | Project ID to deploy to (defaults to linked project) |
 | `--no-gitignore` | Don't ignore paths from .gitignore |
 | `--path-as-root` | Use the path argument as the archive root |
 | `--verbose` | Verbose output |
-| `--json` | Output logs in JSON format (implies CI mode) |
+| `--json` | Machine-readable output: build logs stream as NDJSON and the result is a single JSON object (implies CI mode) |
+
+## First run: sign up and deploy
+
+`railway up` is a complete on-ramp — you don't need to run `railway login` or create a project first.
+
+- **Not signed in?** It opens a browser to sign you in. New accounts are created on the fly through the same flow — there is no separate signup step. On SSH or headless machines it prints a device code to complete sign-in from another device.
+- **No project linked?** Right after a sign-up — or with `-y` — it creates a project and service from the current directory, links them, and deploys. If you're working interactively, it asks whether to create a new project, link an existing one, or cancel.
+- **Scripts and CI never create projects implicitly.** A non-interactive run with no linked project fails with a structured `NOT_AUTHENTICATED` / no-project error instead of prompting or silently creating — set up auth with a [token](/cli/login#environment-variables) and link explicitly for automation.
+
+When the deploy finishes, the CLI prints your project's dashboard link, and the public URL if the service has a domain (run [`railway domain`](/cli/domain) to add one — `up` never exposes a service publicly on its own).
 
 ## Examples
 
@@ -37,13 +54,33 @@ railway up
 
 Compresses and uploads the current directory, then streams build and deployment logs.
 
+### Sign up (or in) and deploy in one shot
+
+```bash
+railway up -y
+```
+
+Signs you in — creating an account if needed — then creates a project from the current directory and deploys it, skipping the surrounding prompts. This is the recommended form for agent-driven and scripted first runs.
+
+### Deploy to a fresh project
+
+```bash
+railway up --new --name my-api
+```
+
+Creates a brand-new project + service from the current directory and deploys it, even if the directory is already linked to another project.
+
 ### Deploy in detached mode
 
 ```bash
 railway up --detach
 ```
 
-Uploads the project and returns immediately without streaming logs.
+Uploads the project and returns once the build is **queued** — it does not wait for the deploy to finish. Poll for the outcome:
+
+```bash
+railway deployment list --json   # newest first; watch .status until SUCCESS / FAILED
+```
 
 ### Deploy to specific service
 
@@ -82,11 +119,16 @@ Use `--no-gitignore` to include files that would normally be ignored.
 
 ## Exit codes
 
-- `0` - Deployment succeeded
-- `1` - Deployment failed or crashed
+- `0` - Deployment reached `SUCCESS` (or, with `--detach`, the build was queued)
+- `1` - Deployment failed or crashed, or the run couldn't proceed (for example `NOT_AUTHENTICATED` in CI)
+
+When attached, the exit code comes from the deployment's terminal status — a failing deploy exits `1` even if the log stream ends early.
 
 ## Related
 
+- [railway login](/cli/login)
+- [railway deployment](/cli/deployment)
+- [railway domain](/cli/domain)
 - [railway redeploy](/cli/redeploy)
 - [railway logs](/cli/logs)
 - [Deploying with the CLI](/cli/deploying)


### PR DESCRIPTION
## Summary

Documents the agentic signup surface shipping in [railwayapp/cli#938](https://github.com/railwayapp/cli/pull/938) ([Agentic Up RFC](https://www.notion.so/railwayapp/3670e4c5456380bb8025e1185df1288f)):

**`railway up`**
- New flags: `-y/--yes`, `--new`, `--name`, `-w/--workspace`, the `--no-wait` alias for `--detach` — plus the previously undocumented `-m/--message`
- New "First run: sign up and deploy" section: unauthenticated `up` signs you in (accounts created on the fly; device code on SSH/headless); with no linked project it creates project + service (automatic after signup or with `-y`, create/link/cancel choice for interactive humans, structured fail-fast for scripts/CI — never an implicit create)
- Detached mode now documents that it returns at **QUEUED**, with a `railway deployment list --json` polling example
- Exit codes clarified: terminal-status driven

**`railway login`**
- Sign-in and sign-up are the same flow — no separate signup command; new users accept ToS/Fair Use while authorizing the CLI
- Automatic device-code fallback when no browser can open; works from non-interactive shells
- Cross-link to `railway up` as the deploy-first path

⚠️ **Merge after the cli#938 release ships** (tonight's merge train) so the docs don't describe unreleased flags.

🤖 Generated with [Claude Code](https://claude.com/claude-code)