### PR TITLE
docs(sandboxes): document sandbox checkpoints (CLI + SDK)

### DIFF
--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -25,6 +25,7 @@ railway sandbox <COMMAND> [OPTIONS]
 | `create` | `new` | Create a sandbox and set it as the active sandbox |
 | `fork` | | Fork a sandbox into a new one and set it as the active sandbox |
 | `template` | | Build and manage sandbox templates |
+| `checkpoint` | | Capture and manage sandbox checkpoints |
 | `list` | `ls` | List sandboxes in the environment |
 | `ssh` | `connect` | Connect to a sandbox over SSH |
 | `exec` | | Run a command inside a sandbox, with live streaming output |
@@ -33,7 +34,7 @@ railway sandbox <COMMAND> [OPTIONS]
 
 ## Active sandbox
 
-`create` and `fork` set the new sandbox as the active sandbox. The `ssh`, `exec`, `forward`, `fork`, and `destroy` commands act on the active sandbox when you don't pass an ID, so a typical session needs no IDs at all. Running `ssh` or `exec` against a specific sandbox makes that one active.
+`create` and `fork` set the new sandbox as the active sandbox. The `ssh`, `exec`, `forward`, `fork`, `checkpoint create`, and `destroy` commands act on the active sandbox when you don't pass an ID, so a typical session needs no IDs at all. Running `ssh` or `exec` against a specific sandbox makes that one active.
 
 Pass `--id <ID>` (or a positional ID for `fork` and `destroy`) to target a specific sandbox instead. `list` marks the active sandbox with an asterisk.
 
