### PR TITLE
Use agents.railway.com for the agent install flow

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -28,7 +28,7 @@ When you ask your AI assistant something like "deploy to Railway" or "check my p
 To install the Railway CLI and configure Railway agent support in one step:
 
 ```bash
-bash <(curl -fsSL cli.new) --agents -y
+curl -fsSL agents.railway.com | sh
 ```
 
 This installs or reuses the Railway CLI, installs the `use-railway` skill, configures Railway MCP for detected tools, and checks Railway authentication. If `railway` is already on `PATH`, the installer reuses it without changing `PATH`. If you are not already logged in, run `railway login` after setup.

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -10,7 +10,7 @@ The Railway Command Line Interface (CLI) lets you interact with your Railway pro
 Install the Railway CLI with agent support configured in one step (macOS, Linux, Windows via WSL):
 
 ```bash
-bash <(curl -fsSL railway.com/install.sh) --agents -y
+curl -fsSL agents.railway.com | sh
 ```
 
 This installs the CLI to `~/.railway/bin` and runs [`railway setup agent`](/cli/setup) to configure detected agent tools.

--- a/src/components/agent-install-command.tsx
+++ b/src/components/agent-install-command.tsx
@@ -27,7 +27,8 @@ function buildCommand({ agents, mcp, autoAccept }: CommandInputs): string {
     return "curl -fsSL agents.railway.com | sh -s -- --remote";
   }
 
-  const base = "bash <(curl -fsSL railway.com/install.sh)";
+  // Standard CLI install path (non-agent) stays on cli.new.
+  const base = "bash <(curl -fsSL cli.new)";
   const yesFlag = autoAccept ? " -y" : "";
 
   // Explicit forms for combos the baked one-liner can't express (no auto-accept,

--- a/src/components/agent-install-command.tsx
+++ b/src/components/agent-install-command.tsx
@@ -17,11 +17,21 @@ interface CommandInputs {
 }
 
 function buildCommand({ agents, mcp, autoAccept }: CommandInputs): string {
-  const base = "bash <(curl -fsSL cli.new)";
+  // agents.railway.com bakes in `--agents -y` (CLI install + `railway setup
+  // agent`, which configures skills + local MCP + login) and forwards extra
+  // args after `-- `. Use it for the canonical full agent setup.
+  if (agents && autoAccept && mcp === "local") {
+    return "curl -fsSL agents.railway.com | sh";
+  }
+  if (agents && autoAccept && mcp === "remote") {
+    return "curl -fsSL agents.railway.com | sh -s -- --remote";
+  }
+
+  const base = "bash <(curl -fsSL railway.com/install.sh)";
   const yesFlag = autoAccept ? " -y" : "";
 
-  // Canonical one-liners: --agents runs `railway setup agent`, which configures
-  // skills + MCP + login. --remote routes that to the hosted MCP server.
+  // Explicit forms for combos the baked one-liner can't express (no auto-accept,
+  // or skills-only without MCP). --agents runs `railway setup agent`.
   if (agents && mcp === "local") {
     return `${base} --agents${yesFlag}`;
   }


### PR DESCRIPTION
## Summary

Updates the agent-setup install command across the agent-related docs to the clean `agents.railway.com` entrypoint:

```bash
curl -fsSL agents.railway.com | sh
```

### Changes
- **`src/components/agent-install-command.tsx`** — the shared install widget (rendered by both `/agents` and `/ai/mcp-server`). The canonical default (Agents + Local MCP + Auto-accept) now emits `curl -fsSL agents.railway.com | sh`; the remote variant forwards `--remote`. The fallback base is modernized from `cli.new` → `railway.com/install.sh` for combos the baked endpoint can't express (no auto-accept, or skills-only). All toggle combinations still produce valid commands.
- **`content/docs/ai/agent-skills.md`** — hardcoded agent install one-liner updated.
- **`content/docs/cli.md`** — the "with agent support" install variant updated (the plain, non-agent install left as-is).

`railway setup agent` references (already-installed path) are intentionally unchanged.

## Note
`agents.railway.com` resolves for readers once the entrypoint is live in prod: Cloudflare proxied record (done), the backboard `agents.` handler deployed (railwayapp/mono#31302, merged), and the cli `agents.sh` wrapper merged (railwayapp/cli#972).

🤖 Generated with [Claude Code](https://claude.com/claude-code)