### PR TITLE
Document railway waf command

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -187,9 +187,11 @@ railway domain example.com      # Add custom domain
 railway cdn status              # Show CDN caching settings
 railway cdn enable              # Enable CDN caching
 railway cdn purge html          # Purge cached HTML
+railway waf under-attack status # Show WAF protection status
+railway waf under-attack enable # Enable Under Attack Mode
 ```
 
-[domain](/cli/domain) · [cdn](/cli/cdn)
+[domain](/cli/domain) · [cdn](/cli/cdn) · [waf](/cli/waf)
 
 ### Volumes
 

--- a/content/docs/cli/waf.md
+++ b/content/docs/cli/waf.md
@@ -1,0 +1,81 @@
+---
+title: railway waf
+description: Manage WAF protection for a service.
+---
+
+Manage Under Attack Mode for a service.
+
+Under Attack Mode requires an applied public domain. Add a Railway-provided or
+custom domain before you enable it.
+
+## Usage
+
+```bash
+railway waf under-attack <COMMAND> [OPTIONS]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show Under Attack Mode status |
+| `enable` | Enable Under Attack Mode |
+| `disable` | Disable Under Attack Mode |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-s, --service <SERVICE>` | Service name or ID |
+| `-e, --environment <ENVIRONMENT>` | Environment to use |
+| `-p, --project <PROJECT_ID>` | Project ID to use |
+| `--json` | Output in JSON format |
+
+## Examples
+
+### Show Under Attack Mode status
+
+```bash
+railway waf under-attack status --service web
+```
+
+Shows whether Under Attack Mode is active for the selected service.
+
+### Enable Under Attack Mode
+
+```bash
+railway waf under-attack enable --service web
+```
+
+Enables Under Attack Mode until you turn it off.
+
+### Enable Under Attack Mode for a set duration
+
+```bash
+railway waf under-attack enable --service web --duration 1h
+```
+
+Enables Under Attack Mode for 1 hour.
+
+### Disable Under Attack Mode
+
+```bash
+railway waf under-attack disable --service web
+```
+
+Disables Under Attack Mode for the selected service.
+
+## Options for `enable`
+
+Use `railway waf under-attack enable` with an optional duration.
+
+| Flag | Description |
+|------|-------------|
+| `--duration <forever\|1h\|3h\|12h\|24h>` | How long Under Attack Mode stays active |
+
+## Related
+
+- [WAF](/networking/waf)
+- [Domains](/networking/domains)
+- [railway domain](/cli/domain)
+- [railway service](/cli/service)

--- a/content/docs/networking/waf.md
+++ b/content/docs/networking/waf.md
@@ -25,6 +25,15 @@ It takes effect across Railway's global network within ~20 seconds.
 
 Set it to run until you turn it off, or to expire on its own after 1, 3, 12, or 24 hours. While it's on, the **Edge** section shows that it's active, with the time remaining. Click **Deactivate** to turn it off early. Visitors who already passed the check aren't affected.
 
+You can also enable Under Attack Mode from the CLI:
+
+```bash
+railway waf under-attack enable --service web
+railway waf under-attack enable --service web --duration 1h
+railway waf under-attack status --service web
+railway waf under-attack disable --service web
+```
+
 ### What it blocks
 
 While Under Attack Mode is on, a CAPTCHA-style browser check guards your service:
@@ -56,3 +65,4 @@ Two other details apply to this setup:
 - [Edge networking](/networking/edge-networking) - How Railway routes requests to the nearest edge location
 - [Public networking](/networking/public-networking) - Expose your services to the internet
 - [Domains](/networking/domains) - Configure Railway-provided and custom domains
+- [railway waf](/cli/waf) - Manage WAF protection from the CLI

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -274,6 +274,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("upgrade"),
       makeCliCommand("variable"),
       makeCliCommand("volume"),
+      makeCliCommand("waf"),
       makeCliCommand("whoami"),
     ],
   },


### PR DESCRIPTION
## Summary

Adds docs for the new `railway waf` CLI command, including the Under Attack Mode status, enable, duration, and disable flows.

## Notes

- Adds the CLI reference page and sidebar entry.
- Cross-links the WAF networking docs to the CLI page.
- Leaves the Railway API guide unchanged.
