### PR TITLE
Document railway cdn command

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -184,9 +184,12 @@ railway metrics                 # View resource and HTTP metrics
 ```bash
 railway domain                  # Generate Railway domain
 railway domain example.com      # Add custom domain
+railway cdn status              # Show CDN caching settings
+railway cdn enable              # Enable CDN caching
+railway cdn purge html          # Purge cached HTML
 ```
 
-[domain](/cli/domain)
+[domain](/cli/domain) · [cdn](/cli/cdn)
 
 ### Volumes
 

--- a/content/docs/cli/cdn.md
+++ b/content/docs/cli/cdn.md
@@ -1,0 +1,127 @@
+---
+title: railway cdn
+description: Manage CDN caching for a service.
+---
+
+Manage CDN caching settings for a service.
+
+CDN caching requires an applied public domain. Add a Railway-provided or custom
+domain before you enable CDN caching.
+
+## Usage
+
+```bash
+railway cdn <COMMAND> [OPTIONS]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show CDN settings for a service |
+| `enable` | Enable CDN caching |
+| `disable` | Disable CDN caching |
+| `update` | Update CDN caching settings |
+| `purge` | Purge cached content |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-s, --service <SERVICE>` | Service name or ID |
+| `-e, --environment <ENVIRONMENT>` | Environment to use |
+| `-p, --project <PROJECT_ID>` | Project ID to use |
+| `--json` | Output in JSON format |
+
+## Examples
+
+### Show CDN settings
+
+```bash
+railway cdn status --service web
+```
+
+Shows whether CDN caching is available and enabled for the selected service.
+
+### Enable CDN caching
+
+```bash
+railway cdn enable --service web
+```
+
+Enables CDN caching with Railway's default settings.
+
+### Configure HTML caching and TTL
+
+```bash
+railway cdn update \
+  --html-caching force \
+  --default-ttl 4h
+```
+
+Sets HTML caching to `force` and the fallback TTL to 4 hours.
+
+### Configure stale-while-revalidate
+
+```bash
+railway cdn update --no-swr
+```
+
+Disables honoring `stale-while-revalidate` directives from your service.
+
+### Configure purge on deploy
+
+```bash
+railway cdn update --purge-on-deploy all
+```
+
+Clears all cached content after each successful deploy.
+
+### Purge cached HTML
+
+```bash
+railway cdn purge html
+```
+
+Clears cached HTML responses and leaves static assets in place.
+
+### Purge all cached content
+
+```bash
+railway cdn purge all
+```
+
+Clears all cached content for the service.
+
+### Disable CDN caching
+
+```bash
+railway cdn disable --service web
+```
+
+Disables CDN caching for the selected service.
+
+## Options for `update`
+
+Use `railway cdn update` with one or more setting flags.
+
+| Flag | Description |
+|------|-------------|
+| `--html-caching <auto\|force\|never>` | Controls when HTML responses are cached |
+| `--default-ttl <TTL>` | Fallback TTL: `30m`, `1h`, `2h`, `4h`, `12h`, `1d`, or matching seconds |
+| `--swr` | Honor `stale-while-revalidate` directives |
+| `--no-swr` | Ignore `stale-while-revalidate` directives |
+| `--purge-on-deploy <off\|html\|all>` | Configure automatic cache purge after successful deploys |
+
+## Arguments for `purge`
+
+| Argument | Description |
+|----------|-------------|
+| `<html\|all>` | Cache scope to purge |
+
+## Related
+
+- [CDN](/networking/cdn)
+- [Domains](/networking/domains)
+- [railway domain](/cli/domain)
+- [railway service](/cli/service)

--- a/content/docs/networking/cdn.md
+++ b/content/docs/networking/cdn.md
@@ -18,6 +18,12 @@ CDN caching is configured per service and applies to all of that service's domai
 1. Open the service you want to cache and go to its **Settings**.
 2. In the **Edge** section, toggle **Enable CDN Caching** on.
 
+You can also enable CDN caching from the CLI:
+
+```bash
+railway cdn enable --service web
+```
+
 Railway routes each request to the nearest edge location automatically. For how that routing works, see [Edge networking](/networking/edge-networking).
 
 ## How caching works
@@ -95,6 +101,8 @@ Railway caches responses whose `Content-Type` matches one of these glob patterns
 ## Configure caching
 
 The **Edge** section of your service settings controls how the CDN caches responses.
