### PR TITLE
Document outbound-network CLI

### DIFF
--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -189,9 +189,12 @@ railway cdn enable              # Enable CDN caching
 railway cdn purge html          # Purge cached HTML
 railway waf under-attack status # Show WAF protection status
 railway waf under-attack enable # Enable Under Attack Mode
+railway outbound-networking status # Show outbound networking status
+railway outbound-networking static-ip enable # Enable Static Outbound IPs
+railway outbound-networking ipv6 enable # Stage Outbound IPv6
 ```
 
-[domain](/cli/domain) · [cdn](/cli/cdn) · [waf](/cli/waf)
+[domain](/cli/domain) · [cdn](/cli/cdn) · [waf](/cli/waf) · [outbound-networking](/cli/outbound-networking)
 
 ### Volumes
 

--- a/content/docs/cli.md
+++ b/content/docs/cli.md
@@ -189,12 +189,12 @@ railway cdn enable              # Enable CDN caching
 railway cdn purge html          # Purge cached HTML
 railway waf under-attack status # Show WAF protection status
 railway waf under-attack enable # Enable Under Attack Mode
-railway outbound-networking status # Show outbound networking status
-railway outbound-networking static-ip enable # Enable Static Outbound IPs
-railway outbound-networking ipv6 enable # Stage Outbound IPv6
+railway outbound-network status # Show outbound networking status
+railway outbound-network static-ip enable # Enable Static Outbound IPs
+railway outbound-network ipv6 enable # Stage Outbound IPv6
 ```
 
-[domain](/cli/domain) · [cdn](/cli/cdn) · [waf](/cli/waf) · [outbound-networking](/cli/outbound-networking)
+[domain](/cli/domain) · [cdn](/cli/cdn) · [waf](/cli/waf) · [outbound-network](/cli/outbound-network)
 
 ### Volumes
 

--- a/content/docs/cli/outbound-network.md
+++ b/content/docs/cli/outbound-network.md
@@ -1,5 +1,5 @@
 ---
-title: railway outbound-networking
+title: railway outbound-network
 description: Manage outbound networking settings for a service.
 ---
 
@@ -15,7 +15,7 @@ staged changes to trigger a redeploy.
 ## Usage
 
 ```bash
-railway outbound-networking <COMMAND> [OPTIONS]
+railway outbound-network <COMMAND> [OPTIONS]
 ```
 
 ## Subcommands
@@ -44,7 +44,7 @@ railway outbound-networking <COMMAND> [OPTIONS]
 ### Show outbound networking status
 
 ```bash
-railway outbound-networking status --service api
+railway outbound-network status --service api
 ```
 
 Shows Static Outbound IP and Outbound IPv6 status for the selected service.
@@ -52,7 +52,7 @@ Shows Static Outbound IP and Outbound IPv6 status for the selected service.
 ### Enable Static Outbound IPs
 
 ```bash
-railway outbound-networking static-ip enable --service api
+railway outbound-network static-ip enable --service api
 ```
 
 Enables Static Outbound IPs and prints the assigned IPv4 addresses. Redeploy the
@@ -61,7 +61,7 @@ service before outbound traffic uses these IP addresses.
 ### Disable Static Outbound IPs
 
 ```bash
-railway outbound-networking static-ip disable --service api
+railway outbound-network static-ip disable --service api
 ```
 
 Disables Static Outbound IPs. Redeploy the service before outbound traffic
@@ -70,7 +70,7 @@ stops using the removed IP addresses.
 ### Stage Outbound IPv6
 
 ```bash
-railway outbound-networking ipv6 enable --service api
+railway outbound-network ipv6 enable --service api
 ```
 
 Stages an environment config change for Outbound IPv6. Apply staged changes to
@@ -79,7 +79,7 @@ trigger a redeploy.
 ### Clear or stage disabling Outbound IPv6
 
 ```bash
-railway outbound-networking ipv6 disable --service api
+railway outbound-network ipv6 disable --service api
 ```
 
 If Outbound IPv6 is enabled, this stages disabling it. If enabling Outbound IPv6
@@ -88,7 +88,7 @@ is staged but not applied, this clears the staged change.
 ### Output JSON
 
 ```bash
-railway outbound-networking static-ip status --service api --json
+railway outbound-network static-ip status --service api --json
 ```
 
 Use `--json` to inspect lifecycle fields for automation. Static Outbound IP

