### PR TITLE
docs(cli): document railway connect --tunnel-only

### DIFF
--- a/content/docs/cli/connect.md
+++ b/content/docs/cli/connect.md
@@ -16,6 +16,10 @@ railway connect [SERVICE_NAME] [OPTIONS]
 | Flag | Description |
 |------|-------------|
 | `-e, --environment <ENV>` | Environment to pull variables from (defaults to linked environment) |
+| `--ssh` | Tunnel to the database over SSH instead of a public TCP proxy. Auto-enabled when the service has no public proxy URL |
+| `--no-ssh` | Force the public TCP proxy path and never fall back to SSH. Conflicts with `--ssh` |
+| `--tunnel-only` | Open the local tunnel without launching a database client; prints connection details for external tools and holds the tunnel open until Ctrl+C. Implies `--ssh` |
+| `-P, --port <PORT>` | Local port to bind for the SSH tunnel (defaults to an ephemeral port) |
 
 ## Supported databases
 
@@ -48,16 +52,25 @@ railway connect postgres
 railway connect postgres --environment staging
 ```
 
+### Point an external GUI client (TablePlus, DBeaver, pgAdmin, ...) at the database
+
+```bash
+railway connect postgres --tunnel-only
+```
+
+Opens a local SSH tunnel to the database and prints the host, port, user, password, database, and full connection URL, then holds the tunnel open until Ctrl+C. Use this when you want to point a GUI client at the database instead of an interactive shell.
+
 ## Requirements
 
-- The database must have a [TCP Proxy](/networking/tcp-proxy) enabled (public URL)
-- The appropriate database client must be installed on your machine
+- The appropriate database client must be installed on your machine, unless using `--tunnel-only`
+- If the database has no public [TCP Proxy](/networking/tcp-proxy), `railway connect` automatically tunnels over SSH instead — no public URL required
 
 ## How it works
 
 1. Detects the database type from the service's image
 2. Fetches connection variables (`DATABASE_PUBLIC_URL`, `REDIS_PUBLIC_URL`, etc.)
-3. Launches the appropriate database client with the connection string
+3. If the service has a public TCP Proxy and `--ssh`/`--tunnel-only` weren't passed, launches the appropriate database client directly against it
+4. Otherwise, opens a local SSH tunnel into the service and either launches the database client against the tunnel, or — with `--tunnel-only` — prints the connection details for an external client and holds the tunnel open
 
 ## Related
 


### PR DESCRIPTION
## Summary
- Documents the new `--ssh`/`--no-ssh`/`--tunnel-only`/`-P` flags on `railway connect` ([cli#1018](https://github.com/railwayapp/cli/pull/1018)).
- Adds an example for pointing external GUI clients (TablePlus, DBeaver, pgAdmin) at a database via `--tunnel-only`.
- Updates the Requirements/How it works sections to reflect the SSH-tunnel fallback when a service has no public TCP proxy.