@@ -176,7 +177,8 @@ railway sandbox destroy sbx_abc123
 | `--idle-timeout-minutes <N>` | Minutes the sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed. The default and range depend on your plan |
 | `--variable <KEY=VALUE>` | Set a variable on the sandbox. Repeatable and comma-separable. See [Variables](#variables) |
 | `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
-| `--template <NAME_OR_ID>` | Create from a built template, by local name or template ID. See [Templates](#templates) |
+| `--template <NAME_OR_ID>` | Create from a built template, by local name or template ID. Can't be combined with `--checkpoint`. See [Templates](#templates) |
+| `--checkpoint <NAME>` | Create from a named checkpoint. Can't be combined with `--template`. See [Checkpoints](#checkpoints) |
 | `--private-network` | Join the environment's private network instead of the default isolated mode |
 | `--json` | Output the created sandbox as JSON |
 
@@ -281,6 +283,59 @@ Reference the template by the local name you gave it or by its template ID.
 | `--json` | Output as JSON |
 
 `template status <ID_OR_NAME>` and `template list` each accept `--json`.
+
+## Checkpoints
+
+A checkpoint is a named snapshot of a sandbox's disk, captured from a running sandbox. Capture one after expensive setup, then boot new sandboxes from it instead of repeating the setup. Where a [template](#templates) is built from a list of shell instructions and tracked in the CLI's local store, a checkpoint captures the live disk of an existing sandbox and is stored server-side in the environment, so it works from any machine.
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `checkpoint create` | `capture`, `save` | Capture a sandbox's disk into a named checkpoint |
+| `checkpoint list` | `ls` | List checkpoints in the environment |
+| `checkpoint rename` | | Rename a checkpoint |
+| `checkpoint delete` | `rm` | Delete a checkpoint and its disk snapshot |
+
+### Capture a checkpoint
+
+```bash
+railway sandbox checkpoint create after-deps
+```
+
+This captures the active sandbox. Pass `--id` to capture a specific one. The sandbox must be running, and it keeps running during the capture.
+
+Capture is synchronous, so the checkpoint is bootable as soon as the command returns. A sandbox with a lot of changed disk takes longer to capture. Reusing a name replaces that checkpoint with the new capture.
+
+### Create a sandbox from a checkpoint
+
+```bash
+railway sandbox create --checkpoint after-deps
+```
+
+The new sandbox boots fresh from a copy of the checkpointed disk, so files are preserved but running processes are not. You can destroy the source sandbox after capturing and still create from the checkpoint later.
+
+### List, rename, and delete checkpoints
+
+```bash
+railway sandbox checkpoint list
+railway sandbox checkpoint rename after-deps node-base
+railway sandbox checkpoint delete node-base
+```
+
+Renaming fails if a checkpoint with the new name already exists. After a rename, `create --checkpoint` works with the new name only. Deleting a checkpoint also deletes its underlying disk snapshot.
+
+### Options for `checkpoint create`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<NAME>` | Name for the checkpoint, usable with `create --checkpoint <NAME>`. 64-character hex names are reserved for template hashes. Required |
+| `--id <ID>` | Source sandbox ID. Defaults to the active sandbox |
+| `--json` | Output as JSON |
+
+`checkpoint list` and `checkpoint rename` each accept `--json`. `checkpoint rename` takes the current name and the new name as positional arguments, and `checkpoint delete` takes the name to delete.
+
+### Checkpoint limits
+
+The number of checkpoints an environment can hold matches its plan's sandbox limit, listed in [Sandbox limits](/sandboxes#sandbox-limits-per-environment). Checkpoints are counted separately from running sandboxes, and replacing a checkpoint by reusing its name doesn't increase the count.
 
 ## Variables
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -198,6 +198,39 @@ await fork.exec("npm test"); // sees the installed dependencies, isolated from b
 
 `Sandbox.create(source)` is equivalent to `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes` or `networkIsolation` to set them on the fork, which doesn't inherit them from the source.
 
+### Checkpoints
+
+A checkpoint is a named snapshot of a sandbox's disk, stored server-side in the environment. Capture one from a running sandbox after expensive setup, then boot new sandboxes from it by name, from any process with access to the environment.
+
+```ts
+const sandbox = await Sandbox.create();
+await sandbox.exec("npm install");
+
+await sandbox.checkpoint("after-deps");
+await sandbox.destroy();
+
+// Later, from any process with access to the environment:
+const fresh = await Sandbox.create("after-deps");
+await fresh.exec("npm test"); // sees the installed dependencies
+```
+
+`checkpoint(name)` requires a running sandbox, which keeps running during the capture. The call resolves once the checkpoint is bootable, so a sandbox with a lot of changed disk takes longer to capture. Reusing a name replaces that checkpoint with the new capture.
+
+Like a [fork](#forking), a sandbox created from a checkpoint boots fresh from a copy of the disk: files are preserved, running processes are not. Unlike a fork, the source sandbox doesn't need to exist anymore. Use a checkpoint for a base you reuse across sessions, and a fork to branch a live sandbox.
+
+Manage the environment's checkpoints with static methods:
+
+```ts
+const checkpoints = await Sandbox.checkpoints(); // newest first
+
+await Sandbox.renameCheckpoint("after-deps", "node-base");
+await Sandbox.deleteCheckpoint("node-base");
+```
+
+Each entry's `key` field holds the checkpoint name, and `renameCheckpoint` and `deleteCheckpoint` take that name. Deleting a checkpoint also deletes its underlying disk snapshot.
+
+The number of checkpoints an environment can hold matches its plan's sandbox limit, listed in [Sandbox limits](#sandbox-limits-per-environment). Checkpoints are counted separately from running sandboxes, and replacing a checkpoint by reusing its name doesn't increase the count.
+
 ### Configuration
 
 `token` and `environmentId` each resolve in order: an explicit option in the configuration object, then an environment variable.
@@ -225,7 +258,7 @@ For complete, runnable code, see the <a href="https://github.com/railwayapp/rail
 
 ## CLI
 
-The Railway CLI can create, fork, connect to, run commands in, forward ports into, and destroy sandboxes, build templates, and seed variables at create time. See [railway sandbox](/cli/sandbox) for all subcommands and options.
+The Railway CLI can create, fork, connect to, run commands in, forward ports into, and destroy sandboxes, build templates, capture and boot from checkpoints, and seed variables at create time. See [railway sandbox](/cli/sandbox) for all subcommands and options.
 
 ## Sandbox limits per environment
 


### PR DESCRIPTION
## What

Documents sandbox checkpoints, which shipped in CLI 5.12.0 (railwayapp/cli#967) and the TS SDK (railwayapp/railway-ts-sdk#20) but had no docs coverage.

### `content/docs/cli/sandbox.md`

- Add `checkpoint` to the subcommands table and `checkpoint create` to the active-sandbox note
- Add `--checkpoint <NAME>` to the `create` options table, noting it can't be combined with `--template`
- New **Checkpoints** section: capture semantics (running sandbox required, synchronous, name reuse replaces), create-from-checkpoint, list/rename/delete, options table, and the per-plan checkpoint limit

### `content/docs/sandboxes.md`

- New **Checkpoints** subsection in the TypeScript SDK section: `sandbox.checkpoint(name)`, `Sandbox.create("name")`, and the `checkpoints`/`renameCheckpoint`/`deleteCheckpoint` statics, with the checkpoint-vs-fork distinction
- Mention checkpoints in the CLI overview sentence

## Verification

Every technical claim was verified against the CLI source (`src/commands/sandbox.rs`), the TS SDK (`src/sandbox/*.ts`), and the backboard resolvers/controllers (`packages/backboard/src/controllers/sandboxes/checkpoint.ts`), including replace-on-name-reuse (backend upsert), rename collision errors, snapshot deletion on delete/replace, the 64-char hex name reservation, and the checkpoint limit sharing the plan's `maxRunningPerEnvironment` value while being counted separately.

Two upstream nits found during verification (not doc issues): the SDK docstring on `checkpoint()` still says the name must be unused (the backend replaces), and `renameCheckpoint`/`deleteCheckpoint` name their parameter `id` though it takes the checkpoint name (`SandboxCheckpoint.id` resolves to `key`).

## Notes

- Touches the same tables as #1191 (`sandbox forward` docs) and #1196 (bot-generated sandbox CLI refresh), so expect a trivial merge conflict with whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
