### PR TITLE
docs(workspaces): allow Members to modify service settings in role matrix

### DIFF
--- a/content/docs/projects/workspaces.md
+++ b/content/docs/projects/workspaces.md
@@ -33,7 +33,7 @@ There are three roles for Workspace members:
 | Creating variables           |  ✔️   |   ✔️   |    ❌    |
 | Modifying variables          |  ✔️   |   ✔️   |    ❌    |
 | Deleting variables           |  ✔️   |   ✔️   |    ❌    |
-| Modifying service settings   |  ✔️   |   ❌   |    ❌    |
+| Modifying service settings   |  ✔️   |   ✔️   |    ❌    |
 | Creating services            |  ✔️   |   ✔️   |    ❌    |
 | Deleting services            |  ✔️   |   ❌   |    ❌    |
 | Viewing logs                 |  ✔️   |   ✔️   |    ❌    |


### PR DESCRIPTION
The workspace role matrix listed "Modifying service settings" as Admin-only, but the `serviceUpdate` and `serviceInstanceUpdate` resolvers gate at `minRoleRequired: "MEMBER"`. Workspace Members can already modify service settings, so this corrects the docs to match actual behavior.

Surfaced by a bug bounty report; confirmed intended behavior with the team (docs were wrong, not the code).

## Changes
- `content/docs/projects/workspaces.md`: role matrix, "Modifying service settings" row, Member column `❌` → `✔️`