### PR TITLE
fix: stop fabricating lastmod dates in sitemaps and structured data

### DIFF
--- a/content-collections.ts
+++ b/content-collections.ts
@@ -26,15 +26,15 @@ const pages = defineCollection({
       ],
     });
     const filePath = `content/docs/${doc._meta.filePath}`;
-    let lastModified: string | undefined;
+    let lastModified: string | null = null;
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "ignore"],
       }).trim();
-      lastModified = result || undefined;
+      lastModified = result || null;
     } catch {
-      lastModified = undefined;
+      lastModified = null;
     }
 
     return {
@@ -84,15 +84,15 @@ const guides = defineCollection({
       ],
     });
     const filePath = `content/guides/${doc._meta.filePath}`;
-    let lastModified: string | undefined;
+    let lastModified: string | null = null;
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
         stdio: ["pipe", "pipe", "ignore"],
       }).trim();
-      lastModified = result || undefined;
+      lastModified = result || null;
     } catch {
-      lastModified = undefined;
+      lastModified = null;
     }
 
     return {

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -26,14 +26,14 @@ const pages = defineCollection({
       ],
     });
     const filePath = `content/docs/${doc._meta.filePath}`;
-    let lastModified: string;
+    let lastModified: string | undefined;
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
       }).trim();
-      lastModified = result || new Date().toISOString();
+      lastModified = result || undefined;
     } catch {
-      lastModified = new Date().toISOString();
+      lastModified = undefined;
     }
 
     return {
@@ -83,14 +83,14 @@ const guides = defineCollection({
       ],
     });
     const filePath = `content/guides/${doc._meta.filePath}`;
-    let lastModified: string;
+    let lastModified: string | undefined;
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
       }).trim();
-      lastModified = result || new Date().toISOString();
+      lastModified = result || undefined;
     } catch {
-      lastModified = new Date().toISOString();
+      lastModified = undefined;
     }
 
     return {

--- a/content-collections.ts
+++ b/content-collections.ts
@@ -30,6 +30,7 @@ const pages = defineCollection({
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
+        stdio: ["pipe", "pipe", "ignore"],
       }).trim();
       lastModified = result || undefined;
     } catch {
@@ -87,6 +88,7 @@ const guides = defineCollection({
     try {
       const result = execSync(`git log -1 --format=%cI -- "${filePath}"`, {
         encoding: "utf-8",
+        stdio: ["pipe", "pipe", "ignore"],
       }).trim();
       lastModified = result || undefined;
     } catch {

--- a/next-sitemap.config.js
+++ b/next-sitemap.config.js
@@ -10,6 +10,7 @@ const redirectSources = redirects
 module.exports = {
   siteUrl: process.env.NEXT_PUBLIC_RAILWAY_DOCS_URL || "https://docs.railway.com",
   generateRobotsTxt: true,
+  autoLastmod: false,
   exclude: redirectSources,
   robotsTxtOptions: {
     additionalSitemaps: [],

--- a/src/layouts/docs-layout.tsx
+++ b/src/layouts/docs-layout.tsx
@@ -121,10 +121,11 @@ export const DocsLayout: React.FC<PropsWithChildren<Props>> = ({
     return buildBreadcrumbs(frontMatter.url, sidebarContent);
   }, [frontMatter.url]);
 
-  // Get last modified date from git history
-  const lastModified = frontMatter.lastModified ?? new Date().toISOString();
+  // Get last modified date from git history — omit if unavailable
+  const lastModified = frontMatter.lastModified;
 
   const formattedLastModified = useMemo(() => {
+    if (!lastModified) return undefined;
     const date = new Date(lastModified);
     return date.toLocaleDateString("en-US", {
       year: "numeric",

--- a/src/layouts/guides-layout.tsx
+++ b/src/layouts/guides-layout.tsx
@@ -70,10 +70,11 @@ export const GuidesLayout: React.FC<PropsWithChildren<GuidesLayoutProps>> = ({
       }));
   }, [headers]);
 
-  // Get last modified date from git history
-  const lastModified = frontMatter.lastModified ?? new Date().toISOString();
+  // Get last modified date from git history — omit if unavailable
+  const lastModified = frontMatter.lastModified;
 
   const formattedLastModified = useMemo(() => {
+    if (!lastModified) return undefined;
     const date = new Date(lastModified);
     return date.toLocaleDateString("en-US", {
       year: "numeric",

--- a/src/pages/[...slug].tsx
+++ b/src/pages/[...slug].tsx
@@ -93,7 +93,7 @@ export default function PostPage({
         title: page.title,
         description: page.description,
         url: page.url,
-        lastModified: page.lastModified,
+        lastModified: page.lastModified ?? undefined,
       }}
       rawMarkdown={rawMarkdown}
     >

--- a/src/pages/dynamic/[...slug].tsx
+++ b/src/pages/dynamic/[...slug].tsx
@@ -86,7 +86,7 @@ export default function PostPage({
         title: page.title,
         description: page.description,
         url: page.url,
-        lastModified: page.lastModified,
+        lastModified: page.lastModified ?? undefined,
       }}
       rawMarkdown={rawMarkdown}
     >


### PR DESCRIPTION
## Problem
Every page in the sitemap gets `lastmod` stamped with either the build timestamp (`next-sitemap` auto-lastmod) or a request-time `new Date()` fallback when git history is unavailable. This trains crawlers to distrust the entire sitemap, wasting crawl budget and disabling recrawl-priority signals.

## Changes
- **content-collections.ts**: Return `undefined` instead of `new Date()` when `git log` produces no result for a file (new uncommitted files, CI without full git history)
- **docs-layout.tsx / guides-layout.tsx**: Remove the `?? new Date().toISOString()` fallback — `lastModified` is now `undefined` when no real date exists, which correctly omits it from structured data and the footer
- **next-sitemap.config.js**: Set `autoLastmod: false` so the sitemap generator doesn't stamp every URL with the build timestamp

## Impact
Real `lastmod` dates (from git history) continue to flow through unchanged. Only fabricated dates are removed. This restores recrawl-priority signals for search engines and AI systems.