### PR TITLE
docs(iac): update Infrastructure as Code docs for GA

### DIFF
--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -11,6 +11,8 @@ Railway Infrastructure as Code lets you define the services and resources in a R
 
 Use Railway IaC when you want one editable file for project-level configuration: services, databases, buckets, custom domains, environment variables, replicas, and canvas groups.
 
+> **TypeScript only (for now).** Railway IaC is authored in TypeScript via the [`railway`](https://www.npmjs.com/package/railway) SDK and a `.railway/railway.ts` file. TypeScript is currently the only supported language; other languages may follow.
+
 <PriorityBoardingBanner />
 
 ## IaC vs Config as Code
@@ -124,7 +126,7 @@ Railway configuration
 Using .railway/railway.ts
 Environment production
 
-Changes (1)
+Plan: 1 to add, 0 to change, 0 to destroy
   + Create service web
 
 Next
@@ -133,11 +135,25 @@ Next
 
 `plan` is safe. It only reads Railway state and prints the changes that would be applied.
 
+Variable values are **redacted** in plan output by default (shown as `«hidden»`), so secrets defined in `.railway/railway.ts` don't end up in your terminal or CI logs. The variable and whether it's changing are still shown. To print the actual values — useful when reviewing non-secret config — pass `--show-values`:
+
+```bash
+railway config plan --show-values
+```
+
 For machine-readable output:
 
 ```bash
 railway config plan --json
 ```
+
+To gate CI on drift, use `--detailed-exit-code`. The plan then exits `0` when nothing would change and `2` when changes are pending (errors stay non-zero):
+
+```bash
+railway config plan --detailed-exit-code
+```
+
+`--detailed-exit-code` is opt-in, so the default exit behavior is unchanged.
 
 ## Apply changes
 
@@ -155,7 +171,13 @@ To apply non-interactively:
 railway config apply --yes
 ```
 
-Destructive changes, such as deleting a service or variable, are marked before confirmation. Review those lines carefully before continuing.
+Destructive changes, such as deleting a service or variable, are marked before confirmation. Review those lines carefully before continuing. Non-interactively (with `--yes`, `--json`, or in an agent session), destructive changes additionally require `--confirm-destructive`, so a stray `--yes` cannot remove resources on its own:
+
+```bash
+railway config apply --yes --confirm-destructive
+```
+
+Apply is also protected against acting on a stale plan. Railway runs a fresh plan immediately before applying and commits against the exact environment state it just read. If the environment changed in between — for example a concurrent apply or a dashboard edit — the apply is rejected and you are asked to run `railway config plan` again. This prevents an apply from silently overwriting changes it never saw.
 
 ## Authoring `.railway/railway.ts`
 

--- a/content/docs/infrastructure-as-code/reference.md
+++ b/content/docs/infrastructure-as-code/reference.md
@@ -162,6 +162,22 @@ const web = service("web", {
 });
 ```
 
+Reference a shared variable defined on the environment using the context:
+
+```ts
+export default defineRailway((ctx) => {
+  const web = service("web", {
+    env: {
+      SENTRY_DSN: ctx.shared.SENTRY_DSN,
+    },
+  });
+
+  return project("my-project", { resources: [web] });
+});
+```
+
+`ctx.shared.NAME` compiles to `${{shared.NAME}}`. It points at an existing [shared variable](/variables) on the environment; it does not define or manage the shared variable itself.
+
 Preserve an existing Railway-managed value:
 
 ```ts


### PR DESCRIPTION
Brings the Infrastructure as Code docs in line with the GA-hardening work and adds the TypeScript-only note.

## Changes
- **TypeScript-only note** (overview intro) — IaC is authored in TypeScript via the `railway` SDK / `.railway/railway.ts`; TS is currently the only supported language.
- **Plan output** — updated example to the new `Plan: N to add, M to change, K to destroy` summary; documented that variable values are **redacted by default** (`«hidden»`) with `--show-values` to reveal them; documented `--detailed-exit-code` for CI drift-gating (opt-in, default behavior unchanged).
- **Apply** — documented `--confirm-destructive` (destructive changes can't be removed by a stray `--yes`) and **stale-plan rejection** (apply is refused if the environment changed since the plan).
- **Reference** — documented shared-variable references (`ctx.shared.NAME` → `${{shared.NAME}}`).

## Merge sequencing
Some of these describe behavior in PRs still in flight — please merge in step with them:
- Stale-plan rejection — **already live** (backboard + SDK shipped).
- `--confirm-destructive` — **already in the CLI**.
- Plan summary → railwayapp/cli #979 · `--detailed-exit-code` → cli #980 · `--show-values` → cli #981 + railway-ts-sdk #34 · value redaction → railway-ts-sdk #32.

Markdown-only; no component or frontmatter changes.