### PR TITLE
fix(seo): make llms.txt/llms-full.txt cover all content, fix sitemap additionalPaths

### DIFF
--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -6,9 +6,12 @@ module.exports = {
     policies: [
       { userAgent: "*", allow: "/" },
     ],
-    additionalPaths: async () => [
-      { route: "/llms.txt", changefreq: "daily", priority: 0.9 },
-      { route: "/llms-full.txt", changefreq: "daily", priority: 0.9 },
-    ],
   },
+  // additionalPaths is a top-level next-sitemap option taking sitemap fields
+  // ({ loc, ... }); nested inside robotsTxtOptions (with `route` keys) it was
+  // silently ignored and llms.txt never reached the sitemap.
+  additionalPaths: async () => [
+    { loc: "/llms.txt", changefreq: "daily", priority: 0.9 },
+    { loc: "/llms-full.txt", changefreq: "daily", priority: 0.9 },
+  ],
 };

--- a/src/pages/api/llms-full.txt.ts
+++ b/src/pages/api/llms-full.txt.ts
@@ -1,7 +1,7 @@
 import type { NextApiHandler } from "next";
 import { allPages, allGuides } from "content-collections";
 import { sidebarContent } from "@/data/sidebar";
-import { IPage, ISidebarSection } from "@/types";
+import { ISidebarSection } from "@/types";
 
 const BASE_URL = "https://docs.railway.com";
 
