### PR TITLE
docs: feature flags guide and MCP discovery

### DIFF
--- a/content/docs/ai/agent-skills.md
+++ b/content/docs/ai/agent-skills.md
@@ -67,6 +67,7 @@ The `use-railway` skill covers the following areas:
 - **Deploy and release operations** - Push code to Railway, manage deployments, and handle the deployment lifecycle
 - **Troubleshooting and recovery** - View build and deploy logs, redeploy, restart, or remove deployments
 - **Environment config and variables** - Query and modify service configuration, environment variables, build/deploy commands, replicas, health checks, and restart policies
+- **Feature flags** - List, inspect, create, update defaults, and delete project-scoped flags via MCP; read workspace-scoped flags
 - **Bucket management** - Create, list, inspect, rename, and delete storage buckets, and view or reset S3-compatible credentials
 - **Networking and domains** - Add Railway-provided domains, configure custom domains, and manage domain settings
 - **Status and observability** - Check project status, query resource usage metrics (CPU, memory, network, disk), and monitor services

--- a/content/docs/ai/mcp-server.md
+++ b/content/docs/ai/mcp-server.md
@@ -82,6 +82,16 @@ The local Railway MCP Server translates natural language requests into CLI workf
   Redeploy my api service in the production environment
   ```
 
+* **Manage feature flags**
+
+  ```text
+  List feature flags for project <projectId>
+  ```
+
+  ```text
+  Set the checkout-v2 feature flag to true on project <projectId>
+  ```
+
 ## Available MCP tools
 
 The Railway MCP Server provides a curated set of tools. Your AI assistant calls these automatically based on the context of your request.
@@ -113,6 +123,9 @@ The remote server exposes a focused set of tools plus a powerful agent entry poi
   * `whoami`
 * **Projects**
   * `list-projects`, `create-project`, `list-services`
+* **Feature flags**
+  * `list-feature-flags`, `get-feature-flag`
+  * `set-feature-flag`, `delete-feature-flag` (admin; destructive delete is marked at the protocol level)
 * **Deployments**
   * `redeploy`
   * `accept-deploy` — commit staged changes and deploy (destructive; clients prompt for confirmation)

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -1,0 +1,105 @@
+---
+title: Feature Flags
+description: Define typed feature flags with targeting rules for your Railway projects and workspaces.
+---
+
+Feature flags (internally **Signals**) are a typed configuration registry scoped to a **project** or **workspace**. Each flag has a default value and optional targeting rules evaluated at read time.
+
+Use feature flags when you need:
+
+- Typed defaults (`bool`, `string`, `number`, `json`)
+- Targeting by attributes (for example `plan = enterprise`)
+- Percentage rollouts keyed on stable attributes (for example `workspace_id`)
+- A central registry that apps poll at runtime (via the SDK or GraphQL)
+
+Feature flags are **not** environment variables. For static per-environment secrets and config, use [Variables](/docs/variables).
+
+## Scopes
+
+| Scope | Owner string | Managed from |
+|---|---|---|
+| Project | `project:<projectId>` | Project **Settings → Feature Flags** |
+| Workspace | `workspace:<workspaceId>` | Workspace settings (read-only in project settings) |
+
+Runtime apps read **one scope** at a time. Project and workspace registries are separate namespaces.
+
+## Dashboard
+
+1. Open a project → **Settings → Feature Flags**
+2. Create a flag: name, type, default, optional targeting rules
+3. Project admins can create, edit, and delete project-scoped flags
+4. Workspace-scoped flags appear in a read-only section when they exist
+
+### Targeting rules
+
+Each rule has:
+
+- **Attribute** — compare a context attribute (for example `plan`)
+- **Rollout %** — bucket on a key attribute with a percentage threshold (0–100 in the UI; stored as 0–1)
+- **Serve** — value returned when the rule matches
+
+All matching rules must agree on the served value; otherwise the default wins.
+
+## Runtime SDK
+
+Install the [Railway TypeScript SDK](https://github.com/railwayapp/railway-ts-sdk) and initialize flags for your scope:
+
+```typescript
+import { flags } from "railway";
+
+await flags.init({
+  scope: { projectId: process.env.RAILWAY_PROJECT_ID! },
+});
+
+const enabled = flags.getBoolean("checkout-v2", {
+  targetingKey: userId,
+  attributes: { plan: "enterprise" },
+});
+```
+
+The SDK polls the registry and evaluates flags in-process using the same resolver as the API.
+
+## GraphQL API
+
+Public GraphQL operations include `signals`, `signal`, `signalCreate`, `signalDefaultSet`, `signalRuleSet`, `signalRuleUnset`, and `signalDelete`. Pass an explicit `owner` (`project:<id>` or `workspace:<id>`).
+
+See the [GraphQL overview](/docs/integrations/api/graphql-overview) for authentication.
+
+## AI agents and MCP
+
+Remote MCP (`https://mcp.railway.com`) exposes feature flag tools:
+
+| Tool | Role | Description |
+|---|---|---|
+| `list-feature-flags` | viewer | List project flags; includes workspace flags when present |
+| `get-feature-flag` | viewer | Inspect one flag |
+| `set-feature-flag` | admin | Create a flag or update its default |
+| `delete-feature-flag` | admin | Delete a project-scoped flag |
+
+Example prompts:
+
+```text
+List feature flags for my Railway project
+```
+
+```text
+Set the checkout-v2 feature flag default to true on project <projectId>
+```
+
+Install agent tooling with `railway setup agent --remote`. See [Railway MCP Server](/docs/ai/mcp-server) and [Agent Skills](/docs/ai/agent-skills).
+
+## CLI
+
+When available in your CLI version:
+
+```bash
+railway flag list --project <project-id> --json
+railway flag checkout-v2 true --project <project-id>
+```
+
+Upgrade with `railway upgrade --yes` if `railway flag` is not found.
+
+## Related
+
+- [Variables](/docs/variables) — environment-scoped configuration
+- [Priority Boarding](/docs/platform/priority-boarding) — account beta program (unrelated to project feature flags)


### PR DESCRIPTION
## Summary
- Add `/docs/feature-flags` user guide for Railway Signals
- Document new MCP tools on the MCP server and agent skills pages

## Test plan
- [ ] Preview docs site renders feature flags page
- [ ] MCP docs list matches deployed tool names


Made with [Cursor](https://cursor.com)