### PR TITLE
docs: expand feature flags docs and add railway flag CLI reference

### DIFF
--- a/content/docs/cli/flag.md
+++ b/content/docs/cli/flag.md
@@ -3,7 +3,7 @@ title: railway flag
 description: Manage feature flags from the command line.
 ---
 
-Create, inspect, and target [feature flags](/feature-flags) for a project or workspace.
+Create, inspect, and target [feature flags](/feature-flags) for a project.
 
 <Banner variant="info">The `flag` command manages [feature flags](/feature-flags), which are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
 
@@ -17,20 +17,24 @@ railway flag <COMMAND> [OPTIONS]
 
 | Subcommand | Aliases | Description |
 |------------|---------|-------------|
-| `list` | `ls` | List feature flags for a scope |
+| `list` | `ls` | List feature flags for a project |
 | `set` | | Set a flag's default value, or attach a targeting rule with `--when` |
 | `unset` | | Remove a targeting rule from a flag |
 | `delete` | `rm`, `remove` | Delete a feature flag |
 
-## Scope
+## Target a project
 
-By default, `railway flag` targets the linked project's **workspace** scope. To manage the project-scoped flags your app reads through the SDK, pass `--scope project:<projectId>`:
+Feature flags belong to a project. Pass the project as a global option, so it works on every subcommand:
 
 ```bash
-railway flag list --scope project:<projectId>
+railway flag list --scope project:<project-id>
 ```
 
-`--scope` accepts `project:<id>` or `workspace:<id>` and is a global option, so it works on every subcommand. You can also set the `RAILWAY_FLAGS_SCOPE` variable.
+To avoid repeating the option, set `RAILWAY_FLAGS_SCOPE`. The examples below assume this variable is set:
+
+```bash
+export RAILWAY_FLAGS_SCOPE=project:<project-id>
+```
 
 ## Examples
 
@@ -106,7 +110,7 @@ Comparison operators are `==`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, and `matc
 
 | Flag | Description |
 |------|-------------|
-| `--scope <SCOPE>` | Flag scope, `project:<id>` or `workspace:<id>`. Defaults to the linked project's workspace |
+| `--scope <SCOPE>` | Project target in the format `project:<id>` |
 | `--json` | Output in JSON format |
 
 ### Options for `set`

--- a/content/docs/cli/flag.md
+++ b/content/docs/cli/flag.md
@@ -24,17 +24,18 @@ railway flag <COMMAND> [OPTIONS]
 
 ## Target a project
 
-Feature flags belong to a project. Pass the project as a global option, so it works on every subcommand:
+Create a [project token](/integrations/api#project-token) from the tokens page in your project settings, then set it as `RAILWAY_TOKEN`:
 
 ```bash
-railway flag list --scope project:<project-id>
+export RAILWAY_TOKEN=<project-token>
+railway flag list
 ```
 
-To avoid repeating the option, set `RAILWAY_FLAGS_SCOPE`. The examples below assume this variable is set:
+The CLI automatically uses the project that owns the token. You don't need to run `railway link`, set `RAILWAY_PROJECT_ID`, or pass `--scope`.
 
-```bash
-export RAILWAY_FLAGS_SCOPE=project:<project-id>
-```
+When you authenticate through `railway login` instead, run `railway link` once. The CLI uses the linked project for subsequent `railway flag` commands.
+
+With user authentication, pass `--scope project:<project-id>` only to override the locally linked project. You can also set the override with `RAILWAY_FLAGS_SCOPE=project:<project-id>`. A project token remains limited to the project that owns it.
 
 ## Examples
 
@@ -110,7 +111,7 @@ Comparison operators are `==`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, and `matc
 
 | Flag | Description |
 |------|-------------|
-| `--scope <SCOPE>` | Project target in the format `project:<id>` |
+| `--scope <SCOPE>` | Override the linked project in the format `project:<id>` |
 | `--json` | Output in JSON format |
 
 ### Options for `set`