@@ -13,8 +13,14 @@ const SUMMARY =
 
 type SourcePage = {
   url: string;
+  title: string;
   description?: string;
   body: { raw: string };
+};
+
+type PageRef = {
+  title: string;
+  slug: string;
 };
 
 function buildSourceMap(): Map<string, SourcePage> {
@@ -48,9 +54,11 @@ function demoteHeadings(markdown: string, levels: number): string {
 }
 
 function renderPage(
-  page: IPage,
+  page: PageRef,
   sources: Map<string, SourcePage>,
+  emitted: Set<string>,
 ): string[] {
+  emitted.add(page.slug);
   const lines: string[] = [];
   const source = sources.get(page.slug);
   const url = `${BASE_URL}${page.slug}.md`;
@@ -78,6 +86,7 @@ function renderPage(
 function renderSection(
   section: ISidebarSection,
   sources: Map<string, SourcePage>,
+  emitted: Set<string>,
 ): string[] {
   const lines: string[] = [];
   for (const item of section.content) {
@@ -89,14 +98,14 @@ function renderSection(
           : item.subTitle.title;
       lines.push(`---`, `<!-- ${label} -->`, "");
       if (typeof item.subTitle !== "string") {
-        lines.push(...renderPage(item.subTitle, sources));
+        lines.push(...renderPage(item.subTitle, sources, emitted));
       }
       for (const page of item.pages) {
         if ("url" in page) continue;
-        lines.push(...renderPage(page, sources));
+        lines.push(...renderPage(page, sources, emitted));
       }
     } else {
-      lines.push(...renderPage(item, sources));
+      lines.push(...renderPage(item, sources, emitted));
     }
   }
   return lines;
@@ -110,6 +119,7 @@ const handler: NextApiHandler = (_req, res) => {
   );
 
   const sources = buildSourceMap();
+  const emitted = new Set<string>();
   const parts: string[] = [];
 
   parts.push("# Railway Documentation");
@@ -121,8 +131,44 @@ const handler: NextApiHandler = (_req, res) => {
     if (section.title) {
       parts.push(`## ${section.title}`);
       parts.push("");
+      // Section hubs (e.g. /platform) are real pages, but the sidebar only
+      // carries them as a section `slug`, so render them explicitly.
+      const hub = section.slug ? sources.get(section.slug) : undefined;
+      if (hub) {
+        parts.push(...renderPage({ title: hub.title, slug: hub.url }, sources, emitted));
+      }
     }
-    parts.push(...renderSection(section, sources));
+    parts.push(...renderSection(section, sources, emitted));
+  }
+
+  // The sidebar is a curated subset; anything it does not surface would
+  // otherwise silently vanish from this file (49 of 85 guides at the time
+  // of writing). Emit the remainder so coverage never depends on curation.
+  const missedGuides = allGuides.filter((guide) => !emitted.has(guide.url));
+  const missedPages = allPages.filter((page) => !emitted.has(page.url));
+
+  if (missedGuides.length > 0) {
+    parts.push("## More guides");
+    parts.push("");
+    const guides = [...missedGuides].sort((a, b) =>
+      a.title.localeCompare(b.title),
+    );
+    for (const guide of guides) {
+      parts.push(
+        ...renderPage({ title: guide.title, slug: guide.url }, sources, emitted),
+      );
+    }
+  }
+
+  if (missedPages.length > 0) {
+    parts.push("## More pages");
+    parts.push("");
+    const pages = [...missedPages].sort((a, b) => a.url.localeCompare(b.url));
+    for (const page of pages) {
+      parts.push(
+        ...renderPage({ title: page.title, slug: page.url }, sources, emitted),
+      );
+    }
   }
 
   res.status(200).send(parts.join("\n"));

--- a/src/pages/api/llms.txt.ts
+++ b/src/pages/api/llms.txt.ts
@@ -1,7 +1,7 @@
 import type { NextApiHandler } from "next";
 import { allPages, allGuides } from "content-collections";
 import { sidebarContent } from "@/data/sidebar";
-import { IPage, ISidebarSection, ISubSection } from "@/types";
+import { ISidebarSection, ISubSection } from "@/types";
 
 const BASE_URL = "https://docs.railway.com";
 
@@ -11,20 +11,32 @@ const SUMMARY =
   "These docs cover deploying applications, configuring services, managing " +
   "data, networking, observability, the CLI, and integrating with Railway's API.";
 
-function buildDescriptionMap(): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const page of allPages) {
-    if (page.description) map.set(page.url, page.description);
-  }
-  for (const guide of allGuides) {
-    if (guide.description) map.set(guide.url, guide.description);
-  }
+type SourceDoc = {
+  url: string;
+  title: string;
+  description?: string;
+};
+
+type LinkTarget = {
+  title: string;
+  slug: string;
+};
+
+function buildSourceMap(): Map<string, SourceDoc> {
+  const map = new Map<string, SourceDoc>();
+  for (const page of allPages) map.set(page.url, page);
+  for (const guide of allGuides) map.set(guide.url, guide);
   return map;
 }
 
-function formatLink(page: IPage, descriptions: Map<string, string>): string {
+function formatLink(
+  page: LinkTarget,
+  sources: Map<string, SourceDoc>,
+  emitted: Set<string>,
+): string {
+  emitted.add(page.slug);
   const url = `${BASE_URL}${page.slug}.md`;
-  const description = descriptions.get(page.slug);
+  const description = sources.get(page.slug)?.description;
   return description
     ? `- [${page.title}](${url}): ${description}`
     : `- [${page.title}](${url})`;
@@ -32,7 +44,8 @@ function formatLink(page: IPage, descriptions: Map<string, string>): string {
 
 function renderSection(
   section: ISidebarSection,
-  descriptions: Map<string, string>,
+  sources: Map<string, SourceDoc>,
+  emitted: Set<string>,
 ): string[] {
   const lines: string[] = [];
   const subsections: ISubSection[] = [];
@@ -42,7 +55,7 @@ function renderSection(
     if ("subTitle" in item) {
       subsections.push(item);
     } else {
-      lines.push(formatLink(item, descriptions));
+      lines.push(formatLink(item, sources, emitted));
     }
   }
 
@@ -53,16 +66,19 @@ function renderSection(
     lines.push(`### ${subTitle}`);
     lines.push("");
     if (typeof sub.subTitle !== "string") {
-      lines.push(formatLink(sub.subTitle, descriptions));
+      lines.push(formatLink(sub.subTitle, sources, emitted));
     }
     for (const page of sub.pages) {
       if ("url" in page) continue;
-      lines.push(formatLink(page, descriptions));
+      lines.push(formatLink(page, sources, emitted));
     }
   }
 
   return lines;
 }
+
+const topicLabel = (topic: string) =>
+  topic === "ai" ? "AI" : topic.charAt(0).toUpperCase() + topic.slice(1);
 
 const handler: NextApiHandler = (_req, res) => {
   res.setHeader("Content-Type", "text/plain; charset=utf-8");
@@ -71,7 +87,8 @@ const handler: NextApiHandler = (_req, res) => {
     "public, s-maxage=3600, stale-while-revalidate=3600",
   );
 
-  const descriptions = buildDescriptionMap();
+  const sources = buildSourceMap();
+  const emitted = new Set<string>();
   const parts: string[] = [];
 
   parts.push("# Railway Documentation");
@@ -89,12 +106,59 @@ const handler: NextApiHandler = (_req, res) => {
     if (section.title) {
       parts.push(`## ${section.title}`);
       parts.push("");
-      parts.push(...renderSection(section, descriptions));
+      // Section hubs (e.g. /platform) are real pages, but the sidebar only
+      // carries them as a section `slug`, so link them explicitly.
+      const hub = section.slug ? sources.get(section.slug) : undefined;
+      if (hub) {
+        parts.push(formatLink({ title: hub.title, slug: hub.url }, sources, emitted));
+      }
+      parts.push(...renderSection(section, sources, emitted));
       parts.push("");
     } else {
-      parts.push(...renderSection(section, descriptions));
+      parts.push(...renderSection(section, sources, emitted));
       parts.push("");
     }
+  }
+
+  // The sidebar is a curated subset; anything it does not surface would
+  // otherwise silently vanish from this index (49 of 85 guides at the time
+  // of writing). Emit the remainder so coverage never depends on curation.
+  const missedGuides = allGuides.filter((guide) => !emitted.has(guide.url));
+  const missedPages = allPages.filter((page) => !emitted.has(page.url));
+
+  if (missedGuides.length > 0) {
+    parts.push("## More guides");
+    parts.push("");
+    const byTopic = new Map<string, typeof missedGuides>();
+    for (const guide of missedGuides) {
+      const topic = guide.topic || "other";
+      byTopic.set(topic, [...(byTopic.get(topic) ?? []), guide]);
+    }
+    for (const topic of Array.from(byTopic.keys()).sort()) {
+      parts.push(`### ${topicLabel(topic)}`);
+      parts.push("");
+      const guides = [...byTopic.get(topic)!].sort((a, b) =>
+        a.title.localeCompare(b.title),
+      );
+      for (const guide of guides) {
+        parts.push(
+          formatLink({ title: guide.title, slug: guide.url }, sources, emitted),
+        );
+      }
+      parts.push("");
+    }
+  }
+
+  if (missedPages.length > 0) {
+    parts.push("## More pages");
+    parts.push("");
+    const pages = [...missedPages].sort((a, b) => a.url.localeCompare(b.url));
+    for (const page of pages) {
+      parts.push(
+        formatLink({ title: page.title, slug: page.url }, sources, emitted),
+      );
+    }
+    parts.push("");
   }
 
   res.status(200).send(parts.join("\n"));


### PR DESCRIPTION
## Problem
`/llms.txt` and `/llms-full.txt` enumerate only `sidebarContent`, so anything the sidebar doesn't surface silently vanishes from both files:
- **49 of 85 guides** — including the entire AI cluster (`mcp-server`, `rag-pipeline-pgvector`, `n8n`, `multi-agent-system`, `ai-agent-workers`, …) plus `docker-compose`, `supabase`, `strapi`, etc.
- **All 15 section hub pages** (`/platform`, `/pricing`, `/enterprise`, `/ai`, `/cli`, …) — sections carry them only as a `slug`, and `renderSection` never emits section roots
- **5 other pages** (`/databases/postgresql-ha`, `/private-networking`, `/public-networking`, `/networking/private-networking/how-it-works`, `/reference/migrate-to-railway-metal`)

Separately, `next-sitemap.config.js` nested `additionalPaths` inside `robotsTxtOptions` (with `route` keys), where next-sitemap silently ignores it — so the llms endpoints never reached the sitemap.

## Change
- Track emitted URLs during the sidebar walk, link each titled section's hub page explicitly, then append everything remaining in `allPages`/`allGuides` under **More guides** (grouped by guide `topic`) and **More pages**. Coverage no longer depends on sidebar curation — new content files are included automatically.
- Same emitted-set approach in `llms-full.txt.ts`, appending full page bodies for the remainder.
- Move `additionalPaths` to the top level with `loc` fields so `/llms.txt` and `/llms-full.txt` are emitted into the sitemap.

The curated sidebar ordering/sections are preserved for everything the sidebar does list.

## Validation
- `tsc -p .` passes
- Ran `next dev` locally: `/llms.txt` lists **325/325** content URLs (0 guides / 0 pages missing, previously 256) and `/llms-full.txt` renders a `Source:` block for each