--- a/content/docs/cli/outbound-networking.md
+++ b/content/docs/cli/outbound-networking.md
@@ -1,0 +1,103 @@
+---
+title: railway outbound-networking
+description: Manage outbound networking settings for a service.
+---
+
+Manage Static Outbound IPs and Outbound IPv6 for a service.
+
+Static Outbound IP changes are committed directly to the service's outbound
+networking settings. Redeploy the service before outbound traffic uses the new
+IP addresses or stops using removed IP addresses.
+
+Outbound IPv6 changes are staged as environment config changes. Apply the
+staged changes to trigger a redeploy.
+
+## Usage
+
+```bash
+railway outbound-networking <COMMAND> [OPTIONS]
+```
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `status` | Show Static Outbound IP and Outbound IPv6 status |
+| `static-ip status` | Show Static Outbound IP status |
+| `static-ip enable` | Enable Static Outbound IPs |
+| `static-ip disable` | Disable Static Outbound IPs |
+| `ipv6 status` | Show Outbound IPv6 status |
+| `ipv6 enable` | Stage enabling Outbound IPv6 |
+| `ipv6 disable` | Stage disabling Outbound IPv6 |
+
+## Options
+
+| Flag | Description |
+|------|-------------|
+| `-s, --service <SERVICE>` | Service name or ID |
+| `-e, --environment <ENVIRONMENT>` | Environment to use |
+| `-p, --project <PROJECT_ID>` | Project ID to use |
+| `--json` | Output in JSON format |
+
+## Examples
+
+### Show outbound networking status
+
+```bash
+railway outbound-networking status --service api
+```
+
+Shows Static Outbound IP and Outbound IPv6 status for the selected service.
+
+### Enable Static Outbound IPs
+
+```bash
+railway outbound-networking static-ip enable --service api
+```
+
+Enables Static Outbound IPs and prints the assigned IPv4 addresses. Redeploy the
+service before outbound traffic uses these IP addresses.
+
+### Disable Static Outbound IPs
+
+```bash
+railway outbound-networking static-ip disable --service api
+```
+
+Disables Static Outbound IPs. Redeploy the service before outbound traffic
+stops using the removed IP addresses.
+
+### Stage Outbound IPv6
+
+```bash
+railway outbound-networking ipv6 enable --service api
+```
+
+Stages an environment config change for Outbound IPv6. Apply staged changes to
+trigger a redeploy.
+
+### Clear or stage disabling Outbound IPv6
+
+```bash
+railway outbound-networking ipv6 disable --service api
+```
+
+If Outbound IPv6 is enabled, this stages disabling it. If enabling Outbound IPv6
+is staged but not applied, this clears the staged change.
+
+### Output JSON
+
+```bash
+railway outbound-networking static-ip status --service api --json
+```
+
+Use `--json` to inspect lifecycle fields for automation. Static Outbound IP
+actions use `direct` lifecycle mode. Outbound IPv6 actions use
+`environmentPatch` lifecycle mode.
+
+## Related
+
+- [Static Outbound IPs](/networking/static-outbound-ips)
+- [Outbound networking](/networking/outbound-networking)
+- [Staged changes](/deployments/staged-changes)
+- [railway service](/cli/service)

--- a/content/docs/networking/outbound-networking.md
+++ b/content/docs/networking/outbound-networking.md
@@ -89,7 +89,7 @@ plan customers who need consistent IP addresses for firewall allowlisting or
 third-party integrations.
 
 You can manage Static Outbound IPs from the dashboard or with the
-[`railway outbound-networking static-ip`](/cli/outbound-networking) CLI
+[`railway outbound-network static-ip`](/cli/outbound-network) CLI
 commands. After enabling or disabling Static Outbound IPs, redeploy the service
 before outbound traffic uses the updated IP assignment.
 
@@ -102,7 +102,7 @@ section, and toggle **Enable Outbound IPv6**. This creates a staged change.
 Apply the staged change to redeploy the service.
 
 You can also stage Outbound IPv6 changes with
-[`railway outbound-networking ipv6`](/cli/outbound-networking).
+[`railway outbound-network ipv6`](/cli/outbound-network).
 
 Outbound IPv6 is disabled by default. Enabling it does not affect your
 service's existing IPv4 outbound connectivity. Both work concurrently when the
@@ -112,6 +112,6 @@ toggle is on. While this setting is disabled, IPv6 connection attempts fail with
 ## Related features
 
 - [Static Outbound IPs](/networking/static-outbound-ips) - Assign permanent outbound IP addresses
