### PR TITLE
docs: route support from Discord to Central Station

### DIFF
--- a/content/docs/access/accounts.md
+++ b/content/docs/access/accounts.md
@@ -76,10 +76,6 @@ Within Account settings, link a Discord account with a Railway account to gain a
 
 If the Discord user has not joined the Railway Discord server, linking the account will automatically invite the user to the server.
 
-### Discord support
-
-Discord users can access the <a href="https://discord.gg/railway" target="_blank">Railway Discord server</a> to get help from the Railway team and other users.
-
 ### Priority boarding enrollment
 
 For the most adventurous, we offer a beta program called Priority Boarding. You can join by flipping the "Priority Boarding" switch on the <a href="https://railway.com/account/feature-flags" target="_blank">Feature Flags page</a>. To learn more, visit [Priority Boarding](/platform/priority-boarding).

--- a/content/docs/community/the-conductor-program.md
+++ b/content/docs/community/the-conductor-program.md
@@ -9,11 +9,11 @@ This program aims to foster collaboration and help Railway's Conductors grow.
 
 ## What do conductors do?
 
-Railway's Conductors spend time in Discord and the Central Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
+Railway's Conductors spend time in the Central Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
 
 Here are a few key ways they contribute -
 
-- Providing community support through [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
+- Providing community support through the [Central Station](https://station.railway.com/).
 
 - Maintaining a healthy and welcoming community atmosphere while moderating the Railway channels and templates.
 
@@ -35,7 +35,7 @@ Here's what we look for in potential Conductors -
 
 - Maintain professional and friendly communication.
 
-- Are active participants in the Discord and Central Station.
+- Are active participants in the Central Station.
 
 - Demonstrate strong technical problem-solving abilities.
 
@@ -59,7 +59,7 @@ As part of the program, conductors will receive -
 
 - Letters of recommendation for educational institutions and employer references.
 
-- Moderation status on [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
+- Moderation status on the [Central Station](https://station.railway.com/).
 
 - Access to a team workspace shared with other Conductors.
 
@@ -87,7 +87,7 @@ As a Conductor, you'll contribute regularly in these key areas -
 
 - Support Activities
 
-  - Helping others in [Discord](https://discord.gg/railway) and the [Central Station](https://station.railway.com/).
+  - Helping others in the [Central Station](https://station.railway.com/).
 
   - Showing consistent engagement by regularly contributing to meaningful solutions across all Railway platforms.
 

--- a/content/docs/community/the-conductor-program.md
+++ b/content/docs/community/the-conductor-program.md
@@ -9,11 +9,11 @@ This program aims to foster collaboration and help Railway's Conductors grow.
 
 ## What do conductors do?
 
-Railway's Conductors spend time in the Central Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
+Railway's Conductors spend time on Central Station answering questions, sharing tips, and making sure everyone can use Railway successfully.
 
 Here are a few key ways they contribute -
 
-- Providing community support through the [Central Station](https://station.railway.com/).
+- Providing community support on [Central Station](https://station.railway.com/).
 
 - Maintaining a healthy and welcoming community atmosphere while moderating the Railway channels and templates.
 
@@ -35,7 +35,7 @@ Here's what we look for in potential Conductors -
 
 - Maintain professional and friendly communication.
 
-- Are active participants in the Central Station.
+- Are active participants on Central Station.
 
 - Demonstrate strong technical problem-solving abilities.
 
@@ -59,7 +59,7 @@ As part of the program, conductors will receive -
 
 - Letters of recommendation for educational institutions and employer references.
 
-- Moderation status on the [Central Station](https://station.railway.com/).
+- Moderation status on [Central Station](https://station.railway.com/).
 
 - Access to a team workspace shared with other Conductors.
 
@@ -87,7 +87,7 @@ As a Conductor, you'll contribute regularly in these key areas -
 
 - Support Activities
 
-  - Helping others in the [Central Station](https://station.railway.com/).
+  - Helping others on [Central Station](https://station.railway.com/).
 
   - Showing consistent engagement by regularly contributing to meaningful solutions across all Railway platforms.
 

--- a/content/docs/integrations/api.md
+++ b/content/docs/integrations/api.md
@@ -179,4 +179,4 @@ To help you get started, we have provided example queries and mutations organize
 
 ## Support
 
-If you run into problems using the API or have any suggestions, feel free to join the [Railway Discord server](https://discord.gg/railway) where you can interact with the engineers working on the API directly.
+If you run into problems using the API or have any suggestions, feel free to reach out on [Central Station](https://station.railway.com) where the team can help you directly.

--- a/content/docs/networking/domains/working-with-domains.md
+++ b/content/docs/networking/domains/working-with-domains.md
@@ -314,4 +314,4 @@ For complete information on configuring services for private networking, see the
 
 ## Troubleshooting
 
-Having trouble with your domain configuration? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having trouble with your domain configuration? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/networking/private-networking/library-configuration.md
+++ b/content/docs/networking/private-networking/library-configuration.md
@@ -103,4 +103,4 @@ docker-entrypoint.sh mongod --ipv6 --bind_ip ::,0.0.0.0
 
 ## Adding more libraries
 
-If you encounter a library that requires specific configuration for Railway's private networking, please let us know on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a> or submit a PR to the documentation.
+If you encounter a library that requires specific configuration for Railway's private networking, please let us know on [Central Station](https://station.railway.com) or submit a PR to the documentation.

--- a/content/docs/networking/tcp-proxy.md
+++ b/content/docs/networking/tcp-proxy.md
@@ -70,4 +70,4 @@ TCP Proxy can also be used in conjunction with [Private Networking](/networking/
 
 ## Troubleshooting
 
-Having issues with your TCP proxy? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having issues with your TCP proxy? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/observability/logs.md
+++ b/content/docs/observability/logs.md
@@ -399,4 +399,4 @@ If you encounter this limit, here are some strategies to reduce your logging vol
 
 ## Troubleshooting
 
-Having issues with logs? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having issues with logs? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/observability/metrics.md
+++ b/content/docs/observability/metrics.md
@@ -68,4 +68,4 @@ The total from all replicas may differ slightly from the Sum view due to roundin
 
 ## Troubleshooting
 
-Having issues understanding your metrics? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having issues understanding your metrics? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/observability/webhooks.md
+++ b/content/docs/observability/webhooks.md
@@ -112,4 +112,4 @@ width={1466} height={810} quality={80} />
 
 ## Troubleshooting
 
-Having issues with webhooks? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having issues with webhooks? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/overview/production-readiness-checklist.md
+++ b/content/docs/overview/production-readiness-checklist.md
@@ -153,4 +153,4 @@ Being prepared for major and unexpected issues helps minimize downtime and data 
 
 Using a mix of native features and external tools, we hope you can feel confident that your applications on Railway meet the highest standards of performance, reliability, and security.
 
-Remember, the Railway team is always here to assist you with solutions. Reach out in <a href="https://discord.com/channels/713503345364697088/1006629907067064482" target="_blank">Discord</a> or over email at [team@railway.com](mailto:team@railway.com) for assistance.
+Remember, the Railway team is always here to assist you with solutions. Reach out on [Central Station](https://station.railway.com) or over email at [team@railway.com](mailto:team@railway.com) for assistance.

--- a/content/docs/platform/compare-to-bolt.md
+++ b/content/docs/platform/compare-to-bolt.md
@@ -130,6 +130,6 @@ For a step-by-step walkthrough, see [Migrate from Bolt to Railway](/platform/mig
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-digitalocean.md
+++ b/content/docs/platform/compare-to-digitalocean.md
@@ -186,6 +186,6 @@ To get started, [create an account on Railway](https://railway.com/new). You can
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-fly.md
+++ b/content/docs/platform/compare-to-fly.md
@@ -214,6 +214,6 @@ To get started, [create an account on Railway](https://railway.com/new). You can
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 For larger workloads or specific requirements, you can [book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-heroku.md
+++ b/content/docs/platform/compare-to-heroku.md
@@ -188,6 +188,6 @@ To get started, [create an account on Railway](https://railway.com/new). You can
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-lovable.md
+++ b/content/docs/platform/compare-to-lovable.md
@@ -122,6 +122,6 @@ If you're ready to move your Lovable app to Railway, just connect your GitHub re
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-render.md
+++ b/content/docs/platform/compare-to-render.md
@@ -183,6 +183,6 @@ To get started, [create an account on Railway](https://railway.com/new). You can
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-replit.md
+++ b/content/docs/platform/compare-to-replit.md
@@ -157,6 +157,6 @@ For a step-by-step walkthrough, see [Migrate from Replit to Railway](/platform/m
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-vercel.md
+++ b/content/docs/platform/compare-to-vercel.md
@@ -210,6 +210,6 @@ To get started, [create an account on Railway](https://railway.com/new). You can
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/compare-to-vps.md
+++ b/content/docs/platform/compare-to-vps.md
@@ -355,6 +355,6 @@ When you need full control over the OS, kernel, and software stack, or your team
 
 ## Need help or have questions?
 
-If you need help along the way, the [Railway Discord](http://discord.gg/railway) and [Help Station](https://station.railway.com/) are great resources to get support from the team and community.
+If you need help along the way, the [Help Station](https://station.railway.com/) is a great resource to get support from the team and community.
 
 Working with a larger workload or have specific requirements? [Book a call with the Railway team](https://cal.com/team/railway/work-with-railway) to explore how we can best support your project.

--- a/content/docs/platform/incident-management.md
+++ b/content/docs/platform/incident-management.md
@@ -11,7 +11,7 @@ Railway understands the importance of effective incident management procedures. 
 
 Railway has a robust monitoring system in place to proactively detect and address any potential incidents. We continuously monitor Railway's infrastructure, including servers, networks, and applications, to ensure their smooth operation. By monitoring key metrics and performance indicators, we can identify any anomalies or potential issues before they escalate into full-blown incidents.
 
-However, it's important to note that while we strive to stay ahead of incidents, there may be situations where unforeseen issues arise. In such cases, we rely on qualitative customer feedback to help us identify and address any issues promptly. We encourage Railway's customers to report any problems they encounter through the [Railway Help Station](https://station.railway.com), [Slack](/platform/support#slack), or [Discord](https://discord.gg/railway).
+However, it's important to note that while we strive to stay ahead of incidents, there may be situations where unforeseen issues arise. In such cases, we rely on qualitative customer feedback to help us identify and address any issues promptly. We encourage Railway's customers to report any problems they encounter through the [Railway Help Station](https://station.railway.com) or [Slack](/platform/support#slack).
 
 ## Status page + uptime
 

--- a/content/docs/platform/migrate-from-heroku.md
+++ b/content/docs/platform/migrate-from-heroku.md
@@ -107,4 +107,4 @@ For more advanced operations, like migrating your databases from Heroku to Railw
 
 ## Need help?
 
-If you run into any issues, or would like help with your migrations, we would be more than happy to answer your questions on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a> or over email at [team@railway.com](mailto:team@railway.com).
+If you run into any issues, or would like help with your migrations, we would be more than happy to answer your questions on [Central Station](https://station.railway.com) or over email at [team@railway.com](mailto:team@railway.com).

--- a/content/docs/platform/migrate-from-render.md
+++ b/content/docs/platform/migrate-from-render.md
@@ -15,7 +15,7 @@ Railway offers:
 - **Flexible Deployment Options**: Use GitHub, Dockerfiles, Docker images from supported registries (Docker Hub, GitHub, RedHat, GitLab, Microsoft), or local deployments via the Railway CLI.
 - **Integrated Tools**: Simplify environment variable management, CI/CD, observability, and service scaling.
 - **Networking Features:** Public and private networking.
-- **Best in Class Support:** Very active community on [Discord](https://discord.gg/railway) and the [Railway Help Station](https://station.railway.com/).
+- **Best in Class Support:** Very active community on the [Railway Help Station](https://station.railway.com/).
 
 ..and so much more. Want to see for yourself? [Try Railway for a spin today!](https://railway.com/new)
 

--- a/content/docs/platform/support.md
+++ b/content/docs/platform/support.md
@@ -12,7 +12,7 @@ your plan level.
 ### Trial, free, hobby
 
 Users on Trial, Free, and Hobby plans receive community support through 
-[Central Station](#central-station) or [Discord](#discord). While Railway 
+[Central Station](#central-station). While Railway 
 employees may participate in community discussions, responses are not 
 guaranteed for these tiers.
 
@@ -47,13 +47,12 @@ case-by-case basis for [Business Class](#business-class) or Enterprise
 customers.
 
 For application-level support, connect with the Railway community on 
-[Central Station](https://station.railway.com) or 
-[Discord](https://discord.gg/railway).
+[Central Station](https://station.railway.com).
 
 ## Email support
 
 Railway does not provide support via email. All support requests should be 
-directed to [Central Station](#central-station) or [Discord](#discord). Email 
+directed to [Central Station](#central-station). Email 
 communication is reserved for the following specific purposes:
 
 - Sales inquiries: [team@railway.com](mailto:team@railway.com)
@@ -101,15 +100,6 @@ see them.
 Railway may make the thread public for community involvement if we determine 
 that there is no sensitive information in your thread, or if you are asking
 for [application-level support](#application-level-support).
-
-## Discord
-
-We have a vibrant Discord community of over 28,000+ users and developers. You 
-can find the Railway Discord at [https://discord.gg/railway](https://discord.gg/railway).
-
-Please ask your questions in the 
-<a href="https://discord.com/channels/713503345364697088/1006629907067064482" target="_blank">✋ ｜ help</a> 
-channel, and refrain from pinging anyone with the `Team` or `Conductor` roles.
 
 ## Slack
 

--- a/content/docs/platform/use-cases.md
+++ b/content/docs/platform/use-cases.md
@@ -90,6 +90,6 @@ Unfortunately, the Railway platform isn't yet well-equipped to handle the follow
 
 ## General recommendations
 
-A document like this can only go so far. We have a standing invitation for any team who needs an extended scale use-case to reach out to us directly by e-mailing [team@railway.com](mailto:team@railway.com), or via the [Railway Discord server](https://discord.gg/railway). You can also schedule some time with us directly by clicking [here](https://cal.com/team/railway/work-with-railway?duration=30).
+A document like this can only go so far. We have a standing invitation for any team who needs an extended scale use-case to reach out to us directly by e-mailing [team@railway.com](mailto:team@railway.com), or on [Central Station](https://station.railway.com). You can also schedule some time with us directly by clicking [here](https://cal.com/team/railway/work-with-railway?duration=30).
 
 We would be happy to answer any additional questions you may have.

--- a/content/docs/private-networking.md
+++ b/content/docs/private-networking.md
@@ -227,4 +227,4 @@ Since an application hosted on Vercel exists outside of the private network in R
 
 ## Troubleshooting
 
-Having issues with private networking? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having issues with private networking? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/public-networking.md
+++ b/content/docs/public-networking.md
@@ -77,4 +77,4 @@ To have traffic from the public internet properly forwarded to your service's ex
 
 ## Troubleshooting
 
-Having trouble connecting to your app from the internet? Check out the [Troubleshooting guide](/troubleshooting) or reach out on the <a href="https://discord.gg/railway" target="_blank">Railway Discord</a>.
+Having trouble connecting to your app from the internet? Check out the [Troubleshooting guide](/troubleshooting) or reach out on [Central Station](https://station.railway.com).

--- a/content/docs/quick-start.md
+++ b/content/docs/quick-start.md
@@ -237,4 +237,4 @@ Happy Building!
 
 ### Join the community
 
-Chat with Railway members, ask questions, and hang out in the <a href="https://discord.gg/railway" target="_blank">Railway Discord community</a> with fellow builders! We'd love to have you!
+Chat with Railway members, ask questions, and get help on [Central Station](https://station.railway.com)! We'd love to have you!

--- a/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
+++ b/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
@@ -487,4 +487,4 @@ Now that you've deployed your Node.js applications, explore these resources:
 
 ## Need help?
 
-If you have any questions or run into issues, you can reach out in the [Railway Discord](http://discord.gg/railway) community or on [Central Station](https://station.railway.com/).
+If you have any questions or run into issues, you can reach out on [Central Station](https://station.railway.com/).

--- a/content/guides/github-actions-post-deploy.md
+++ b/content/guides/github-actions-post-deploy.md
@@ -49,4 +49,4 @@ It's that simple! You can now customize the final run step to execute any comman
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or [Central Station](https://station.railway.com). Happy coding!

--- a/content/guides/github-actions-post-deploy.md
+++ b/content/guides/github-actions-post-deploy.md
@@ -49,4 +49,4 @@ It's that simple! You can now customize the final run step to execute any comman
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!

--- a/content/guides/github-actions-pr-environment.md
+++ b/content/guides/github-actions-pr-environment.md
@@ -65,4 +65,4 @@ This can very easily be modified to run commands in order to find variables and 
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or [Central Station](https://station.railway.com). Happy coding!

--- a/content/guides/github-actions-pr-environment.md
+++ b/content/guides/github-actions-pr-environment.md
@@ -65,4 +65,4 @@ This can very easily be modified to run commands in order to find variables and 
 
 ## Conclusion
 
-We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Discord](https://discord.gg/railway), [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!
+We hope this tutorial has been helpful and that you'll find it useful for your own projects. If you have any questions or feedback, please feel free to reach out to us on [Slack](/platform/support#slack) or the [Central Station](https://station.railway.com). Happy coding!

--- a/content/guides/preview-deployments-with-pr-environments.md
+++ b/content/guides/preview-deployments-with-pr-environments.md
@@ -136,4 +136,4 @@ While any infrastructure created via a PR Environment is automatically destroyed
 
 ## Conclusion
 
-You now have a project that automatically previews every PR in an isolated environment, with Focused PR Environments to keep builds fast in a monorepo and Bot PR Environments to control how bot-opened PRs are handled. If you have any questions or feedback, reach out on <a href="https://discord.gg/railway" target="_blank">Discord</a>, [Slack](/platform/support#slack), or the <a href="https://station.railway.com/" target="_blank">Central Station</a>.
+You now have a project that automatically previews every PR in an isolated environment, with Focused PR Environments to keep builds fast in a monorepo and Bot PR Environments to control how bot-opened PRs are handled. If you have any questions or feedback, reach out on [Slack](/platform/support#slack) or the <a href="https://station.railway.com/" target="_blank">Central Station</a>.

--- a/content/guides/running-agents-on-railway.md
+++ b/content/guides/running-agents-on-railway.md
@@ -179,4 +179,4 @@ Every agent in that list swaps the same three things: where it listens for input
 
 ## Conclusion
 
-You now have a project that automatically opens PRs in response to new issues, and a general framework for deploying agents on Railway. If you have any questions or feedback, reach out on <a href="https://discord.gg/railway" target="_blank">Discord</a>, [Slack](/platform/support#slack), or the <a href="https://station.railway.com/" target="_blank">Central Station</a>.
+You now have a project that automatically opens PRs in response to new issues, and a general framework for deploying agents on Railway. If you have any questions or feedback, reach out on [Slack](/platform/support#slack) or the <a href="https://station.railway.com/" target="_blank">Central Station</a>.

--- a/content/guides/static-hosting.md
+++ b/content/guides/static-hosting.md
@@ -187,4 +187,4 @@ Now that you've deployed your static site, explore these resources:
 
 ## Need help?
 
-If you have any questions or run into issues, you can reach out in the [Railway Discord](http://discord.gg/railway) community or on [Central Station](https://station.railway.com/).
+If you have any questions or run into issues, you can reach out on [Central Station](https://station.railway.com/).

--- a/public/static/faq.json
+++ b/public/static/faq.json
@@ -82,7 +82,7 @@
       "Why can't I connect to my plugin?",
       "I can't seem to connect to Postgres?"
     ],
-    "answer": "Ensure that you are using the correct connection URL. If you can't load the data panel on your plugin's dashboard - it could be an issue on our end, be sure to reach out to the team on Discord if that is the case.",
+    "answer": "Ensure that you are using the correct connection URL. If you can't load the data panel on your plugin's dashboard - it could be an issue on our end, be sure to reach out to the team on Central Station if that is the case.",
     "link": ""
   },
   "feature-requests": {

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -752,12 +752,6 @@ const Home: NextPage = () => {
                 <Icon name="XIcon" className="size-4" />
               </Link>
               <Link
-                href="https://discord.gg/railway"
-                className="text-muted-base hover:text-muted-high-contrast transition-colors"
-              >
-                <Icon name="Discord" className="size-4" />
-              </Link>
-              <Link
                 href="https://youtube.com/@railwayapp"
                 className="text-muted-base hover:text-muted-high-contrast transition-colors"
               >


### PR DESCRIPTION
Removes Discord as a community/support venue across the docs and routes users to Central Station instead. Product references to Discord (account linking, webhook Muxer, the Railway Agent Discord integration, the "deploy a Discord bot" guide) are left intact.

- Deletes the `## Discord` section on the Support page and the `#help` channel deep-links
- Swaps "reach out on the Railway Discord" support/troubleshooting CTAs to Central Station
- Drops Discord from the "Railway Discord and Help Station" support pairings
- Removes the "Discord support" subsection on the Accounts page
- Removes Discord from the Conductor Program page's community-support / moderation descriptions
- Removes the Discord social icon from the docs footer
