### PR TITLE
fix: canonicalize networking links and deduplicate reference page titles

### DIFF
--- a/content/docs/databases/reference.md
+++ b/content/docs/databases/reference.md
@@ -1,5 +1,5 @@
 ---
-title: Databases
+title: Databases reference
 description: Database services on Railway.
 ---
 

--- a/content/docs/deployments/reference.md
+++ b/content/docs/deployments/reference.md
@@ -1,5 +1,5 @@
 ---
-title: Deployments
+title: Deployments reference
 description: Deployments are attempts to build and deliver your service. Learn how they work on Railway.
 ---
 

--- a/content/docs/deployments/troubleshooting/slow-deployments.md
+++ b/content/docs/deployments/troubleshooting/slow-deployments.md
@@ -187,7 +187,7 @@ If your application is in one region but your database is in another, every quer
 
 ### Not using private networking
 
-If services within the same project communicate over the public internet instead of [private networking](/private-networking), you add unnecessary latency and incur [egress costs](/pricing/plans#resource-usage-pricing). Private networking is for **server-to-server communication only**. It won't work for requests originating from a user's browser.
+If services within the same project communicate over the public internet instead of [private networking](/networking/private-networking), you add unnecessary latency and incur [egress costs](/pricing/plans#resource-usage-pricing). Private networking is for **server-to-server communication only**. It won't work for requests originating from a user's browser.
 
 **Symptoms:**
 - Using public URLs (e.g., `your-app.up.railway.app`) for inter-service communication

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -409,7 +409,7 @@ Set the idle timeout with `idleTimeoutMinutes` in the SDK or `--idle-timeout-min
 
 ## Networking
 
-Every sandbox has outbound internet access through a NAT gateway. Whether it can reach the rest of your environment over the [private network](/private-networking) depends on its network isolation mode, set when you create or fork it.
+Every sandbox has outbound internet access through a NAT gateway. Whether it can reach the rest of your environment over the [private network](/networking/private-networking) depends on its network isolation mode, set when you create or fork it.
 
 | Mode | Behavior |
 |------|----------|
@@ -441,7 +441,7 @@ railway sandbox forward 3000
 
 Forwarding runs over SSH, so it needs an SSH key on your Railway account. Add one at [Account Settings -> SSH Keys](https://railway.com/account/ssh-keys).
 
-To serve traffic on a public URL, deploy a [service](/services) and give it a [public domain](/public-networking).
+To serve traffic on a public URL, deploy a [service](/services) and give it a [public domain](/networking/public-networking).
 
 ## Pricing
 


### PR DESCRIPTION
## SEO/AEO canonicalization cleanup

### Problem
- 3 internal links pointed to legacy root-level paths (`/private-networking`, `/public-networking`) instead of the canonical `/networking/*` URLs, forcing unnecessary 301 redirect hops on every crawl and click
- `databases/reference.md` and `deployments/reference.md` shared identical `title` frontmatter with their parent hub pages (`databases.md` and `deployments.md`), creating title ambiguity for search engines and answer engines

### Changes
**Link fixes (3 files):**
- `slow-deployments.md:190` — `/private-networking` → `/networking/private-networking`
- `sandboxes.md:412` — `/private-networking` → `/networking/private-networking`
- `sandboxes.md:444` — `/public-networking` → `/networking/public-networking`

**Title deduplication (2 files):**
- `databases/reference.md` — `Databases` → `Databases reference`
- `deployments/reference.md` — `Deployments` → `Deployments reference`

### Impact
- Eliminates redirect-chain crawl budget waste
- Gives search engines and LLM answer engines a unique title signal per page
- No content or URL changes, so no redirect needed