### PR TITLE
Update status page links and document status/POP API endpoints

### DIFF
--- a/content/docs/networking/edge-networking.md
+++ b/content/docs/networking/edge-networking.md
@@ -21,7 +21,7 @@ The key insight is that **"nearest" is determined by network topology, not geogr
 
 Railway's network has two distinct layers:
 
-- **Edge POPs** are the entry points where user traffic first reaches Railway. Each request is terminated at the nearest POP and tagged with that POP's ID in the `X-Railway-Edge` header. Railway operates POPs in [dozens of cities worldwide](https://status.railway.com/locations).
+- **Edge POPs** are the entry points where user traffic first reaches Railway. Each request is terminated at the nearest POP and tagged with that POP's ID in the `X-Railway-Edge` header. Railway operates POPs in [dozens of cities worldwide](https://status.railway.com/locations); the current list is also available as JSON at `https://railway.com/.railway/pops` (provided as-is, without any support, and the response format may change without notice).
 - **Deployment regions** are where your applications actually run. Railway offers four: **US West**, **US East**, **Europe West**, and **Asia Southeast**.
 
 You choose which regions to deploy your app to, but all edge POPs are available automatically. Your users always enter Railway at the POP nearest to them, regardless of where your app is deployed.

--- a/content/docs/platform/incident-management.md
+++ b/content/docs/platform/incident-management.md
@@ -17,6 +17,13 @@ However, it's important to note that while we strive to stay ahead of incidents,
 
 Railway's uptime and incident retrospective can be accessed on the Railway status page at https://status.railway.com/. On this page, you can view the historical uptime of Railway's systems and services. Additionally, you can find detailed information about past incidents, including retrospectives that provide insights into how incidents were handled and what measures were taken to prevent similar issues in the future.
 
+The status page is built and hosted in-house. If you'd like to consume its data programmatically, it's backed by two simple JSON endpoints:
+
+- `https://api.railwaystatus.com/status` — current status of Railway's systems and services. Its response schema is published at `https://api.railwaystatus.com/status/schema.json`.
+- `https://railway.com/.railway/pops` — Railway's CDN points of presence (POPs) and their status. These are edge POPs, not [deployment regions](/deployments/regions).
+
+These endpoints are provided as-is, without any support, and their response format may change without notice.
+
 For Enterprise customers, we offer SLOs and guarantees of service that may not be represented on the uptime dashboard.
 
 ## Incident severity

--- a/content/docs/platform/philosophy.md
+++ b/content/docs/platform/philosophy.md
@@ -76,7 +76,7 @@ Your code will either be in some, or all steps depending on the amount of Railwa
 
 ### Operational procedures
 
-Railway uses a suite of alerting vendors, additional internal tools, and PagerDuty to ensure uptime of Railway's services described above. You can see Railway's uptime on the [Instatus page](https://railway.instatus.com/). Operational incident management reports and RCAs are available by request for those on an Enterprise plan.
+Railway uses a suite of alerting vendors, additional internal tools, and PagerDuty to ensure uptime of Railway's services described above. You can see Railway's uptime on our in-house [status page](https://status.railway.com/). Operational incident management reports and RCAs are available by request for those on an Enterprise plan.
 
 ### Do I have to change how I write Code?
 


### PR DESCRIPTION
## What

- **`platform/philosophy.md`** — replace the old Instatus link (`railway.instatus.com`) with the new in-house status page (`status.railway.com`), and note it's built in-house.
- **`platform/incident-management.md`** — document the two JSON endpoints that back the status page:
  - `https://api.railwaystatus.com/status` (with its `schema.json`)
  - `https://railway.com/.railway/pops` (CDN POPs, not deployment regions)
- **`networking/edge-networking.md`** — cross-reference the pops endpoint where Edge POPs are introduced.

Both endpoints are documented as provided as-is, without support, and the response format may change without notice.

## ⚠️ Merge gating

`https://api.railwaystatus.com/status/schema.json` is **not live yet** (currently 404s). Hold this merge until the schema endpoint is live so we don't ship a dead link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)