### PR TITLE
Link feature docs to their blog deep-dives

### DIFF
--- a/content/docs/builds/railpack.md
+++ b/content/docs/builds/railpack.md
@@ -24,7 +24,7 @@ Currently, we support the following languages out of the box:
 
 ## How it works
 
-Railpack automatically analyzes your code and turns it into a container image.
+Railpack automatically <a href="https://blog.railway.com/p/introducing-railpack" target="_blank">analyzes your code and turns it into a container image</a>.
 It detects your programming language, installs dependencies, and configures
 build and start commands without any manual configuration required.
 

--- a/content/docs/functions.md
+++ b/content/docs/functions.md
@@ -4,7 +4,7 @@ description: Write and deploy code from the Railway canvas without managing infr
 ---
 
 Write and deploy code from the Railway canvas without managing infrastructure or creating a git repository.
-Functions are [Services](/services) that run a single file of TypeScript code using the [Bun](https://bun.sh/) runtime.
+Functions are [Services](/services) that <a href="https://blog.railway.com/p/introducing-railway-functions" target="_blank">run a single file of TypeScript code</a> using the [Bun](https://bun.sh/) runtime.
 Use them like any other Service, but without the overhead of a repository.
 
 They are ideal for small tasks like handling webhooks, cron jobs, or simple APIs.

--- a/content/docs/networking/cdn.md
+++ b/content/docs/networking/cdn.md
@@ -3,7 +3,7 @@ title: CDN
 description: Cache static assets and HTML at the edge with Railway's built-in CDN to reduce latency and origin load.
 ---
 
-Railway's CDN serves your service's responses from the edge location nearest each visitor, so a cached request returns faster than a round trip to your service. It caches static assets and HTML across a global network of points of presence (POPs), which also lowers load on your service and reduces network egress costs.
+Railway's CDN serves your service's responses from the edge location nearest each visitor, so a cached request returns faster than a round trip to your service. It caches static assets and HTML across a <a href="https://blog.railway.com/p/railway-cdn" target="_blank">global network of points of presence (POPs)</a>, which also lowers load on your service and reduces network egress costs.
 
 CDN caching is available on all plans at no additional cost. It's off by default and enabled per service.
 

--- a/content/docs/platform/railway-metal.md
+++ b/content/docs/platform/railway-metal.md
@@ -4,7 +4,7 @@ description: Railway Metal is Railway’s own cloud infrastructure, built for hi
 ---
 
 Railway Metal is the next generation of Railway's underlying infrastructure.
-It is built on hardware that we own and operate in datacenters around the world.
+It is built on <a href="https://blog.railway.com/p/railway-metal-gen-2" target="_blank">hardware that we own and operate in datacenters around the world</a>.
 
 <Image
 src="https://res.cloudinary.com/railway/image/upload/v1736893474/docs/m0_homdt8.png"


### PR DESCRIPTION
## What

Step 3 of the internal linking programme: docs now link out, closing the blog → docs → deploy → docs loop. Four links, each wrapping an existing phrase (zero copy changes), using `<a target="_blank">` per the docs-writing conventions:

- **/networking/cdn** — "global network of points of presence (POPs)" → [railway-cdn](https://blog.railway.com/p/railway-cdn)
- **/platform/railway-metal** — "hardware that we own and operate in datacenters around the world" → [railway-metal-gen-2](https://blog.railway.com/p/railway-metal-gen-2)
- **/builds/railpack** — "analyzes your code and turns it into a container image" → [introducing-railpack](https://blog.railway.com/p/introducing-railpack)
- **/functions** — "run a single file of TypeScript code" → [introducing-railway-functions](https://blog.railway.com/p/introducing-railway-functions)

## Why docs → blog and not docs → deploy

Docs → deploy already exists organically: all four database pages link their deploy templates (`via the [template](railway.com/deploy/...)`), quick-start links the Umami template and the marketplace, and `build-a-database-service`/`databases/reference` link a dozen more. Docs → blog was the missing direction. These four pages document features with announcement/engineering deep-dives, and `platform/railway-metal` already sets the precedent by linking the data-center build post.

All four blog URLs verified against the blog sitemap.