### PR TITLE
ci: scope GITHUB_TOKEN to contents:read in workflows (#5, #7)

### DIFF
--- a/.github/workflows/build-search-index.yml
+++ b/.github/workflows/build-search-index.yml
@@ -5,6 +5,9 @@ on:
   deployment_status:
     states: [success]
 
+permissions:
+  contents: read
+
 jobs:
   build-index:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   CI: true
 


### PR DESCRIPTION
## Summary of changes

Resolves CodeQL alerts [#5](https://github.com/railwayapp/docs/security/code-scanning/5) (`ci.yml`) and [#7](https://github.com/railwayapp/docs/security/code-scanning/7) (`build-search-index.yml`), both `actions/missing-workflow-permissions`.

Neither workflow declared an explicit `permissions` block, so `GITHUB_TOKEN` fell back to the repository's default permissions (read-write for repos created before Feb 2023), violating least privilege.

Both workflows only use the token to check out the repo — neither writes back to the repo or calls the GitHub API:

- **ci.yml** — checks out code and runs the build (pnpm install, content-collections, Next.js).
- **build-search-index.yml** — checks out code, then runs a Docker scraper that indexes into Meilisearch using repo secrets (not `GITHUB_TOKEN`).

So a top-level `permissions: contents: read` block on each is the minimal scope that keeps them working, matching CodeQL's suggested starting point.

## Docs

No documentation changes. CI/security hardening only.

```yaml
permissions:
  contents: read
```
