### PR TITLE
Add Deploy with Railway button to docs sidebar

### DIFF
--- a/src/components/page-actions.tsx
+++ b/src/components/page-actions.tsx
@@ -3,6 +3,7 @@ import { useCopyableCode } from "@/contexts/copyable-code-context";
 import { reconstructMarkdownWithFrontmatter } from "@/utils/markdown";
 import { cn } from "@/lib/cn";
 import * as React from "react";
+import posthog from "posthog-js";
 import { Icon } from "./icon";
 import type { FrontMatter } from "@/types";
 
@@ -118,6 +119,22 @@ export function PageActions({
           />
         </span>
       </button>
+
+      {/* Deploy with Railway */}
+      <a
+        href={`https://railway.com/new?doc=${encodeURIComponent(slug)}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        onClick={() => {
+          posthog.capture("docs_deploy_button_clicked", {
+            page: slug,
+          });
+        }}
+        className="inline-flex items-center justify-center gap-1.5 h-9 px-2.5 mt-4 rounded-lg text-sm font-medium text-white bg-primary-solid hover:bg-primary-solid-hover active:bg-primary-solid-active transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-offset-2 focus-visible:ring-offset-muted-app"
+      >
+        Deploy with Railway
+        <Icon name="ArrowUpRight" className="size-4" />
+      </a>
     </div>
   );
 }


### PR DESCRIPTION
Adds a purple "Deploy with Railway" button below the Ask AI section in the right sidebar of every doc page.

- Same style as the "Go to Railway" button in the top nav
- Links to `railway.com/new?doc=<slug>` with the current page slug
- Tracks clicks via PostHog (`docs_deploy_button_clicked`)