### PR TITLE
feat: add guides RSS feed at /guides/rss.xml

### DIFF
--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -429,6 +429,12 @@ const GuidesPage: NextPage<GuidesPageProps> = ({ guides }) => {
         ]}
       />
       <Head>
+        <link
+          rel="alternate"
+          type="application/rss+xml"
+          title="Railway Guides"
+          href="https://docs.railway.com/guides/rss.xml"
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{

--- a/src/pages/guides/rss.xml.ts
+++ b/src/pages/guides/rss.xml.ts
@@ -1,0 +1,70 @@
+import type { GetServerSideProps } from "next";
+import { allGuides } from "content-collections";
+
+const BASE_URL = "https://docs.railway.com";
+const FEED_LIMIT = 50;
+
+const escapeXML = (value: string) =>
+  value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&apos;");
+
+export const getServerSideProps: GetServerSideProps = async ({ res }) => {
+  // Sort by lastModified descending (most recently updated first), cap at FEED_LIMIT
+  const guides = [...allGuides]
+    .sort((a, b) => {
+      const da = a.lastModified ?? "";
+      const db = b.lastModified ?? "";
+      return db.localeCompare(da);
+    })
+    .slice(0, FEED_LIMIT);
+
+  const items = guides
+    .map((guide) => {
+      const link = `${BASE_URL}${guide.url}`;
+      const pubDate = guide.lastModified
+        ? new Date(guide.lastModified).toUTCString()
+        : new Date().toUTCString();
+      const tags = (guide.tags ?? [])
+        .map((tag) => `      <category>${escapeXML(tag)}</category>`)
+        .join("\n");
+
+      return `    <item>
+      <title>${escapeXML(guide.title)}</title>
+      <link>${escapeXML(link)}</link>
+      <guid isPermaLink="true">${escapeXML(link)}</guid>
+      <pubDate>${pubDate}</pubDate>
+      <description>${escapeXML(guide.description)}</description>
+${tags}
+    </item>`;
+    })
+    .join("\n");
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
+  <channel>
+    <title>Railway Guides</title>
+    <link>${BASE_URL}/guides</link>
+    <description>In-depth guides, tutorials, and how-tos for deploying on Railway</description>
+    <language>en</language>
+    <atom:link href="${BASE_URL}/guides/rss.xml" rel="self" type="application/rss+xml" />
+${items}
+  </channel>
+</rss>`;
+
+  res.setHeader("Content-Type", "application/rss+xml; charset=utf-8");
+  res.setHeader(
+    "Cache-Control",
+    "public, s-maxage=3600, stale-while-revalidate=86400",
+  );
+  res.write(xml);
+  res.end();
+
+  return { props: {} };
+};
+
+const Noop = () => null;
+export default Noop;


### PR DESCRIPTION
## What

Adds an RSS feed for Railway guides with autodiscovery.

## Changes

- **New route** `src/pages/guides/rss.xml.ts` — serves RSS 2.0 via `getServerSideProps`, sorted by `lastModified` descending, capped at 50 guides. Includes tags as `<category>` elements. CDN-cacheable (1h, SWR 24h).
- **Autodiscovery** — `<link rel="alternate" type="application/rss+xml">` on the guides index page.

## Why

The docs site had no RSS feed for guides despite having all the content available via `allGuides` from content-collections. This was flagged in the SEO crawl hygiene audit (G11). RSS is a first-class AI-ingestion path.