### PR TITLE
Fix mobile horizontal overflow that zooms out code/table-heavy pages

### DIFF
--- a/src/components/inline-code.tsx
+++ b/src/components/inline-code.tsx
@@ -6,7 +6,7 @@ export interface Props {
 
 export const InlineCode: React.FC<Props> = ({ children }) => {
   return (
-    <code className="rounded-lg font-mono whitespace-nowrap inline-block before:content-[''] after:content-[''] bg-muted-element text-muted-high-contrast px-2 py-0.5">
+    <code className="rounded-lg font-mono break-words before:content-[''] after:content-[''] bg-muted-element text-muted-high-contrast px-2 py-0.5">
       {children}
     </code>
   );

--- a/src/components/table.tsx
+++ b/src/components/table.tsx
@@ -1,0 +1,9 @@
+import React from "react";
+
+export const Table: React.FC<React.ComponentProps<"table">> = props => {
+  return (
+    <div className="table-scroll">
+      <table {...props} />
+    </div>
+  );
+};

--- a/src/layouts/docs-layout.tsx
+++ b/src/layouts/docs-layout.tsx
@@ -141,7 +141,7 @@ export const DocsLayout: React.FC<PropsWithChildren<Props>> = ({
       />
       <TOCProvider items={tocItems}>
         <CopyableCodeProvider>
-        <div className="flex flex-col min-h-[calc(100vh-53px)]">
+        <div className="flex flex-col min-w-0 min-h-[calc(100vh-53px)]">
           {/* Two-column layout */}
           <div className="max-w-full flex flex-row flex-1">
             <div className="flex-auto min-w-0 prose dark:prose-invert">

--- a/src/layouts/guides-layout.tsx
+++ b/src/layouts/guides-layout.tsx
@@ -93,7 +93,7 @@ export const GuidesLayout: React.FC<PropsWithChildren<GuidesLayoutProps>> = ({
         lastModified={lastModified}
       />
       <TOCProvider items={tocItems}>
-        <div className="flex flex-col min-h-[calc(100vh-53px)]">
+        <div className="flex flex-col min-w-0 min-h-[calc(100vh-53px)]">
           {/* Two-column layout */}
           <div className="max-w-full flex flex-row flex-1">
             <div className="flex-auto min-w-0 prose dark:prose-invert">

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/banner";
 import { Collapse } from "@/components/collapse";
 import { Pre, CodeBlock, CodeTab } from "@/components/code-block";
+import { Table } from "@/components/table";
 import { GraphQLCodeTabs } from "@/components/graphql-code-tabs";
 import { Card, CardGrid } from "@/components/card";
 import { Frame } from "@/components/frame";
@@ -49,6 +50,7 @@ const components: Record<string, React.ElementType> = {
   TallyButton,
   CodeBlock,
   CodeTab,
+  table: Table,
   GraphQLCodeTabs,
   Card,
   CardGrid,

--- a/src/pages/dynamic/[...slug].tsx
+++ b/src/pages/dynamic/[...slug].tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/banner";
 import { Collapse } from "@/components/collapse";
 import { Pre, CodeBlock, CodeTab } from "@/components/code-block";
+import { Table } from "@/components/table";
 import { GraphQLCodeTabs } from "@/components/graphql-code-tabs";
 import { Card, CardGrid } from "@/components/card";
 import { Frame } from "@/components/frame";
@@ -48,6 +49,7 @@ const components: Record<string, React.ElementType> = {
   TallyButton,
   pre: Pre,
   code: InlineCode,
+  table: Table,
   CodeBlock,
   CodeTab,
   GraphQLCodeTabs,

--- a/src/pages/dynamic/guides/[...slug].tsx
+++ b/src/pages/dynamic/guides/[...slug].tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/banner";
 import { Collapse } from "@/components/collapse";
 import { Pre, CodeBlock, CodeTab } from "@/components/code-block";
+import { Table } from "@/components/table";
 import { GraphQLCodeTabs } from "@/components/graphql-code-tabs";
 import { Frame } from "@/components/frame";
 import { Steps, Step } from "@/components/steps";
@@ -46,6 +47,7 @@ const components: Record<string, React.ElementType> = {
   pre: Pre,
   CodeBlock,
   CodeTab,
+  table: Table,
   GraphQLCodeTabs,
   Frame,
   Steps,

--- a/src/pages/guides/[...slug].tsx
+++ b/src/pages/guides/[...slug].tsx
@@ -5,6 +5,7 @@ import {
 } from "@/components/banner";
 import { Collapse } from "@/components/collapse";
 import { Pre, CodeBlock, CodeTab } from "@/components/code-block";
+import { Table } from "@/components/table";
 import { GraphQLCodeTabs } from "@/components/graphql-code-tabs";
 import { Frame } from "@/components/frame";
 import { Steps, Step } from "@/components/steps";
@@ -44,6 +45,7 @@ const components: Record<string, React.ElementType> = {
   TallyButton,
   CodeBlock,
   CodeTab,
+  table: Table,
   GraphQLCodeTabs,
   Frame,
   Steps,

--- a/src/styles/prose.css
+++ b/src/styles/prose.css
@@ -235,9 +235,13 @@
 
 /* Tables */
 .prose table {
-  @apply my-6 w-full caption-bottom overflow-hidden rounded-lg border border-muted text-sm;
+  @apply w-full caption-bottom overflow-hidden rounded-lg border border-muted text-sm;
   border-collapse: separate;
   border-spacing: 0;
+}
+
+.prose .table-scroll {
+  @apply my-6 overflow-x-auto;
 }
 
 .prose thead {
@@ -341,6 +345,8 @@
   @apply rounded-none font-mono text-xs leading-relaxed sm:text-sm;
   margin: 0 !important;
   overflow: visible;
+  width: fit-content;
+  min-width: 100%;
 }
 
 .shiki-wrapper .shiki code {


### PR DESCRIPTION
## summary of the problem this pr exists 

Pages with wide code blocks, tables, or long inline-code tokens rendered the whole layout wider than the mobile viewport, so the browser zoomed the page out and shrank all text. Three independent causes, all fixed here: 

- table overflow 
- inline code snipper overflow 

## verification 

Verified at a 390px viewport: sandboxes, services, build-deploy, cli/sandbox, guides, and deployments all render at correct scale with no page overflow.