-- [railway outbound-networking](/cli/outbound-networking) - Manage outbound networking from the CLI
+- [railway outbound-network](/cli/outbound-network) - Manage outbound networking from the CLI
 - [Private Networking](/networking/private-networking) - Internal service communication
 - [Public Networking](/networking/public-networking) - Inbound traffic to your services

--- a/content/docs/networking/outbound-networking.md
+++ b/content/docs/networking/outbound-networking.md
@@ -11,7 +11,10 @@ SMTP is only available on the Pro plan and above.
 
 Free, Trial, and Hobby plans must use transactional email services with HTTPS APIs. SMTP is disabled on these plans to prevent spam and abuse. However, even when SMTP is available, we recommend transactional email services with HTTPS APIs for all plans due to their enhanced features and analytics.
 
-<Banner variant="info">Upon upgrading to Pro, please re-deploy your service that needs to use SMTP for the changes to take effect.</Banner>
+<Banner variant="info">
+After upgrading to Pro, redeploy the service that needs to use SMTP for the
+changes to take effect.
+</Banner>
 
 ### Email service examples
 
@@ -81,18 +84,34 @@ and share the output of the command for further assistance
 
 ## Static outbound IPs
 
-Railway offers [Static Outbound IPs](/networking/static-outbound-ips) for Pro plan customers who need consistent IP addresses for firewall whitelisting or third-party integrations.
+Railway offers [Static Outbound IPs](/networking/static-outbound-ips) for Pro
+plan customers who need consistent IP addresses for firewall allowlisting or
+third-party integrations.
+
+You can manage Static Outbound IPs from the dashboard or with the
+[`railway outbound-networking static-ip`](/cli/outbound-networking) CLI
+commands. After enabling or disabling Static Outbound IPs, redeploy the service
+before outbound traffic uses the updated IP assignment.
 
 ## Outbound IPv6
 
 Railway supports outbound IPv6 connections on an opt-in basis per service. Enable this when you need to reach IPv6-only destinations or services that perform better over IPv6.
 
-To enable it, open your service's **Settings** tab, scroll to the **Networking** section, and toggle **Enable Outbound IPv6**. Redeploy the service for the change to take effect.
+To enable it, open your service's **Settings** tab, scroll to the **Networking**
+section, and toggle **Enable Outbound IPv6**. This creates a staged change.
+Apply the staged change to redeploy the service.
 
-Outbound IPv6 is disabled by default. Enabling it does not affect your service's existing IPv4 outbound connectivity — both work concurrently when the toggle is on. While this setting is disabled, IPv6 connection attempts will fail with "Network is unreachable" or `ENETUNREACH`.
+You can also stage Outbound IPv6 changes with
+[`railway outbound-networking ipv6`](/cli/outbound-networking).
+
+Outbound IPv6 is disabled by default. Enabling it does not affect your
+service's existing IPv4 outbound connectivity. Both work concurrently when the
+toggle is on. While this setting is disabled, IPv6 connection attempts fail with
+"Network is unreachable" or `ENETUNREACH`.
 
 ## Related features
 
 - [Static Outbound IPs](/networking/static-outbound-ips) - Assign permanent outbound IP addresses
+- [railway outbound-networking](/cli/outbound-networking) - Manage outbound networking from the CLI
 - [Private Networking](/networking/private-networking) - Internal service communication
 - [Public Networking](/networking/public-networking) - Inbound traffic to your services

--- a/content/docs/networking/static-outbound-ips.md
+++ b/content/docs/networking/static-outbound-ips.md
@@ -3,24 +3,28 @@ title: Static Outbound IPs
 description: Learn how to enable static outbound IPs on Railway.
 ---
 
-Static Outbound IPs allows customers on the Pro plan to assign permanent outbound IPv4 addresses to a service. These IP addresses will **always** be used for outbound traffic from any replicas running within the service. 
+Static Outbound IPs let customers on the Pro plan assign permanent outbound
+IPv4 addresses to a service. These IP addresses are used for outbound traffic
+from any replicas running within the service.
 
 Traffic will be balanced over multiple IPs for high throughput and resiliency.
 
 ## Use cases
 
-This feature may be useful to you if you're using a third-party service provider or firewall which requires you to whitelist which IP addresses your services will be connecting from, such as MongoDB Atlas.
+This feature may be useful to you if you're using a third-party service provider
+or firewall that requires you to allowlist the IP addresses your services
+connect from, such as MongoDB Atlas.
 
 The IPv4 addresses assigned to your service through this feature **cannot** be used to receive inbound traffic.
 
-## Enabling static outbound IPs
+## Enable static outbound IPs
 
 Customers on the Pro plan can enable Static Outbound IPs for any service they wish.
 
