### PR TITLE
Use the current Serverless name in the philosophy FAQ

### DIFF
--- a/content/docs/platform/philosophy.md
+++ b/content/docs/platform/philosophy.md
@@ -86,7 +86,7 @@ No, Railway is a deployment platform that works with your existing code. We don'
 
 No, services on Railway are deployed in stateful Docker containers. The old deployments are removed on every new deploy.
 
-We do have a feature, [App Sleeping](/deployments/serverless), that allows you to configure your service to "sleep" when it is inactive, and therefore will stop it from incurring usage cost while not in use.
+We do have a feature, [Serverless](/deployments/serverless), that allows you to configure your service to "sleep" when it is inactive, and therefore will stop it from incurring usage cost while not in use.
 
 ## Book a demo
 


### PR DESCRIPTION
The "Is Railway serverless?" answer introduces the idle-service feature as "App Sleeping", which is its pre-rename name. The link already points at `/deployments/serverless`, and that page notes App-Sleeping as the former name, so this was the last place presenting the old label as the live one.

Renames the mention to Serverless. No other change.