### PR TITLE
Add guide: Use Agents in Railway Sandboxes

### DIFF
--- a/content/guides/agents-in-sandboxes.md
+++ b/content/guides/agents-in-sandboxes.md
@@ -1,0 +1,305 @@
+---
+title: Use Agents in Railway Sandboxes
+description: Drive Railway sandboxes from your local AI coding agent. Spin up isolated environments for development, run agents against your real infrastructure, and use the create, configure, checkpoint, and fork loop to move fast.
+date: "2026-06-24"
+tags:
+  - agents
+  - sandboxes
+  - claude
+  - cli
+topic: ai
+---
+
+<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+A [sandbox](/sandboxes) is a short-lived, isolated Linux environment you provision on demand, run commands in, and destroy. This guide covers how to fold sandboxes into your development loop and let your local AI coding agent drive them.
+
+Two layers of agents come together here. Your local agent, like Claude Code or Codex running on your laptop, drives sandboxes through the [Railway CLI](/cli) or the [TypeScript SDK](/sandboxes#typescript-sdk). Inside the sandbox, the same agent harnesses ship in the default image, so the environment can run untrusted code, test against real infrastructure, and do the work without you bootstrapping a toolchain each time.
+
+By the end, you'll understand where sandboxes fit in your flow: create an environment from a known base, configure it for the task, checkpoint the prepared state, fork it when the work branches, and tear it all down when you're done.
+
+## Why sandboxes for development
+
+A sandbox isn't a shell floating off to the side. Because it lives in a Railway [environment](/environments), it can join the same [private network](/networking/private-networking) as the rest of your services. That changes what an agent can do inside one.
+
+- **Isolation for untrusted work.** Run agent-generated code, dependency installs, and migrations in a throwaway environment instead of on your machine.
+- **Access to real infrastructure.** Create a sandbox on the private network and it can reach the [Postgres](/databases/postgresql), [Redis](/databases/redis), and internal services already in your project, so agents test against the same infrastructure they'll ship against.
+- **A branchable workspace.** Snapshot expensive setup once, then boot or fork as many copies as you need. Each new run is one command, not a fresh bootstrap.
+
+## The development loop
+
+The loop most teams adopt with sandboxes looks like this:
+
+```txt
+template -> create -> configure -> checkpoint -> create/fork -> verify -> destroy
+```
+
+Each step maps to a sandbox primitive:
+
+1. **Template:** build a reusable base with your common packages and tooling.
+2. **Create:** start a sandbox from that base.
+3. **Configure:** clone a repo, install dependencies, write guidance files, seed variables.
+4. **Checkpoint:** snapshot the prepared state into a named, server-side snapshot.
+5. **Create or fork:** boot fresh sandboxes from the checkpoint, or fork a running one when the work branches.
+6. **Verify:** run the agent, run tests, inspect the result.
+7. **Destroy:** tear down the temporary sandboxes and reclaim the resources.
+
+The point of the loop is that an agent doesn't rebuild the world every time. It carries forward the useful state and throws away the rest.
+
+## Prerequisites
+
+- A Railway account with [Sandboxes](/sandboxes) enabled through [Priority Boarding](/platform/priority-boarding).
+- The [Railway CLI](/cli) installed and logged in with `railway login`.
+- A project linked with `railway link`.
+- Node.js 22+ if you plan to use the [TypeScript SDK](/sandboxes#typescript-sdk).
+
+## Let your local agent drive sandboxes
+
+Your local coding agent can operate sandboxes the same way it operates the rest of Railway: through the CLI, guided by [Railway Agent Skills](/ai/agent-skills). Install the CLI and configure agent support in one step:
+
+```bash
+railway setup agent
+```
+
+This adds skills that teach Claude Code, Codex, OpenCode, and Cursor how to drive Railway, including the [`railway sandbox`](/cli/sandbox) commands. Once the skills are installed, you can ask your local agent to create a sandbox, run a command in it, checkpoint it, or fork it, and it knows which commands to run.
+
+The rest of this guide shows the two interfaces your agent drives: the CLI for terminal-driven work, and the SDK for building sandboxes into an application.
+
+## The CLI loop
+
+For most development work, you don't need to write code around a sandbox. The CLI gives you the full loop from your terminal, and the [`railway sandbox`](/cli/sandbox) reference covers every subcommand.
+
+Build a reusable template with your base tooling:
+
+```bash
+railway sandbox template build \
+  --name node-agent-base \
+  -c "apt-get update && apt-get install -y git curl build-essential" \
+  -c "curl -fsSL https://bun.sh/install | bash" \
+  --wait
+```
+
+Start a sandbox from it on the private network so it can reach your services:
+
+```bash
+railway sandbox create --template node-agent-base --private-network
+```
+
+Run the setup. The CLI keeps an active sandbox for the session, so most commands need no ID:
+
+```bash
+railway sandbox exec -- git clone https://github.com/your-org/your-app /root/workspace
+railway sandbox exec -- 'cd /root/workspace && /root/.bun/bin/bun install'
+```
+
+Checkpoint the prepared state so you can return to it from any machine:
+
+```bash
+railway sandbox checkpoint create app-base
+```
+
+Boot a fresh sandbox from the checkpoint and run an agent against the code:
+
+```bash
+railway sandbox create --checkpoint app-base
+railway sandbox exec -- bash -lc 'codex "fix the failing tests and explain the patch"'
+```
+
+To see a dev server the sandbox is running, start it in the background with `--detach`, then forward the port back to your machine:
+
+```bash
+railway sandbox exec --detach -- 'cd /root/workspace && /root/.bun/bin/bun run dev'
+railway sandbox forward 3000
+```
+
+When the work branches, fork the active sandbox to try a second approach without disturbing the first:
+
+```bash
+railway sandbox fork
+railway sandbox exec -- 'cd /root/workspace && /root/.bun/bin/bun run typecheck'
+```
+
+Destroy the sandbox when you're done. A short [idle timeout](/sandboxes#idle-timeout) also tears it down automatically:
+
+```bash
+railway sandbox destroy
+```
+
+## The SDK loop
+
+When you want to build sandboxes into an application, the [TypeScript SDK](/sandboxes#typescript-sdk) is the programmatic interface. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>. Install it with `bun add railway`, or scaffold a new project with `bun create railway@latest`.
+
+The minimal shape creates a sandbox, runs a command, and destroys it:
+
+```ts
+import { Sandbox } from "railway";
+
+const sandbox = await Sandbox.create();
+
+const result = await sandbox.exec("git --version");
+console.log(result.stdout);
+
+await sandbox.destroy();
+```
+
+`Sandbox.create()` reads `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID` from the environment and resolves once the sandbox is running and ready to accept commands.
+
+### Prepare a base and checkpoint it
+
+The loop gets useful when you stop treating each sandbox as a one-off machine. Define a template for the repeatable base, create a sandbox from it on the private network, run the expensive setup once, then checkpoint the prepared workspace:
+
+```ts
+import { Sandbox } from "railway";
+
+const base = Sandbox.template()
+  .withPackages("git", "curl", "build-essential")
+  .run("curl -fsSL https://bun.sh/install | bash");
+
+const sandbox = await Sandbox.create(base, {
+  idleTimeoutMinutes: 30,
+  env: {
+    RAILWAY_API_TOKEN: process.env.RAILWAY_API_TOKEN!,
+    DATABASE_URL: "${{Postgres.DATABASE_URL}}",
+  },
+  networkIsolation: "PRIVATE",
+});
+
+await sandbox.exec(
+  "git clone https://github.com/your-org/your-app /root/workspace",
+);
+
+await sandbox.files.write(
+  "/root/workspace/AGENTS.md",
+  [
+    "# sandbox guidance",
+    "Work in /root/workspace.",
+    "Write important results to files before the turn ends.",
+  ].join("\n"),
+);
+
+const install = await sandbox.exec("/root/.bun/bin/bun install", {
+  cwd: "/root/workspace",
+});
+
+if (install.exitCode !== 0) {
+  console.error(install.stderr);
+}
+
+await sandbox.checkpoint("app-base");
+```
+
+A few things are happening here:
+
+- The [`${{Postgres.DATABASE_URL}}`](/variables/reference#template-syntax) syntax resolves a Railway variable reference when the sandbox is created.
+- [`networkIsolation: "PRIVATE"`](/sandboxes#networking) joins the sandbox to your environment's private network.
+- [`sandbox.files.write`](/sandboxes#files) writes an `AGENTS.md` guidance file straight into the workspace, so an agent running inside knows how to behave.
+
+The template handles the repeatable base. The sandbox does the live work. The checkpoint captures the state after the costly setup, so later runs skip it.
+
+**Note:** Sandboxes use [mise](https://mise.jdx.dev/) for the default toolchain. For non-interactive `exec` calls, run commands through `bash -lc` to get the same configured environment the sandbox image expects.
+
+### Run a long-lived agent and detach
+
+A command started with `exec` runs on the sandbox independently of the client that started it, so an agent keeps working even if your process disconnects. Boot a sandbox from the checkpoint, start the agent, and detach with a durable session name:
+
+```ts
+import { Sandbox } from "railway";
+
+const sandbox = await Sandbox.create("app-base", {
+  env: {
+    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+  },
+});
+
+const agent = sandbox.exec(
+  'bash -lc \'claude "inspect the failing tests and propose a fix"\'',
+  {
+    cwd: "/root/workspace",
+    onStdout: (chunk) => process.stdout.write(chunk),
+    onStderr: (chunk) => process.stdout.write(chunk),
+  },
+);
+
+const sessionName = await agent.sessionName;
+await agent.detach();
+
+console.log(`Agent is running in session ${sessionName}`);
+```
+
+[Long-running commands](/sandboxes#long-running-commands) keep going in the sandbox after you detach. Reattach later from any process by passing the session name back to `exec`:
+
+```ts
+const sandbox = await Sandbox.connect(process.env.SANDBOX_ID!);
+
+await sandbox.exec(
+  { sessionName: process.env.AGENT_SESSION! },
+  {
+    resumeFromLastRead: true,
+    onStdout: (chunk) => process.stdout.write(chunk),
+  },
+);
+```
+
+You aren't forced to keep one local process alive to keep the work going. The sandbox is where the work happens, and getting back into that state is one call away.
+
+### Fork when the work branches
+
+[Checkpoints](/sandboxes#checkpoints) are best for reusable bases. [Forks](/sandboxes#forking) are best when the work branches from something already running. A fork clones a running sandbox's filesystem into a new, independent one: files are preserved, running processes are not. That's usually what you want, since you copy the workbench, not the half-running experiment.
+
+Install dependencies once, then fork per task to run independent agent attempts in parallel:
+
+```ts
+const base = await Sandbox.create("app-base");
+
+const typescriptUpgrade = await base.fork();
+const authRefactor = await base.fork();
+
+await Promise.all([
+  typescriptUpgrade.exec(
+    "bash -lc \"codex 'upgrade this app to TypeScript 5.8 and run tests'\"",
+    { cwd: "/root/workspace" },
+  ),
+  authRefactor.exec(
+    "bash -lc \"opencode 'refactor the auth middleware and run tests'\"",
+    { cwd: "/root/workspace" },
+  ),
+]);
+```
+
+This is the pattern behind apps like the <a href="https://github.com/codyde/repo-review-agent" target="_blank">Repo Review Agent</a>, which prepares a repository once, checkpoints it, then creates one sandbox per agent: one for tests, one for architecture, one for security, one for product polish. When each run finishes, it collects the results and destroys the temporary sandbox.
+
+## Agents bundled in the default image
+
+The default sandbox image includes [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), <a href="https://developers.openai.com/codex/cli/" target="_blank">Codex</a>, <a href="https://opencode.ai/docs/" target="_blank">OpenCode</a>, and <a href="https://pi.dev/" target="_blank">Pi</a>. You don't spend the first minutes of every session reinstalling a harness you've set up many times before.
+
+For now, you pass each agent its configuration or API key. Set the key when you create the sandbox so it's available to every command:
+
+```bash
+railway sandbox create --checkpoint app-base --variable ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+```
+
+In the SDK, pass the key through the `env` option as shown in the long-lived agent example above. Agents that persist credentials to disk, like signing in with `claude auth login` over SSH, keep those credentials through a checkpoint, so you can sign in once and snapshot the authenticated state.
+
+## Templates, checkpoints, and forks
+
+The three primitives look similar but serve different points in the loop.
+
+| Primitive | What it captures | When to use it |
+|-----------|------------------|----------------|
+| [Template](/sandboxes#templates) | An ordered list of build steps, content-addressed and cached | A repeatable base: install common packages, set up language tooling, prewarm a known environment |
+| [Checkpoint](/sandboxes#checkpoints) | The disk of a running sandbox as a named, server-side snapshot | After expensive live setup: cloned repo, installed dependencies, generated assets, migrated fixtures |
+| [Fork](/sandboxes#forking) | A clone of a running sandbox into another running sandbox | When the work branches right now: compare two fixes, run parallel agent attempts |
+
+A template is built from instructions and rebuilds cheaply. A checkpoint outlives its source sandbox, so you can destroy the original and still create from the checkpoint later. A fork needs a running source and copies its disk, not its processes.
+
+## Next steps
+
+Explore these resources to go deeper on sandboxes and agents:
+
+- [Sandboxes](/sandboxes): concepts, the SDK reference, networking, and limits.
+- [`railway sandbox` CLI reference](/cli/sandbox): templates, checkpoints, forks, exec, and port forwarding.
+- [Railway for Agents](/agents): the broader agent setup with the CLI, MCP, and skills.
+- [Agent Skills](/ai/agent-skills): teach your local agent to drive Railway.
+- [Running Agents on Railway](/guides/running-agents-on-railway): deploy an always-on, autonomous agent as a service.
+</content>
+</invoke>

--- a/content/guides/agents-in-sandboxes.md
+++ b/content/guides/agents-in-sandboxes.md
@@ -12,11 +12,11 @@ topic: ai
 
 <Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
 
-A [sandbox](/sandboxes) is a short-lived, isolated Linux environment you provision on demand, run commands in, and destroy. This guide covers how to fold sandboxes into your development loop and let your local AI coding agent drive them.
+A [sandbox](/sandboxes) is a short-lived, isolated Linux environment you provision on demand, run commands in, and destroy. This guide covers how to fold sandboxes into your development loop and let agents do real work inside them.
 
-Two layers of agents come together here. Your local agent, like Claude Code or Codex running on your laptop, drives sandboxes through the [Railway CLI](/cli) or the [TypeScript SDK](/sandboxes#typescript-sdk). Inside the sandbox, the same agent harnesses ship in the default image, so the environment can run untrusted code, test against real infrastructure, and do the work without you bootstrapping a toolchain each time.
+Two layers of agents come together here. Your local agent, like Claude Code or Codex running on your laptop, drives sandboxes through the [Railway CLI](/cli) or the [TypeScript SDK](/sandboxes#typescript-sdk). Inside the sandbox, the same agent harnesses ship in the default image, so the environment can run untrusted code, test against your real infrastructure, and do the work without you bootstrapping a toolchain each time.
 
-By the end, you'll understand where sandboxes fit in your flow: create an environment from a known base, configure it for the task, checkpoint the prepared state, fork it when the work branches, and tear it all down when you're done.
+The guide builds toward a concrete example: the <a href="https://github.com/codyde/repo-review-agent" target="_blank">Repo Review Agent</a>, an app that prepares a repository once, then fans out one sandbox per agent to review it for bugs, architecture, security, and product polish. By the end, you'll understand where each sandbox primitive fits in that flow.
 
 ## Why sandboxes for development
 
@@ -31,18 +31,17 @@ A sandbox isn't a shell floating off to the side. Because it lives in a Railway 
 The loop most teams adopt with sandboxes looks like this:
 
 ```txt
-template -> create -> configure -> checkpoint -> create/fork -> verify -> destroy
+create -> configure -> checkpoint -> create/fork -> verify -> destroy
 ```
 
 Each step maps to a sandbox primitive:
 
-1. **Template:** build a reusable base with your common packages and tooling.
-2. **Create:** start a sandbox from that base.
-3. **Configure:** clone a repo, install dependencies, write guidance files, seed variables.
-4. **Checkpoint:** snapshot the prepared state into a named, server-side snapshot.
-5. **Create or fork:** boot fresh sandboxes from the checkpoint, or fork a running one when the work branches.
-6. **Verify:** run the agent, run tests, inspect the result.
-7. **Destroy:** tear down the temporary sandboxes and reclaim the resources.
+1. **Create:** start a sandbox. The default image already ships git, Node, npm, and the agent harnesses, so most work needs no setup image.
+2. **Configure:** clone a repo, install dependencies, sign agents in, write guidance files, seed variables.
+3. **Checkpoint:** snapshot the prepared state into a named, server-side snapshot.
+4. **Create or fork:** boot fresh sandboxes from the checkpoint, or fork a running one when the work branches.
+5. **Verify:** run the agent, run tests, inspect the result.
+6. **Destroy:** tear down the temporary sandboxes and reclaim the resources.
 
 The point of the loop is that an agent doesn't rebuild the world every time. It carries forward the useful state and throws away the rest.
 
@@ -53,81 +52,87 @@ The point of the loop is that an agent doesn't rebuild the world every time. It 
 - A project linked with `railway link`.
 - Node.js 22+ if you plan to use the [TypeScript SDK](/sandboxes#typescript-sdk).
 
-## Let your local agent drive sandboxes
+## Drive sandboxes from the CLI
 
-Your local coding agent can operate sandboxes the same way it operates the rest of Railway: through the CLI, guided by [Railway Agent Skills](/ai/agent-skills). Install the CLI and configure agent support in one step:
+For most development work, you don't need to write code around a sandbox. The CLI gives you the full loop from your terminal, and the [`railway sandbox`](/cli/sandbox) reference covers every subcommand. Your local agent can run these same commands once you install [Railway Agent Skills](/ai/agent-skills) with `railway setup agent`, which teaches Claude Code, Codex, OpenCode, and Cursor how to drive Railway.
 
-```bash
-railway setup agent
-```
+### Sign agents in once and checkpoint the result
 
-This adds skills that teach Claude Code, Codex, OpenCode, and Cursor how to drive Railway, including the [`railway sandbox`](/cli/sandbox) commands. Once the skills are installed, you can ask your local agent to create a sandbox, run a command in it, checkpoint it, or fork it, and it knows which commands to run.
+The agent harnesses are in the image, but each one still needs credentials. Sign them in once, then capture a checkpoint so every later sandbox boots already authenticated. This is the one-time configuration the Repo Review Agent depends on.
 
-The rest of this guide shows the two interfaces your agent drives: the CLI for terminal-driven work, and the SDK for building sandboxes into an application.
-
-## The CLI loop
-
-For most development work, you don't need to write code around a sandbox. The CLI gives you the full loop from your terminal, and the [`railway sandbox`](/cli/sandbox) reference covers every subcommand.
-
-Build a reusable template with your base tooling:
+Create a sandbox and open a shell in it:
 
 ```bash
-railway sandbox template build \
-  --name node-agent-base \
-  -c "apt-get update && apt-get install -y git curl build-essential" \
-  -c "curl -fsSL https://bun.sh/install | bash" \
-  --wait
+railway sandbox create
+railway sandbox ssh
 ```
 
-Start a sandbox from it on the private network so it can reach your services:
+Inside the sandbox, sign in to each agent you plan to use:
 
 ```bash
-railway sandbox create --template node-agent-base --private-network
+claude auth login    # Anthropic OAuth
+codex login          # OpenAI / ChatGPT
+opencode auth login  # choose a provider, then paste the key
 ```
 
-Run the setup. The CLI keeps an active sandbox for the session, so most commands need no ID:
+`claude`, `codex`, and `opencode` each persist credentials to disk, so they survive a checkpoint. Pi has no interactive login and reads its key from `ANTHROPIC_API_KEY` at runtime, so you pass that key in at create time instead.
+
+Exit the shell and capture the authenticated state under a name you'll reuse:
 
 ```bash
-railway sandbox exec -- git clone https://github.com/your-org/your-app /root/workspace
-railway sandbox exec -- 'cd /root/workspace && /root/.bun/bin/bun install'
+railway sandbox checkpoint create agent-box
 ```
 
-Checkpoint the prepared state so you can return to it from any machine:
+The checkpoint is stored server-side in the environment, so you can destroy the original sandbox and still boot from `agent-box` from any machine.
+
+### Run the loop
+
+Create a sandbox on the private network so it can reach your other services. The default image already has the toolchain, so there's nothing to pre-install:
 
 ```bash
-railway sandbox checkpoint create app-base
+railway sandbox create --checkpoint agent-box --private-network
 ```
 
-Boot a fresh sandbox from the checkpoint and run an agent against the code:
+Clone a repo and install dependencies. The CLI keeps an active sandbox for the session, so these commands need no ID. Run non-interactive commands through `bash -lc` to get the sandbox's configured [mise](https://mise.jdx.dev/) toolchain:
 
 ```bash
-railway sandbox create --checkpoint app-base
-railway sandbox exec -- bash -lc 'codex "fix the failing tests and explain the patch"'
+railway sandbox exec -- bash -lc 'git clone https://github.com/codyde/repo-review-agent /root/workspace'
+railway sandbox exec -- bash -lc 'cd /root/workspace && npm ci'
 ```
 
-To see a dev server the sandbox is running, start it in the background with `--detach`, then forward the port back to your machine:
+Checkpoint the prepared workspace so you can return to it without repeating the clone and install:
 
 ```bash
-railway sandbox exec --detach -- 'cd /root/workspace && /root/.bun/bin/bun run dev'
-railway sandbox forward 3000
+railway sandbox checkpoint create repo-ready
 ```
 
-When the work branches, fork the active sandbox to try a second approach without disturbing the first:
+Boot a fresh sandbox from that checkpoint and run an agent against the code:
+
+```bash
+railway sandbox create --checkpoint repo-ready
+railway sandbox exec -- bash -lc 'cd /root/workspace && codex exec "review the repo for likely bugs and explain what you would change"'
+```
+
+To watch a dev server the sandbox is running, start it in the background with `--detach`, then forward the port back to your machine. The Repo Review Agent binds `PORT=8080`, so forward `8080`:
+
+```bash
+railway sandbox exec --detach -- bash -lc 'cd /root/workspace && npm run dev'
+railway sandbox forward 8080
+```
+
+When the work branches, fork the active sandbox to try a second approach without disturbing the first, then destroy what you no longer need:
 
 ```bash
 railway sandbox fork
-railway sandbox exec -- 'cd /root/workspace && /root/.bun/bin/bun run typecheck'
-```
-
-Destroy the sandbox when you're done. A short [idle timeout](/sandboxes#idle-timeout) also tears it down automatically:
-
-```bash
+railway sandbox exec -- bash -lc 'cd /root/workspace && npm run build'
 railway sandbox destroy
 ```
 
-## The SDK loop
+A short [idle timeout](/sandboxes#idle-timeout) also tears a sandbox down automatically if you forget.
 
-When you want to build sandboxes into an application, the [TypeScript SDK](/sandboxes#typescript-sdk) is the programmatic interface. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>. Install it with `bun add railway`, or scaffold a new project with `bun create railway@latest`.
+## Build the flow into an app with the SDK
+
+When you want sandboxes inside an application instead of your terminal, the [TypeScript SDK](/sandboxes#typescript-sdk) is the programmatic interface. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>. Install it with `bun add railway`, or scaffold a new project with `bun create railway@latest`.
 
 The minimal shape creates a sandbox, runs a command, and destroys it:
 
@@ -144,86 +149,140 @@ await sandbox.destroy();
 
 `Sandbox.create()` reads `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID` from the environment and resolves once the sandbox is running and ready to accept commands.
 
-### Prepare a base and checkpoint it
+The Repo Review Agent builds the full loop on top of that. Its flow, defined in `src/lib/review.server.ts`, runs end to end on each review:
 
-The loop gets useful when you stop treating each sandbox as a one-off machine. Define a template for the repeatable base, create a sandbox from it on the private network, run the expensive setup once, then checkpoint the prepared workspace:
+```txt
+create from agent-box -> clone -> install/build -> checkpoint -> sandbox per agent -> review -> destroy
+```
+
+The sections below walk through that pipeline.
+
+### Share one set of sandbox options
+
+Every sandbox in the app is created with the same token, environment, idle timeout, and the provider keys the harnesses read at runtime. The app centralizes them so each `create` call is consistent:
 
 ```ts
 import { Sandbox } from "railway";
 
-const base = Sandbox.template()
-  .withPackages("git", "curl", "build-essential")
-  .run("curl -fsSL https://bun.sh/install | bash");
+function sandboxOptions() {
+  return {
+    token: process.env.RAILWAY_API_TOKEN!,
+    environmentId: process.env.RAILWAY_ENVIRONMENT_ID!,
+    idleTimeoutMinutes: 30,
+    env: {
+      // Pi reads ANTHROPIC_API_KEY at runtime; the others fall back to it.
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY!,
+      OPENCODE_API_KEY: process.env.OPENCODE_API_KEY!,
+    },
+  };
+}
+```
 
-const sandbox = await Sandbox.create(base, {
-  idleTimeoutMinutes: 30,
-  env: {
-    RAILWAY_API_TOKEN: process.env.RAILWAY_API_TOKEN!,
-    DATABASE_URL: "${{Postgres.DATABASE_URL}}",
-  },
-  networkIsolation: "PRIVATE",
-});
+`env` bakes variables into the sandbox for its whole lifetime, available to every command. Values can reference other Railway variables, for example [`${{Postgres.DATABASE_URL}}`](/variables/reference#template-syntax), resolved when the sandbox is created. Pair an internal reference with `networkIsolation: "PRIVATE"` so the sandbox can resolve it over the [private network](/sandboxes#networking).
 
-await sandbox.exec(
-  "git clone https://github.com/your-org/your-app /root/workspace",
+### Prepare the repository once, then checkpoint it
+
+Boot the base sandbox from the `agent-box` checkpoint you captured with the CLI, clone the target repo, install dependencies, and run a build to verify the workspace is sound. Then checkpoint the prepared state under a fresh name:
+
+```ts
+const base = await Sandbox.create("agent-box", sandboxOptions());
+
+// Clone and install in one shell so the working directory carries across.
+await base.exec(
+  "bash -lc 'git clone --depth 1 https://github.com/codyde/repo-review-agent /root/workspace && cd /root/workspace && npm ci'",
 );
 
-await sandbox.files.write(
+// Drop guidance for the agents that will run inside.
+await base.files.write(
   "/root/workspace/AGENTS.md",
   [
     "# sandbox guidance",
     "Work in /root/workspace.",
-    "Write important results to files before the turn ends.",
+    "Do not modify files. Write findings to the final message.",
   ].join("\n"),
 );
 
-const install = await sandbox.exec("/root/.bun/bin/bun install", {
-  cwd: "/root/workspace",
+// Verify the workspace builds before snapshotting it.
+const build = await base.exec("bash -lc 'cd /root/workspace && npm run build'", {
+  timeoutSec: 900,
 });
+if (build.exitCode !== 0) console.error(build.stderr);
 
-if (install.exitCode !== 0) {
-  console.error(install.stderr);
-}
-
-await sandbox.checkpoint("app-base");
+const checkpoint = `repo-ready-${process.env.JOB_ID}`;
+await base.checkpoint(checkpoint);
 ```
 
-A few things are happening here:
+`exec` doesn't throw on a non-zero exit code, so the app inspects `exitCode` and `timedOut` after each step. The [`base.files.write`](/sandboxes#files) call writes an `AGENTS.md` guidance file straight into the workspace, so an agent running inside knows how to behave. The checkpoint captures the cloned, installed, verified workspace, so every agent run skips that setup.
 
-- The [`${{Postgres.DATABASE_URL}}`](/variables/reference#template-syntax) syntax resolves a Railway variable reference when the sandbox is created.
-- [`networkIsolation: "PRIVATE"`](/sandboxes#networking) joins the sandbox to your environment's private network.
-- [`sandbox.files.write`](/sandboxes#files) writes an `AGENTS.md` guidance file straight into the workspace, so an agent running inside knows how to behave.
+### Fan out one sandbox per agent
 
-The template handles the repeatable base. The sandbox does the live work. The checkpoint captures the state after the costly setup, so later runs skip it.
-
-**Note:** Sandboxes use [mise](https://mise.jdx.dev/) for the default toolchain. For non-interactive `exec` calls, run commands through `bash -lc` to get the same configured environment the sandbox image expects.
-
-### Run a long-lived agent and detach
-
-A command started with `exec` runs on the sandbox independently of the client that started it, so an agent keeps working even if your process disconnects. Boot a sandbox from the checkpoint, start the agent, and detach with a durable session name:
+With the prepared checkpoint in hand, the app creates one sandbox per agent and runs each harness in headless mode against the same starting state. Because every sandbox boots from the same checkpoint, the reviews are isolated and run in parallel:
 
 ```ts
-import { Sandbox } from "railway";
+const agents = [
+  { id: "codex", prompt: "Review this repo for likely bugs and missing tests." },
+  { id: "claude", prompt: "Review this repo for architecture and maintainability risks." },
+  { id: "opencode", prompt: "Triage this repo for security issues: auth, secrets, injection." },
+  { id: "pi", prompt: "Review this repo from a product and UX angle." },
+];
 
-const sandbox = await Sandbox.create("app-base", {
-  env: {
-    ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
-  },
-});
+function commandFor(id: string, prompt: string) {
+  switch (id) {
+    case "codex":
+      return `codex exec --json --dangerously-bypass-approvals-and-sandbox ${quote(prompt)}`;
+    case "claude":
+      return `claude --print --output-format json --permission-mode dontAsk ${quote(prompt)}`;
+    case "opencode":
+      return `opencode run --format json -- ${quote(prompt)}`;
+    case "pi":
+      return `pi --print --mode json --no-session --approve --tools read,grep,find,ls ${quote(prompt)}`;
+  }
+}
+
+const results = await Promise.all(
+  agents.map(async (agent) => {
+    const sandbox = await Sandbox.create(checkpoint, sandboxOptions());
+    try {
+      const result = await sandbox.exec(
+        `bash -lc 'cd /root/workspace && ${commandFor(agent.id, agent.prompt)}'`,
+        { timeoutSec: 900 },
+      );
+      return { id: agent.id, summary: result.stdout };
+    } finally {
+      await sandbox.destroy().catch(() => {});
+    }
+  }),
+);
+```
+
+Each harness runs with the flags that make it non-interactive: `--print` and `--permission-mode dontAsk` for Claude Code, `codex exec` with approvals bypassed, `opencode run`, and `pi --print --approve`. The `--json` and `--format json` flags give the app structured output it can parse into a summary per agent. `quote` shell-escapes the prompt so it travels safely inside the `bash -lc` string. Wrapping every sandbox run in `try`/`finally` guarantees the sandbox is destroyed even when a review throws.
+
+### Clean up the base and the checkpoint
+
+When all reviews finish, destroy the base sandbox and delete the temporary checkpoint so neither counts against your [environment's sandbox limit](/sandboxes#sandbox-limits-per-environment):
+
+```ts
+await base.destroy().catch(() => {});
+await Sandbox.deleteCheckpoint(checkpoint, sandboxOptions()).catch(() => {});
+```
+
+The reusable `agent-box` checkpoint stays in place. The next review boots from it again, so the only per-run cost is the clone, install, and the agent work itself.
+
+### Keep a long-lived agent running after you disconnect
+
+A command started with `exec` runs on the sandbox independently of the client that started it, so an agent keeps working even if your process disconnects. Start the agent, grab its durable `sessionName`, and detach:
+
+```ts
+const sandbox = await Sandbox.create("repo-ready", sandboxOptions());
 
 const agent = sandbox.exec(
-  'bash -lc \'claude "inspect the failing tests and propose a fix"\'',
-  {
-    cwd: "/root/workspace",
-    onStdout: (chunk) => process.stdout.write(chunk),
-    onStderr: (chunk) => process.stdout.write(chunk),
-  },
+  `bash -lc 'cd /root/workspace && claude -p "review src/lib/review.server.ts and propose improvements"'`,
+  { onStdout: (chunk) => process.stdout.write(chunk) },
 );
 
 const sessionName = await agent.sessionName;
-await agent.detach();
-
-console.log(`Agent is running in session ${sessionName}`);
+await agent.detach(); // stop streaming; the command keeps running
 ```
 
 [Long-running commands](/sandboxes#long-running-commands) keep going in the sandbox after you detach. Reattach later from any process by passing the session name back to `exec`:
@@ -242,43 +301,40 @@ await sandbox.exec(
 
 You aren't forced to keep one local process alive to keep the work going. The sandbox is where the work happens, and getting back into that state is one call away.
 
-### Fork when the work branches
+### Fork instead of recreating when the work branches
 
-[Checkpoints](/sandboxes#checkpoints) are best for reusable bases. [Forks](/sandboxes#forking) are best when the work branches from something already running. A fork clones a running sandbox's filesystem into a new, independent one: files are preserved, running processes are not. That's usually what you want, since you copy the workbench, not the half-running experiment.
-
-Install dependencies once, then fork per task to run independent agent attempts in parallel:
+The app creates a new sandbox per agent from the checkpoint, but forking is an option when you're branching from a sandbox that's already running. A [fork](/sandboxes#forking) clones a running sandbox's filesystem into a new, independent one: files are preserved, running processes are not. Install dependencies once, then fork per task:
 
 ```ts
-const base = await Sandbox.create("app-base");
+const base = await Sandbox.create("repo-ready", sandboxOptions());
 
-const typescriptUpgrade = await base.fork();
-const authRefactor = await base.fork();
+const bugReview = await base.fork();
+const securityReview = await base.fork();
 
 await Promise.all([
-  typescriptUpgrade.exec(
-    "bash -lc \"codex 'upgrade this app to TypeScript 5.8 and run tests'\"",
-    { cwd: "/root/workspace" },
+  bugReview.exec(
+    "bash -lc \"cd /root/workspace && codex exec 'find likely bugs in src/lib/review.server.ts, then run npm run build'\"",
   ),
-  authRefactor.exec(
-    "bash -lc \"opencode 'refactor the auth middleware and run tests'\"",
-    { cwd: "/root/workspace" },
+  securityReview.exec(
+    "bash -lc \"cd /root/workspace && opencode run 'audit the sandbox exec calls for command injection'\"",
   ),
 ]);
 ```
 
-This is the pattern behind apps like the <a href="https://github.com/codyde/repo-review-agent" target="_blank">Repo Review Agent</a>, which prepares a repository once, checkpoints it, then creates one sandbox per agent: one for tests, one for architecture, one for security, one for product polish. When each run finishes, it collects the results and destroys the temporary sandbox.
+A fork copies the workbench, not the half-running experiment, which is usually what you want when you split one prepared workspace into parallel attempts.
 
 ## Agents bundled in the default image
 
 The default sandbox image includes [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview), <a href="https://developers.openai.com/codex/cli/" target="_blank">Codex</a>, <a href="https://opencode.ai/docs/" target="_blank">OpenCode</a>, and <a href="https://pi.dev/" target="_blank">Pi</a>. You don't spend the first minutes of every session reinstalling a harness you've set up many times before.
 
-For now, you pass each agent its configuration or API key. Set the key when you create the sandbox so it's available to every command:
+For now, you pass each agent its configuration or API key. There are two ways to get credentials into a sandbox:
+
+- **Sign in and checkpoint** for harnesses that persist credentials to disk, like `claude auth login`. The authenticated state survives the checkpoint, as shown in [the CLI setup above](#sign-agents-in-once-and-checkpoint-the-result).
+- **Pass a key at create time** for harnesses that read from the environment, like Pi reading `ANTHROPIC_API_KEY`. Use `--variable` in the CLI or the `env` option in the SDK:
 
 ```bash
-railway sandbox create --checkpoint app-base --variable ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
+railway sandbox create --checkpoint agent-box --variable ANTHROPIC_API_KEY=$ANTHROPIC_API_KEY
 ```
-
-In the SDK, pass the key through the `env` option as shown in the long-lived agent example above. Agents that persist credentials to disk, like signing in with `claude auth login` over SSH, keep those credentials through a checkpoint, so you can sign in once and snapshot the authenticated state.
 
 ## Templates, checkpoints, and forks
 
@@ -286,11 +342,11 @@ The three primitives look similar but serve different points in the loop.
 
 | Primitive | What it captures | When to use it |
 |-----------|------------------|----------------|
-| [Template](/sandboxes#templates) | An ordered list of build steps, content-addressed and cached | A repeatable base: install common packages, set up language tooling, prewarm a known environment |
-| [Checkpoint](/sandboxes#checkpoints) | The disk of a running sandbox as a named, server-side snapshot | After expensive live setup: cloned repo, installed dependencies, generated assets, migrated fixtures |
-| [Fork](/sandboxes#forking) | A clone of a running sandbox into another running sandbox | When the work branches right now: compare two fixes, run parallel agent attempts |
+| [Template](/sandboxes#templates) | An ordered list of build steps, content-addressed and cached | A repeatable base for tooling the default image doesn't include |
+| [Checkpoint](/sandboxes#checkpoints) | The disk of a running sandbox as a named, server-side snapshot | After expensive live setup: signed-in agents, cloned repo, installed dependencies |
+| [Fork](/sandboxes#forking) | A clone of a running sandbox into another running sandbox | When the work branches right now: parallel agent attempts from one prepared workspace |
 
-A template is built from instructions and rebuilds cheaply. A checkpoint outlives its source sandbox, so you can destroy the original and still create from the checkpoint later. A fork needs a running source and copies its disk, not its processes.
+A template is built from instructions and rebuilds cheaply, but the Repo Review Agent skips it because git, Node, npm, and the agents already ship in the image. A checkpoint outlives its source sandbox, so you can destroy the original and still create from it later. A fork needs a running source and copies its disk, not its processes.
 
 ## Next steps
 

--- a/content/guides/agents-in-sandboxes.md
+++ b/content/guides/agents-in-sandboxes.md
@@ -301,5 +301,3 @@ Explore these resources to go deeper on sandboxes and agents:
 - [Railway for Agents](/agents): the broader agent setup with the CLI, MCP, and skills.
 - [Agent Skills](/ai/agent-skills): teach your local agent to drive Railway.
 - [Running Agents on Railway](/guides/running-agents-on-railway): deploy an always-on, autonomous agent as a service.
-</content>
-</invoke>


### PR DESCRIPTION
## What

Adds a new guide, `content/guides/agents-in-sandboxes.md`, on leveraging agents in Railway sandboxes. The focus is the **development loop**: how someone uses their local AI coding agent to drive Railway sandboxes for development, and where sandboxes fit in the flow.

## Why

Sandboxes now bundle Claude Code, Codex, OpenCode, and Pi in the default image, and the CLI/SDK make the create → configure → checkpoint → fork → verify → destroy loop practical for everyday development. There wasn't a guide tying these together from the developer's point of view. This complements the existing `running-agents-on-railway` guide (which covers deploying always-on autonomous agents as services) rather than overlapping with it.

## What it covers

- Why sandboxes fit development: isolation, access to real project infrastructure over the private network, and a branchable workspace.
- The development loop, mapped to sandbox primitives.
- Letting a local agent drive sandboxes via `railway setup agent` and Agent Skills.
- The **CLI loop**: template, create, configure, checkpoint, run an agent, forward a port, fork, destroy.
- The **SDK loop**: prepare a base and checkpoint it, run a long-lived agent and detach/reattach, fork when work branches (grounded in the Repo Review Agent example).
- Agents bundled in the default image and how keys/credentials are passed.
- Templates vs checkpoints vs forks comparison.

## Notes

- Written with the `docs-writing` skill style guide.
- Verified all CLI commands, SDK methods, and flags against `content/docs/sandboxes.md` and `content/docs/cli/sandbox.md`.
- All internal links verified to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)