### PR TITLE
fix(api-docs): wrap long lines in GraphQL code tabs instead of horizontal scroll

### DIFF
--- a/src/components/graphql-code-tabs.tsx
+++ b/src/components/graphql-code-tabs.tsx
@@ -283,7 +283,7 @@ export function GraphQLCodeTabs({
             </div>
           ) : (
             <div
-              className="shiki-wrapper"
+              className="shiki-wrapper graphql-tabs-wrap"
               dangerouslySetInnerHTML={{ __html: htmlCache[cacheKey] || "" }}
             />
           )}
@@ -401,7 +401,7 @@ function VariablesSection({
             </div>
           ) : (
             <div
-              className="shiki-wrapper"
+              className="shiki-wrapper graphql-tabs-wrap"
               dangerouslySetInnerHTML={{ __html: html }}
             />
           )}

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -457,3 +457,44 @@
   @apply border-l-warning bg-warning-element/30;
 }
 
+/* ===== GraphQLCodeTabs: wrap long lines instead of horizontal scroll =====
+   The API examples (GraphQL / cURL / JavaScript / Python + the Variables JSON)
+   render in a fixed ~648px content column. A modest 80-char mutation, and the
+   far longer generated cURL `-d '{...}'` body, overflow it and force horizontal
+   scrolling that hides the start of the line. We let these wrap instead.
+
+   Scoped via the `graphql-tabs-wrap` marker class, added ONLY on the
+   GraphQLCodeTabs code body and its VariablesSection wrappers
+   (graphql-code-tabs.tsx). Regular code blocks (code-block.tsx) use the bare
+   `.shiki-wrapper` and never match this compound selector, so they keep
+   `white-space: pre` + horizontal scroll, which suits shell/config snippets.
+
+   No `overflow-x` override is needed: once content wraps it never exceeds the
+   column, so the inherited `overflow-x: auto` simply never shows a scrollbar.
+   Leaving it `auto` keeps a graceful fallback instead of silently clipping. */
+
+/* The base rule gives <code> `w-fit min-w-full` (width: fit-content), which
+   would grow to the longest line and defeat wrapping. Pin it to the container
+   so the wrap has an edge. This selector is (0,3,1) vs the base (0,2,1) and
+   both carry `!important`, so the higher specificity wins. */
+.shiki-wrapper.graphql-tabs-wrap .shiki code {
+  width: 100% !important;
+  max-width: 100% !important;
+  min-width: 0 !important;
+  white-space: pre-wrap !important; /* beat base `white-space: pre !important` */
+  /* `pre-wrap` only breaks at existing whitespace, so the cURL `-d '{...}'`
+     JSON one-liner (a long run with no spaces) would still overflow.
+     `overflow-wrap: anywhere` breaks inside such a run only when it would
+     otherwise overflow, so GraphQL/JS/Python keep wrapping at token
+     boundaries and stay readable. */
+  overflow-wrap: anywhere;
+}
+
+/* Each line also carries `white-space: pre !important`, so override it too.
+   Padding/margin/width are untouched here, so the diff / highlighted / focused
+   full-bleed lines (-mx-4 px-4 + colored border) keep rendering correctly. */
+.shiki-wrapper.graphql-tabs-wrap .shiki .line {
+  white-space: pre-wrap !important;
+  overflow-wrap: anywhere;
+}
+


### PR DESCRIPTION
## Problem

`<GraphQLCodeTabs>` (the GraphQL / cURL / JavaScript / Python tabs on the API docs pages) renders code in a fixed ~648px content column with `white-space: pre`. A modest 80-char mutation like `serviceInstanceDeployV2` overflows by ~56px, and the generated **cURL** tab's `-d '{…json…}'` body is a single ~250-char run. The result is horizontal scrolling that hides the **start** of the line (reported on the *Deploy a service* example — the line read `…ion serviceInstanceDeployV2(…)` once scrolled).

## Fix

Soft-wrap the code in these blocks instead of scrolling:

- `white-space: pre-wrap` so lines wrap at the column edge.
- `overflow-wrap: anywhere` so the spaceless cURL JSON run also breaks (plain `pre-wrap` only breaks at whitespace).
- Pin `<code>` to `width: 100%` (the base rule's `w-fit`/`fit-content` would otherwise grow to the longest line and defeat wrapping).

Scoped via a `graphql-tabs-wrap` marker class added on the code body and Variables wrappers, so **regular code blocks** (`code-block.tsx`, shell/config snippets) keep `white-space: pre` + horizontal scroll. The override beats the existing `white-space: pre !important` purely on selector specificity; no `overflow-x` change (inherited `auto` just stops showing a scrollbar once content wraps, and stays a graceful fallback).

## Verification

Ran the docs locally and measured the *Deploy a service* block:

| Tab | Longest line | Horizontal overflow (before → after) |
|-----|--------------|--------------------------------------|
| GraphQL | 80 chars | 56px → **0px** |
| cURL | 253 chars | (large) → **0px** |

Both diff/highlight line styling and copy-to-clipboard (copies the raw string, CSS-independent) are unaffected.