### PR TITLE
Redirect /reference/billing to /pricing

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -165,6 +165,13 @@ const redirects = [
     permanent: true,
   },
   {
+    // Never a real page — but a plausible guess from the legacy /reference/*
+    // IA that LLMs and old links keep producing. Send it to the pricing hub.
+    source: "/reference/billing",
+    destination: "/pricing",
+    permanent: true,
+  },
+  {
     source: "/guides/fixing-common-errors",
     destination: "/networking/troubleshooting/application-failed-to-respond",
     permanent: true,


### PR DESCRIPTION
# What

Adds a permanent redirect for `/reference/billing` → `/pricing`.

`docs.railway.com/reference/billing` has never been a real page, but it currently 404s for users who land on it. The legacy docs IA kept all pricing pages under `/reference/pricing/*` (which already redirect to `/pricing/*`), so `/reference/billing` is a natural guess — LLM assistants and stale external links keep producing it. This sends those visitors to the pricing hub instead of a 404.

# Changes

- `redirects.js`: add `/reference/billing` → `/pricing` (permanent), next to the existing `/reference/pricing*` redirect family.