### PR TITLE
docs(deps): fix ephemeral info

### DIFF
--- a/content/docs/deployments/reference.md
+++ b/content/docs/deployments/reference.md
@@ -124,7 +124,7 @@ Cancels the selected [initializing](#initializing) or [building](#building) depl
 
 ## Ephemeral storage
 
-Every service deployment has access to 1GB of ephemeral storage on the Free plan and 100GB on a paid plan. If a service deployment consumes more than 10GB, it can be forcefully stopped and redeployed.
+Every service deployment has access to 1GB of ephemeral storage on the Free plan and 100GB on a paid plan. If a service deployment exceeds the maximum allowed storage, it can be forcefully stopped and redeployed.
 
 If your service requires data to persist between deployments, or needs more than 10GB of storage, you should add a [volume](/volumes).
 


### PR DESCRIPTION
- Removes the 10GB text and uses "maximum allowed storage" instead.