### PR TITLE
fix(seo): PNG logos + dedupe ItemList on guides index (G15)

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -92,7 +92,7 @@ export const SEO: React.FC<Props> = ({
     "@type": "Organization",
     name: "Railway",
     url: "https://railway.com",
-    logo: "https://docs.railway.com/railway.svg",
+    logo: "https://railway.com/brand/logo-dark.png",
     sameAs: ["https://twitter.com/Railway", "https://github.com/railwayapp"],
   };
   schemas.push(organizationSchema);
@@ -145,7 +145,7 @@ export const SEO: React.FC<Props> = ({
         name: "Railway",
         logo: {
           "@type": "ImageObject",
-          url: "https://docs.railway.com/railway.svg",
+          url: "https://railway.com/brand/logo-dark.png",
         },
       },
       ...(publishedTime && { datePublished: publishedTime }),

--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -432,37 +432,14 @@ const GuidesPage: NextPage<GuidesPageProps> = ({ guides }) => {
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{
-            __html: JSON.stringify([
-              {
-                "@context": "https://schema.org",
-                "@type": "CollectionPage",
-                name: "Railway Guides",
-                description: "In-depth guides, tutorials, and how-tos for deploying on Railway",
-                url: `${baseUrl}/guides`,
-                mainEntity: {
-                  "@type": "ItemList",
-                  numberOfItems: guides.length,
-                  itemListElement: guides.map((guide, i) => ({
-                    "@type": "ListItem",
-                    position: i + 1,
-                    name: guide.title,
-                    url: `${baseUrl}${guide.url}`,
-                    item: {
-                      "@type": "Article",
-                      name: guide.title,
-                      url: `${baseUrl}${guide.url}`,
-                      description: guide.description,
-                      ...(guide.tags && guide.tags.length > 0 && {
-                        keywords: guide.tags.join(", "),
-                      }),
-                    },
-                  })),
-                },
-              },
-              {
-                "@context": "https://schema.org",
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "CollectionPage",
+              name: "Railway Guides",
+              description: "In-depth guides, tutorials, and how-tos for deploying on Railway",
+              url: `${baseUrl}/guides`,
+              mainEntity: {
                 "@type": "ItemList",
-                name: "Railway Guides",
                 numberOfItems: guides.length,
                 itemListElement: guides.map((guide, i) => ({
                   "@type": "ListItem",
@@ -480,7 +457,7 @@ const GuidesPage: NextPage<GuidesPageProps> = ({ guides }) => {
                   },
                 })),
               },
-            ]),
+            }),
           }}
         />
       </Head>


### PR DESCRIPTION
## What

Fix three structured-data issues from G15.

### Changes

1. **Organization logo SVG → PNG** — `railway.svg` → `railway.com/brand/logo-dark.png`. Google rich results require raster logos; SVGs are ignored.

2. **Publisher logo SVG → PNG** — same fix in the Article schema publisher block.

3. **Dedupe ItemList on guides index** — `guides/index.tsx` had a `CollectionPage` schema with an embedded `ItemList` (correct), plus a second standalone `ItemList` with identical content (duplicate). Removed the standalone copy.

### Risk
Low — metadata-only. The CollectionPage + embedded ItemList is the correct schema structure per Google's docs; the standalone duplicate was noise.