--- a/content/docs/cli/flag.md
+++ b/content/docs/cli/flag.md
@@ -1,0 +1,145 @@
+---
+title: railway flag
+description: Manage feature flags from the command line.
+---
+
+Create, inspect, and target [feature flags](/feature-flags) for a project or workspace.
+
+<Banner variant="info">The `flag` command manages [feature flags](/feature-flags), which are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
+
+## Usage
+
+```bash
+railway flag <COMMAND> [OPTIONS]
+```
+
+## Subcommands
+
+| Subcommand | Aliases | Description |
+|------------|---------|-------------|
+| `list` | `ls` | List feature flags for a scope |
+| `set` | | Set a flag's default value, or attach a targeting rule with `--when` |
+| `unset` | | Remove a targeting rule from a flag |
+| `delete` | `rm`, `remove` | Delete a feature flag |
+
+## Scope
+
+By default, `railway flag` targets the linked project's **workspace** scope. To manage the project-scoped flags your app reads through the SDK, pass `--scope project:<projectId>`:
+
+```bash
+railway flag list --scope project:<projectId>
+```
+
+`--scope` accepts `project:<id>` or `workspace:<id>` and is a global option, so it works on every subcommand. You can also set the `RAILWAY_FLAGS_SCOPE` variable.
+
+## Examples
+
+### List flags
+
+```bash
+railway flag list
+```
+
+Add `--full` to show rule IDs and empty rule sections.
+
+### Set a flag's default
+
+The type is inferred from the value: `true` or `false` becomes `bool`, a number becomes `number`, valid JSON becomes `json`, and anything else becomes `string`.
+
+```bash
+railway flag set checkout.v2 true
+railway flag set theme "blue"
+railway flag set api-rate-limit 100
+railway flag set model-config '{"name":"small","temperature":0.2}'
+```
+
+Pass `--type` to set the type explicitly. Changing an existing flag's type clears its rules and requires `--force --type <type>`.
+
+### Attach a targeting rule
+
+`--when` adds a rule that serves the value when its condition matches, instead of changing the default. The flag must already exist.
+
+```bash
+railway flag set checkout.v2 true --when 'plan == "enterprise"'
+railway flag set checkout.v2 true --when "bucket(key) < 0.25"
+```
+
+Rules are keyed by `--rule-id`. Reuse an ID to replace a rule. Omit it and the CLI derives a stable ID from the name and expression.
+
+### Roll out to a percentage of a segment
+
+Combine conditions with `&&` and `||` in a single rule. This serves `true` to 25% of enterprise users:
+
+```bash
+railway flag set checkout.v2 true \
+  --when 'plan == "enterprise" && bucket(key) < 0.25'
+```
+
+### Remove a rule
+
+```bash
+railway flag unset checkout.v2 --rule-id enterprise-on
+```
+
+### Delete a flag
+
+```bash
+railway flag delete checkout.v2
+```
+
+## Targeting expressions
+
+`--when` takes a CEL-style expression or raw JSON.
+
+| Form | Example |
+|------|---------|
+| Comparison | `plan == "enterprise"`, `region == "us-west"` |
+| List membership | `plan in ["enterprise", "pro"]` |
+| Percentage rollout | `bucket(key) < 0.25` |
+| Boolean logic | `plan == "enterprise" && bucket(key) < 0.25`, `!(plan == "free")` |
+
+Comparison operators are `==`, `!=`, `<`, `<=`, `>`, `>=`, `contains`, and `matches`. Bucket thresholds are between 0 and 1, so `< 0.25` is 25%. Target rules on the attributes your app passes in the [evaluation context](/feature-flags#read-a-flag), like `plan` or `region`. The bucket attribute is the stable key each subject is hashed on, typically the `key` in that context.
+
+## Options
+
+### Global options
+
+| Flag | Description |
+|------|-------------|
+| `--scope <SCOPE>` | Flag scope, `project:<id>` or `workspace:<id>`. Defaults to the linked project's workspace |
+| `--json` | Output in JSON format |
+
+### Options for `set`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<NAME>` | Flag name. Letters, numbers, dots, dashes, and underscores. Required |
+| `<VALUE>` | Default value, or the rule's value when `--when` is passed. Required |
+| `--when <EXPRESSION>` | Attach a targeting rule with this condition instead of changing the default |
+| `--rule-id <ID>` | Stable rule ID for `--when`. Defaults to a hash of the name and expression |
+| `--type <TYPE>` | Flag type: `bool`, `string`, `number`, or `json`. Inferred from the value when omitted |
+| `--force` | Allow replacing an existing flag's type, which clears its rules |
+
+### Options for `list`
+
+| Flag | Description |
+|------|-------------|
+| `--full` | Show rule IDs and empty rule sections |
+
+### Options for `unset`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<NAME>` | Flag name. Required |
+| `--rule-id <ID>` | Rule ID to remove. Required |
+
+### Options for `delete`
+
+| Argument or flag | Description |
+|------------------|-------------|
+| `<NAME>` | Flag name to delete. Required |
+
+## Related
+
+- [Feature flags](/feature-flags)
+- [railway setup](/cli/setup)

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -1,11 +1,11 @@
 ---
 title: Feature Flags
-description: Define typed feature flags with targeting rules for a Railway project or workspace, and read them at runtime with the TypeScript SDK, CLI, or MCP.
+description: Define typed feature flags with targeting rules for a Railway project, and read them at runtime with the TypeScript SDK, CLI, or MCP.
 ---
 
 <Banner variant="primary">Feature Flags are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
 
-Feature flags are a typed configuration registry scoped to a project or workspace. Each flag has a default value and optional targeting rules evaluated at read time.
+Feature flags are a typed configuration registry scoped to a project. Each flag has a default value and optional targeting rules evaluated at read time.
 
 Use feature flags to:
 
@@ -33,13 +33,6 @@ const on = flags.getBoolean("checkout-v2", {
 Railway checks the flag's rules against that context. A rule like "serve `true` when plan is enterprise" matches, so `on` is `true`. For a user on the free plan, no rule matches, so `on` falls back to the flag's default.
 
 A read always returns a value: the matching rules' value when they agree, otherwise the default. Your app doesn't call Railway on every read either. The SDK keeps a copy of your flags in memory and refreshes it in the background, so reads are instant.
-
-## Flag scopes
-
-A flag belongs to one of two scopes:
-
-- **Project**: owned by a single project. Your app reads project flags through the SDK with a [project token](/integrations/api#project-token), and you manage them in the project's **Feature Flags** settings, the CLI, or MCP.
-- **Workspace**: shared across every project in a workspace. They appear read-only in a project's **Feature Flags** settings and are managed at the workspace level.
 
 ## Flag types
 
@@ -79,11 +72,11 @@ bun add railway
 
 **Note:** The SDK is under active development while feature flags are in Priority Boarding, and its API may change in breaking ways between releases.
 
-### Authentication and scope
+### Authentication
 
-The SDK needs a token and a flag scope. The recommended setup is a project token, which supplies both.
+The recommended setup uses a [project token](/integrations/api#project-token), which authenticates the SDK and identifies the project that owns the flags.
 
-Set a [project token](/integrations/api#project-token) as the `RAILWAY_TOKEN` variable on your service. The SDK reads it automatically, and Railway infers the project scope from the token, so initialization takes no arguments and no project ID:
+Set the project token as the `RAILWAY_TOKEN` variable on your service. The SDK reads it automatically and infers the project from the token:
 
 ```typescript
 import { flags } from "railway";
@@ -91,23 +84,27 @@ import { flags } from "railway";
 await flags.init();
 ```
 
-For other setups, pass options to `init()`:
+You don't need to set `RAILWAY_PROJECT_ID` or pass a project ID when you use a project token.
+
+When you pass a project token directly, set `authType` to `"project-token"`. The SDK still infers the project from the token:
 
 ```typescript
-// Pass a token explicitly instead of reading it from the environment.
-await flags.init({ token: myToken });
-
-// An explicit project token must set authType so the SDK infers its scope.
-await flags.init({ token: myProjectToken, authType: "project-token" });
-
-// Scope to a project explicitly (needed with an account token off Railway).
-await flags.init({ scope: { projectId: "<project-id>" } });
-
-// Scope to a workspace instead of a project.
-await flags.init({ scope: { workspaceId: "<workspace-id>" } });
+await flags.init({
+  token: myProjectToken,
+  authType: "project-token",
+});
 ```
 
-Token resolution order is the explicit `token` option, then `RAILWAY_TOKEN` (project token, recommended), then `RAILWAY_API_TOKEN` (account or workspace bearer token). On Railway, `RAILWAY_PROJECT_ID` is injected and used as the scope when you authenticate with an account token. Without a resolvable scope, `init()` throws.
+An account token doesn't identify a project. If you use one instead, pass the project explicitly or rely on the `RAILWAY_PROJECT_ID` variable injected into Railway deployments:
+
+```typescript
+await flags.init({
+  token: myAccountToken,
+  scope: { projectId: "<project-id>" },
+});
+```
+
+Token resolution order is the explicit `token` option, then `RAILWAY_TOKEN` (project token, recommended), then `RAILWAY_API_TOKEN` (account token). Without a project token or an explicit or injected project ID, `init()` throws.
 
 ### Read a flag
 
@@ -155,7 +152,7 @@ const { value, reason, trace } = flags.evaluateBoolean(
 Combine attribute targeting with a percentage rollout to ship progressively. Create a rule that serves `true` to 25% of enterprise users with the [CLI](/cli/flag):
 
 ```bash
-railway flag set checkout-v2 true --scope project:<projectId> \
+railway flag set checkout-v2 true --scope project:<project-id> \
   --when 'plan == "enterprise" && bucket(key) < 0.25'
 ```
 
@@ -178,16 +175,19 @@ A rule that buckets on `key` needs a `key` in the read context. Without one, the
 Manage flags with `railway flag`. See the [full command reference](/cli/flag) for every subcommand and option.
 
 ```bash
-railway flag list
-railway flag set checkout.v2 true
-railway flag set theme "blue"
-railway flag set checkout.v2 true --when 'plan == "enterprise"'
-railway flag set checkout.v2 true --when "bucket(key) < 0.25"
-railway flag unset checkout.v2 --rule-id enterprise-on
-railway flag delete checkout.v2
+railway flag list --scope project:<project-id>
+railway flag set checkout.v2 true --scope project:<project-id>
+railway flag set theme "blue" --scope project:<project-id>
+railway flag set checkout.v2 true --scope project:<project-id> \
+  --when 'plan == "enterprise"'
+railway flag set checkout.v2 true --scope project:<project-id> \
+  --when "bucket(key) < 0.25"
+railway flag unset checkout.v2 --scope project:<project-id> \
+  --rule-id enterprise-on
+railway flag delete checkout.v2 --scope project:<project-id>
 ```
 
-`railway flag` defaults to the linked project's **workspace** scope. To manage the project-scoped flags your app reads through the SDK, pass `--scope project:<projectId>`. Use `--json` for machine-readable output.
+Pass `--scope project:<project-id>` to target the project that owns the flags. You can set `RAILWAY_FLAGS_SCOPE=project:<project-id>` to avoid repeating the option. Use `--json` for machine-readable output.
 
 ## AI agents and MCP
 

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -152,7 +152,7 @@ const { value, reason, trace } = flags.evaluateBoolean(
 Combine attribute targeting with a percentage rollout to ship progressively. Create a rule that serves `true` to 25% of enterprise users with the [CLI](/cli/flag):
 
 ```bash
-railway flag set checkout-v2 true --scope project:<project-id> \
+railway flag set checkout-v2 true \
   --when 'plan == "enterprise" && bucket(key) < 0.25'
 ```
 
@@ -174,20 +174,21 @@ A rule that buckets on `key` needs a `key` in the read context. Without one, the
 
 Manage flags with `railway flag`. See the [full command reference](/cli/flag) for every subcommand and option.
 
+Create a [project token](/integrations/api#project-token) and set it as `RAILWAY_TOKEN`. The CLI identifies the project from the token, so you don't need to run `railway link`, set `RAILWAY_PROJECT_ID`, or pass a project ID:
+
 ```bash
-railway flag list --scope project:<project-id>
-railway flag set checkout.v2 true --scope project:<project-id>
-railway flag set theme "blue" --scope project:<project-id>
-railway flag set checkout.v2 true --scope project:<project-id> \
-  --when 'plan == "enterprise"'
-railway flag set checkout.v2 true --scope project:<project-id> \
-  --when "bucket(key) < 0.25"
-railway flag unset checkout.v2 --scope project:<project-id> \
-  --rule-id enterprise-on
-railway flag delete checkout.v2 --scope project:<project-id>
+export RAILWAY_TOKEN=<project-token>
+
+railway flag list
+railway flag set checkout.v2 true
+railway flag set theme "blue"
+railway flag set checkout.v2 true --when 'plan == "enterprise"'
+railway flag set checkout.v2 true --when "bucket(key) < 0.25"
+railway flag unset checkout.v2 --rule-id enterprise-on
+railway flag delete checkout.v2
 ```
 
-Pass `--scope project:<project-id>` to target the project that owns the flags. You can set `RAILWAY_FLAGS_SCOPE=project:<project-id>` to avoid repeating the option. Use `--json` for machine-readable output.
+When you authenticate through `railway login` instead, the CLI uses the project linked with `railway link`. Use `--json` for machine-readable output.
 
 ## AI agents and MCP
 

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -1,56 +1,193 @@
 ---
 title: Feature Flags
-description: Define typed feature flags with targeting rules for your Railway projects.
+description: Define typed feature flags with targeting rules for a Railway project or workspace, and read them at runtime with the TypeScript SDK, CLI, or MCP.
 ---
 
-Feature flags are a typed configuration registry scoped to your project. Each flag has a default value and optional targeting rules evaluated at read time.
+<Banner variant="primary">Feature Flags are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+Feature flags are a typed configuration registry scoped to a project or workspace. Each flag has a default value and optional targeting rules evaluated at read time.
 
 Use feature flags to:
 
-- Ship a risky rewrite dark and flip it on for your own team before anyone else sees it
-- Roll a new pricing model or algorithm out to 10% of users, watch metrics, then go wide
-- Gate enterprise-only capabilities by plan without maintaining separate builds
-- Kill switch an expensive endpoint or flip on `maintenance-mode` mid-incident without a deploy
-- Tune runtime knobs — rate limits, batch sizes, model parameters — as `number` or `json` values that change without redeploying
+- Enable a feature for your team before rolling it out to everyone
+- Roll out a new pricing model or algorithm to 10% of users and adjust based on metrics
+- Gate capabilities by plan without maintaining separate builds
+- Turn off an expensive endpoint or enable maintenance mode without a deploy
+- Change runtime values like rate limits or batch sizes without redeploying
 
 Feature flags are not environment variables. For static per-environment secrets and config, use [Variables](/variables).
 
+## How it works
+
+Each flag has a default value and, optionally, some rules. A rule is a condition plus the value to serve when that condition is true.
+
+When your app reads a flag, it passes context about who's asking, then gets a value back:
+
+```typescript
+const on = flags.getBoolean("checkout-v2", {
+  key: "user_8f3a",
+  plan: "enterprise",
+});
+```
+
+Railway checks the flag's rules against that context. A rule like "serve `true` when plan is enterprise" matches, so `on` is `true`. For a user on the free plan, no rule matches, so `on` falls back to the flag's default.
+
+A read always returns a value: the matching rules' value when they agree, otherwise the default. Your app doesn't call Railway on every read either. The SDK keeps a copy of your flags in memory and refreshes it in the background, so reads are instant.
+
+## Flag scopes
+
+A flag belongs to one of two scopes:
+
+- **Project**: owned by a single project. Your app reads project flags through the SDK with a [project token](/integrations/api#project-token), and you manage them in the project's **Feature Flags** settings, the CLI, or MCP.
+- **Workspace**: shared across every project in a workspace. They appear read-only in a project's **Feature Flags** settings and are managed at the workspace level.
+
+## Flag types
+
+Every flag has one of four types, fixed when you create it.
+
+| Type | Use it for | Example default |
+|---|---|---|
+| `bool` | On/off gates and kill switches | `false` |
+| `string` | Variants, modes, or a single string value | `"classic"` |
+| `number` | Runtime knobs like rate limits or batch sizes | `100` |
+| `json` | Structured config read as one object | `{"model":"small"}` |
+
 ## Dashboard
 
-1. Open a project → **Settings → Feature Flags**
-2. Create a flag: name, type (`bool`, `string`, `number`, `json`), default, and optional targeting rules
-3. Project admins can create, edit, and delete flags
+Manage project flags from the dashboard:
+
+1. Open a project, then navigate to **Settings → Feature Flags**.
+2. Click **Create flag**, then set a name, type, default value, and optional targeting rules.
+3. Project admins can create, edit, and delete flags. Members with read access can view them.
 
 ### Targeting rules
 
-Each rule has:
+A rule has a **When** condition and a **Serve** value. The condition is one of:
 
-- **Attribute** — compare a context attribute (for example `plan`)
-- **Rollout %** — bucket on a key attribute with a percentage threshold
-- **Serve** — value returned when the rule matches
+- **Attribute**: compare a context attribute against a value, for example `plan` equals `enterprise`.
+- **Rollout %**: enter a **Key** attribute to hash on and a percentage. The rule matches that share of subjects, held stable by the key.
 
-All matching rules must agree on the served value; otherwise the default wins.
+Add several rules to a flag to layer targeting. All matching rules must agree on the served value; otherwise the default wins. The dashboard builder writes one condition per rule. To combine conditions in a single rule with `AND`/`OR`, use the [CLI](/cli/flag) or API.
 
-## Railway TypeScript SDK
+## TypeScript SDK
 
-Install the [Railway TypeScript SDK](https://github.com/railwayapp/railway-ts-sdk) and set a [project token](/integrations/api#project-token) as the `RAILWAY_TOKEN` variable on your service. Initialization is then zero-config — the project token authenticates the SDK and pins the flag scope to its project:
+Read flags at runtime with the [Railway TypeScript SDK](https://github.com/railwayapp/railway-ts-sdk), which is <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>.
+
+```bash
+bun add railway
+```
+
+**Note:** The SDK is under active development while feature flags are in Priority Boarding, and its API may change in breaking ways between releases.
+
+### Authentication and scope
+
+The SDK needs a token and a flag scope. The recommended setup is a project token, which supplies both.
+
+Set a [project token](/integrations/api#project-token) as the `RAILWAY_TOKEN` variable on your service. The SDK reads it automatically, and Railway infers the project scope from the token, so initialization takes no arguments and no project ID:
 
 ```typescript
 import { flags } from "railway";
 
 await flags.init();
-
-// Context is a flat bag of attributes; `key` is the stable identity
-// used for percentage rollouts.
-const enabled = flags.getBoolean("checkout-v2", { key: userId, plan: "enterprise" }, false);
-
-// evaluate* variants also return the resolution reason and rule trace.
-const limit = flags.evaluateNumber("api-rate-limit", { key: userId }, 100);
 ```
 
-The SDK polls the registry in the background and evaluates flags in-process, so reads are synchronous and never block a request.
+For other setups, pass options to `init()`:
 
-Token resolution order: explicit `token` option → `RAILWAY_TOKEN` (project token, recommended) → `RAILWAY_API_TOKEN` (account bearer token, last resort).
+```typescript
+// Pass a token explicitly instead of reading it from the environment.
+await flags.init({ token: myToken });
+
+// An explicit project token must set authType so the SDK infers its scope.
+await flags.init({ token: myProjectToken, authType: "project-token" });
+
+// Scope to a project explicitly (needed with an account token off Railway).
+await flags.init({ scope: { projectId: "<project-id>" } });
+
+// Scope to a workspace instead of a project.
+await flags.init({ scope: { workspaceId: "<workspace-id>" } });
+```
+
+Token resolution order is the explicit `token` option, then `RAILWAY_TOKEN` (project token, recommended), then `RAILWAY_API_TOKEN` (account or workspace bearer token). On Railway, `RAILWAY_PROJECT_ID` is injected and used as the scope when you authenticate with an account token. Without a resolvable scope, `init()` throws.
+
+### Read a flag
+
+Reads are synchronous. Pass the flag name, an evaluation context, and a fallback:
+
+```typescript
+// bool: gate a feature
+const checkoutV2 = flags.getBoolean("checkout-v2", { key: userId }, false);
+
+// string: pick a variant
+const theme = flags.getString("ui-theme", { key: userId }, "classic");
+
+// number: tune a runtime knob without redeploying
+const rateLimit = flags.getNumber("api-rate-limit", { key: userId }, 100);
+
+// json: read structured config as one object
+const model = flags.getJson<{ name: string; temperature: number }>(
+  "model-config",
+  { key: userId },
+  { name: "small", temperature: 0.2 },
+);
+```
+
+The context is a flat bag of attributes. `key` is the stable identity used for percentage rollouts. Any other attributes, like `plan` or `region`, are matched against targeting rules.
+
+**Note:** The fallback is returned only when the flag can't be read: the registry hasn't synced yet, the flag doesn't exist, or its type doesn't match. When the flag exists but no rule matches, the read returns the flag's configured default.
+
+### Inspect a resolution
+
+Each read has an `evaluate*` variant that returns the value along with why it resolved that way:
+
+```typescript
+const { value, reason, trace } = flags.evaluateBoolean(
+  "checkout-v2",
+  { key: userId },
+  false,
+);
+// reason: "TARGETING_MATCH", "SPLIT", "NO_MATCH", "NOT_FOUND", ...
+```
+
+`trace` lists each rule that was checked and whether it matched, which is useful when a flag doesn't resolve the way you expect.
+
+### Roll out to a percentage of a segment
+
+Combine attribute targeting with a percentage rollout to ship progressively. Create a rule that serves `true` to 25% of enterprise users with the [CLI](/cli/flag):
+
+```bash
+railway flag set checkout-v2 true --scope project:<projectId> \
+  --when 'plan == "enterprise" && bucket(key) < 0.25'
+```
+
+Your app reads the flag with the same attributes the rule targets:
+
+```typescript
+const enabled = flags.getBoolean(
+  "checkout-v2",
+  { key: userId, plan: user.plan },
+  false,
+);
+```
+
+Bucketing is deterministic, so the same subject stays in or out of the rollout across reads. Raise the threshold to widen the rollout, with no deploy.
+
+A rule that buckets on `key` needs a `key` in the read context. Without one, the flag returns its default instead of applying the rollout, so a missing key never rolls a feature out at random. The bucket attribute doesn't have to be `key`: you can hash on any attribute you pass, such as `accountId`. Passing `{ key: ... }` is the convention, and it also exposes the value as `targetingKey`. In the dashboard, the rollout rule's **Key** field is where you name the attribute to hash on.
+
+## CLI
+
+Manage flags with `railway flag`. See the [full command reference](/cli/flag) for every subcommand and option.
+
+```bash
+railway flag list
+railway flag set checkout.v2 true
+railway flag set theme "blue"
+railway flag set checkout.v2 true --when 'plan == "enterprise"'
+railway flag set checkout.v2 true --when "bucket(key) < 0.25"
+railway flag unset checkout.v2 --rule-id enterprise-on
+railway flag delete checkout.v2
+```
+
+`railway flag` defaults to the linked project's **workspace** scope. To manage the project-scoped flags your app reads through the SDK, pass `--scope project:<projectId>`. Use `--json` for machine-readable output.
 
 ## AI agents and MCP
 
@@ -75,22 +212,7 @@ Set the checkout-v2 feature flag default to true on project <projectId>
 
 Install agent tooling with `railway setup agent --remote`. See [Railway MCP Server](/ai/mcp-server) and [Agent Skills](/ai/agent-skills).
 
-## CLI
-
-Manage flags with `railway flag`:
-
-```bash
-railway flag list
-railway flag set checkout.v2 true
-railway flag set theme "blue"
-railway flag set checkout.v2 true --when 'plan == "enterprise"'
-railway flag set checkout.v2 true --when "bucket(user_id) < 0.25"
-railway flag unset checkout.v2 --rule-id enterprise-on
-railway flag delete checkout.v2
-```
-
-`--when` attaches a targeting rule instead of changing the default. Use `--json` for machine-readable output.
-
 ## Related
 
-- [Variables](/variables) — environment-scoped configuration
+- [railway flag](/cli/flag) (CLI command reference)
+- [Variables](/variables) (environment-scoped configuration)

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -259,6 +259,7 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("domain"),
       makeCliCommand("down"),
       makeCliCommand("environment"),
+      makeCliCommand("flag"),
       makeCliCommand("functions"),
       makeCliCommand("init"),
       makeCliCommand("link"),


### PR DESCRIPTION
## Summary

Expands the Feature Flags documentation with the details needed to use the Priority Boarding preview without reading the source.

- Adds the preview disclaimer, flag types, targeting behavior, per-type SDK examples, resolution traces, and percentage rollout examples.
- Clarifies that project tokens identify their project automatically, so `RAILWAY_PROJECT_ID`, `railway link`, and an explicit project ID aren't needed.
- Keeps the public documentation focused on project-scoped flags.
- Adds a dedicated `railway flag` CLI reference and project-token setup.
- Adds the CLI page to the sidebar.

## Docs

- `content/docs/feature-flags.md`
- `content/docs/cli/flag.md`
- `src/data/sidebar.ts`