+
+You can also configure these settings from the CLI with [`railway cdn update`](/cli/cdn#options-for-update).
 
 ### HTML caching
 
@@ -195,6 +203,13 @@ The **Purge Cache** controls in your service's **Edge** settings let you clear c
 
 Railway shows when each scope was last purged.
 
+You can also purge cached content from the CLI:
+
+```bash
+railway cdn purge html
+railway cdn purge all
+```
+
 Purging applies to the whole service. There's no per-URL purge, so to invalidate a single page, purge HTML or all content, or redeploy the service.
 
 ### Purge on deploy
@@ -207,6 +222,12 @@ The **Purge Cache on Deploy** setting clears cached content after each successfu
 | Purge HTML on each successful deploy (default) | Clears cached HTML so a freshly deployed page can't reference outdated asset URLs, while immutable static assets stay cached. |
 | Purge everything on each successful deploy | Clears all cached content, including static assets. |
 
+Configure purge on deploy from the CLI:
+
+```bash
+railway cdn update --purge-on-deploy html
+```
+
 ### Purge propagation
 
 Purges apply across all edge locations. They aren't instant: each location picks up a purge within a few seconds, typically around 10 seconds, and locations update independently rather than all at once. After a purge, the next request for an affected URL revalidates against your service.
@@ -218,3 +239,4 @@ Purges apply across all edge locations. They aren't instant: each location picks
 - [Public networking](/networking/public-networking) - Expose your services to the internet
 - [Domains](/networking/domains) - Configure Railway-provided and custom domains
 - [Deployment regions](/deployments/regions) - Choose where your service runs
+- [railway cdn](/cli/cdn) - Manage CDN caching from the CLI

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -234,6 +234,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("add"),
       makeCliCommand("agent"),
       makeCliCommand("bucket"),
+      makeCliCommand("cdn"),
       makeCliCommand("completion"),
       makeCliCommand("connect"),
       makeCliCommand("delete"),


### PR DESCRIPTION
## Summary

Documents the new `railway cdn` command for service CDN cache management.

Adds CLI reference coverage for:

```bash
railway cdn status
railway cdn enable
railway cdn disable
railway cdn update [options]
railway cdn purge <html|all>
```

All documented commands support:

```bash
-s, --service <SERVICE>
-e, --environment <ENVIRONMENT>
-p, --project <PROJECT_ID>
--json
```

## Changes

- Adds `content/docs/cli/cdn.md` with command usage, examples, selectors, update options, and cache purge scopes.
- Adds `makeCliCommand("cdn")` to the CLI sidebar.
- Adds CDN examples to `content/docs/cli.md` under Networking.
- Updates `content/docs/networking/cdn.md` with CLI instructions and cross-links.

## Command behavior documented

### `railway cdn status`

Shows the current CDN state for the selected service, including:

- whether CDN is available
- whether CDN caching is enabled
- applied public domain status
- HTML caching mode
- default TTL
- stale-while-revalidate state
- purge-on-deploy policy
- last HTML purge time
- last full purge time

### `railway cdn enable`

Enables CDN caching for the selected service.

Requires an applied public domain. If no domain is available, the command explains that CDN caching can't be enabled until a domain is added.

Uses the dashboard/default CDN settings, then reads back and displays the updated status.

### `railway cdn disable`

Disables CDN caching for the selected service without prompting, matching the dashboard toggle behavior. After disabling, it reads back and displays the updated status.

### `railway cdn update`

Updates CDN caching settings for a service that already has CDN enabled.

Requires at least one setting flag:

```bash
--html-caching <auto|force|never>
--default-ttl <30m|1h|2h|4h|12h|1d|1800|3600|7200|14400|43200|86400>
--swr
--no-swr
--purge-on-deploy <off|html|all>
```

The command preserves existing settings that were not changed, then displays the updated status.

### `railway cdn purge <html|all>`

Purges CDN cache for the selected service.

Supported scopes:

- `html`: purge HTML cache only
- `all`: purge the full CDN cache

## Validation

Validated on a branch based on the latest `origin/main` with:

```bash
pnpm tsc
pnpm build
```

The build passes with existing warnings for the local Node version, pnpm overrides, Next.js workspace root inference, generated CSS `@property` warnings, and the existing `/guides` page data size warning.
