### PR TITLE
fix: restore CDN caching by only routing markdown requests to /dynamic

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -42,14 +42,24 @@ export function middleware(request: NextRequest) {
     prefersMarkdown(request.headers.get("accept") || "") ||
     isAIAgent(request.headers.get("user-agent") || "");
 
-  const url = request.nextUrl.clone();
-  url.pathname = "/dynamic" + pagePath;
+  // Only rewrite to /dynamic (SSR) when markdown is actually needed;
+  // otherwise let the request fall through to SSG pages for CDN caching.
   if (wantsMarkdown) {
+    const url = request.nextUrl.clone();
+    url.pathname = "/dynamic" + pagePath;
     url.searchParams.set("format", "md");
+    const response = NextResponse.rewrite(url);
+    response.headers.set("Vary", "Accept, User-Agent");
+    return response;
   }
-  const response = NextResponse.rewrite(url);
-  // Ensure CDN/proxies cache HTML and markdown separately
+
+  // HTML path: pass through to SSG with CDN-friendly cache headers
+  const response = NextResponse.next();
   response.headers.set("Vary", "Accept, User-Agent");
+  response.headers.set(
+    "Link",
+    `<https://docs.railway.com${pagePath}.md>; rel="alternate"; type="text/markdown"`,
+  );
   return response;
 }
 


### PR DESCRIPTION
## Problem

The middleware in `src/middleware.ts` unconditionally rewrites **all** known pages to `/dynamic/*`, which uses `getServerSideProps` (SSR). This forces `cache-control: private, no-cache, no-store` on every response across all ~326 URLs.

The pre-rendered SSG routes (`pages/[...slug].tsx`, `pages/guides/[...slug].tsx`) using `getStaticProps` are effectively dead code — no traffic ever reaches them.

## Fix

Only rewrite to `/dynamic/*` when the request actually wants markdown:
- `.md` extension
- `?format=md` query parameter
- `Accept: text/markdown` header preference
- AI agent user-agents (Claude, GPT, Perplexity, etc.)

Regular HTML requests now pass through to the SSG pages via `NextResponse.next()`, enabling CDN caching with proper headers.

Also adds a `Link: rel=alternate` HTTP header on the SSG HTML path so the markdown alternate URL is advertised in both HTTP headers and HTML `<head>`.

## SEO / AEO Impact

- **SEO**: CDN-cached SSG pages have significantly faster TTFB, directly improving Core Web Vitals (LCP). Google uses CWV as a ranking signal.
- **AEO**: Markdown content negotiation continues to work for AI agents through the dynamic route. The `Link: rel=alternate` header ensures discoverability.
- **Crawl efficiency**: Search engine crawlers get fast cached responses instead of hitting origin on every request.