-1. Navigate to the Settings tab of your desired service
-2. Toggle `Enable Static IPs` in the Networking section of Settings
-3. You will be presented with IPv4 addresses tied to the region your service is deployed in
-4. The Static IPs will be used by your service after the next deploy
+1. Navigate to the **Settings** tab of your desired service.
+2. Toggle **Enable Static IPs** in the **Networking** section.
+3. Review the IPv4 addresses tied to the region your service is deployed in.
+4. Redeploy the service.
 
 <Image
   src="https://res.cloudinary.com/railway/image/upload/v1779459868/ha-static-ip-endabled_v5mhct.png"
@@ -28,13 +32,32 @@ Customers on the Pro plan can enable Static Outbound IPs for any service they wi
   alt="Static IPs"
   width={1528} height={1132} quality={80} />
 
+### Enable static outbound IPs from the CLI
+
+Use the [`railway outbound-networking`](/cli/outbound-networking) command group
+to manage Static Outbound IPs from the CLI:
+
+```bash
+railway outbound-networking static-ip enable --service api
+railway outbound-networking static-ip status --service api
+railway outbound-networking static-ip disable --service api
+```
+
+Enabling or disabling Static Outbound IPs from the CLI commits the IP assignment
+change directly. Redeploy the service before outbound traffic uses the updated
+IP assignment.
+
 ## Upgrade to HA Static Outbound IPs
 
-Previously a service would be assigned a single IP. For improved throughput and resiliency, services will now be assigned 3 IPs with outbound traffic load balanced over them.
+Previously a service would be assigned a single IP. For improved throughput and
+resiliency, services are assigned three IPs with outbound traffic load balanced
+over them.
 
-If you have an existing single IP service, you can upgrade by clicking the `Enable HA Static IP` link under the `Enable Static IPs` toggle. 
+If you have an existing single IP service, you can upgrade by clicking
+**Enable HA Static IP** under the **Enable Static IPs** toggle.
 
-You be shown the new Static IPs which will be allocated to your service. Once you have updated your downstream allowlists, click `Deploy` to start using them. 
+Railway shows the new Static IPs allocated to your service. Once you have
+updated your downstream allowlists, click **Deploy** to start using them.
 
 <Image
   src="https://res.cloudinary.com/railway/image/upload/v1779459868/ha-static-ips-migrate_gyvlmj.png"
@@ -43,7 +66,9 @@ You be shown the new Static IPs which will be allocated to your service. Once yo
   width={1540} height={1052} quality={80} />
 
 <Banner variant="warning">
-Services using Legacy Static IP have been contacted by Railway asking to migrate before July 13 2026. Any service still on a Legacy Static IP after July 13, 2026 will automatically migrated.
+Railway has contacted services using Legacy Static IPs to migrate before July
+13, 2026. Any service still on a Legacy Static IP after July 13, 2026 will be
+automatically migrated.
 </Banner>
 
 ## Caveats

--- a/content/docs/networking/static-outbound-ips.md
+++ b/content/docs/networking/static-outbound-ips.md
@@ -34,13 +34,13 @@ Customers on the Pro plan can enable Static Outbound IPs for any service they wi
 
 ### Enable static outbound IPs from the CLI
 
-Use the [`railway outbound-networking`](/cli/outbound-networking) command group
+Use the [`railway outbound-network`](/cli/outbound-network) command group
 to manage Static Outbound IPs from the CLI:
 
 ```bash
-railway outbound-networking static-ip enable --service api
-railway outbound-networking static-ip status --service api
-railway outbound-networking static-ip disable --service api
+railway outbound-network static-ip enable --service api
+railway outbound-network static-ip status --service api
+railway outbound-network static-ip disable --service api
 ```
 
 Enabling or disabling Static Outbound IPs from the CLI commits the IP assignment

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -255,6 +255,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("mcp"),
       makeCliCommand("metrics"),
       makeCliCommand("open"),
+      makeCliCommand("outbound-networking"),
       makeCliCommand("project"),
       makeCliCommand("redeploy"),
       makeCliCommand("restart"),

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -255,7 +255,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("mcp"),
       makeCliCommand("metrics"),
       makeCliCommand("open"),
-      makeCliCommand("outbound-networking"),
+      makeCliCommand("outbound-network"),
       makeCliCommand("project"),
       makeCliCommand("redeploy"),
       makeCliCommand("restart"),


### PR DESCRIPTION
Updates CLI docs for `railway outbound-network` and links them from the CLI overview and outbound networking docs.