### PR TITLE
fix(seo): G17 — markdown-negotiation hygiene

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -8,6 +8,7 @@ import {
 import Head from "next/head";
 import { useRouter } from "next/router";
 import { Header, FAQItem } from "@/utils/seo";
+import { pageUrlSet } from "@/utils/page-url-set";
 
 export interface Props extends NextSeoProps {
   title?: string;
@@ -227,8 +228,10 @@ export const SEO: React.FC<Props> = ({
         {/* Last modification date */}
         {lastModified && <meta name="last-modified" content={lastModified} />}
 
-        {/* Markdown alternate for LLM/agent discovery */}
-        <link rel="alternate" type="text/markdown" href={`${url}.md`} />
+        {/* Markdown alternate for LLM/agent discovery — only when the .md exists */}
+        {pageUrlSet.has(router.asPath.split("?")[0].split("#")[0]) && (
+          <link rel="alternate" type="text/markdown" href={`${url}.md`} />
+        )}
 
         {/* Structured data schemas */}
         {schemas.map((schema, index) => (

--- a/src/pages/dynamic/[...slug].tsx
+++ b/src/pages/dynamic/[...slug].tsx
@@ -113,7 +113,9 @@ export const getServerSideProps = async (
       { title: page.title, description: page.description, url: page.url },
       page.body.raw,
     );
+    const htmlUrl = `https://docs.railway.com${page.url}`;
     context.res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+    context.res.setHeader("Link", `<${htmlUrl}>; rel="canonical"`);
     context.res.write(markdown);
     context.res.end();
     return { props: {} };

--- a/src/pages/dynamic/guides/[...slug].tsx
+++ b/src/pages/dynamic/guides/[...slug].tsx
@@ -104,7 +104,9 @@ export const getServerSideProps = async (
       { title: guide.title, description: guide.description, url: guide.url },
       guide.body.raw,
     );
+    const htmlUrl = `https://docs.railway.com${guide.url}`;
     context.res.setHeader("Content-Type", "text/markdown; charset=utf-8");
+    context.res.setHeader("Link", `<${htmlUrl}>; rel="canonical"`);
     context.res.write(markdown);
     context.res.end();
     return { props: {} };

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,11 +1,6 @@
 import { NextResponse } from "next/server";
 import type { NextRequest } from "next/server";
-import { allPages, allGuides } from "content-collections";
-
-const pageUrlSet = new Set([
-  ...allPages.map(page => page.url),
-  ...allGuides.map(guide => guide.url),
-]);
+import { pageUrlSet } from "@/utils/page-url-set";
 
 function prefersMarkdown(acceptHeader: string): boolean {
   const types = acceptHeader.split(",");
@@ -18,7 +13,7 @@ function prefersMarkdown(acceptHeader: string): boolean {
 
 // Known AI agent / crawler user-agent patterns
 const AI_UA_RE =
-  /claudebot|claude-web|anthropic|gptbot|chatgpt|oai-searchbot|openai|perplexitybot|perplexity|cohere|gemini|googlebot-richsnippets|meta-externalagent|bingbot.*ai|bingpreview|duckassistbot/i;
+  /claudebot|claude-web|anthropic|gptbot|chatgpt|oai-searchbot|openai|perplexitybot|perplexity|cohere|gemini|googlebot-richsnippets|meta-externalagent|duckassistbot/i;
 
 function isAIAgent(uaHeader: string): boolean {
   return AI_UA_RE.test(uaHeader);

--- a/src/utils/page-url-set.ts
+++ b/src/utils/page-url-set.ts
@@ -1,0 +1,12 @@
+import { allPages, allGuides } from "content-collections";
+
+/**
+ * Set of all page URL paths that have a corresponding `.md` representation.
+ * Used by the proxy middleware (to gate rewrites) and the SEO component
+ * (to gate the `<link rel="alternate" type="text/markdown">` tag so we
+ * never advertise a `.md` URL that would 404).
+ */
+export const pageUrlSet = new Set([
+  ...allPages.map(page => page.url),
+  ...allGuides.map(guide => guide.url),
+]);


### PR DESCRIPTION
## What
Markdown-negotiation hygiene so .md twins stay crawlable+citable but never compete with HTML in search results.

## Changes
- **Canonical Link on .md responses**: Every `.md` response now carries `Link: <html-url>; rel="canonical"` header — tells search engines the HTML version is authoritative (NOT noindex, so .md stays crawlable/citable)
- **Gate alternate tag on pageUrlSet**: The `<link rel="alternate" type="text/markdown">` tag in `seo.tsx` now only emits when the page URL exists in `pageUrlSet` — stops `/` and `/guides` from advertising `.md` URLs that 404
- **Extract pageUrlSet**: Moved the page URL set into `src/utils/page-url-set.ts` shared utility (used by both proxy middleware and SEO component)
- **Drop Bing from AI UA regex**: Removed `bingbot.*ai|bingpreview` from `AI_UA_RE` in proxy.ts — Bing was getting raw markdown instead of HTML, preventing proper indexing

## Impact
- Prevents 320+ indexable raw-text duplicates from competing with HTML pages
- Stops advertising broken `.md` alternates on non-content pages
- Fixes Bing indexing (was getting markdown instead of HTML)

Part of G17 — markdown-negotiation hygiene