### PR TITLE
Remove pricing-focused comparison callout from compare-to docs

### DIFF
--- a/content/docs/platform/compare-to-fly.md
+++ b/content/docs/platform/compare-to-fly.md
@@ -5,8 +5,6 @@ description: Compare Railway and Fly.io on deployment model, scaling, pricing an
 
 _Last updated: June 2026_
 
-> Looking for a pricing-focused comparison? See [railway.com/compare/fly](https://railway.com/compare/fly).
-
 At a high level, both Railway and Fly.io can be used to deploy your app. Both platforms share several similarities:
 
 - You can deploy your app from a Docker image or by importing your app’s source code from GitHub.

--- a/content/docs/platform/compare-to-heroku.md
+++ b/content/docs/platform/compare-to-heroku.md
@@ -5,8 +5,6 @@ description: Compare Railway and Heroku on infrastructure, pricing model and dep
 
 _Last updated: June 2026_
 
-> Looking for a pricing-focused comparison? See [railway.com/compare/heroku](https://railway.com/compare/heroku).
-
 At a high level, both Railway and Heroku can be used to deploy your app. Both platforms share many similarities:
 
 - You can deploy your app from a Docker image or by importing your app’s source code from GitHub.

--- a/content/docs/platform/compare-to-render.md
+++ b/content/docs/platform/compare-to-render.md
@@ -5,8 +5,6 @@ description: Compare Railway and Render on infrastructure, pricing model and das
 
 _Last updated: June 2026_
 
-> Looking for a pricing-focused comparison? See [railway.com/compare/render](https://railway.com/compare/render).
-
 At a high level, both Railway and Render can be used to deploy your app. Both platforms share many similarities:
 
 - You can deploy your app from a Docker image or by importing your app’s source code from GitHub.

--- a/content/docs/platform/compare-to-vercel.md
+++ b/content/docs/platform/compare-to-vercel.md
@@ -5,8 +5,6 @@ description: Compare Railway and Vercel on infrastructure, pricing model and dep
 
 _Last updated: June 2026_
 
-> Looking for a pricing-focused comparison? See [railway.com/compare/vercel](https://railway.com/compare/vercel).
-
 At a high level, both Railway and Vercel enable you to deploy your app without the hassle of managing infrastructure. Both platforms share several similarities:
 
 - Git-based automated deployments with support for instant rollbacks.


### PR DESCRIPTION
Removes the pricing-focused comparison blockquote callout from all four compare-to docs (Heroku, Fly, Vercel, Render).