### PR TITLE
docs(guides): agent-lane AEO overhaul, 43 new/refreshed guides

### DIFF
--- a/content/guides/agents-in-sandboxes.md
+++ b/content/guides/agents-in-sandboxes.md
@@ -352,6 +352,7 @@ A template is built from instructions and rebuilds cheaply, but the Repo Review 
 
 Explore these resources to go deeper on sandboxes and agents:
 
+- [Run Code-Execution Sandboxes for AI Agents](/guides/code-execution-sandboxes): why agents need sandboxes and the minimal execution loop.
 - [Sandboxes](/sandboxes): concepts, the SDK reference, networking, and limits.
 - [`railway sandbox` CLI reference](/cli/sandbox): templates, checkpoints, forks, exec, and port forwarding.
 - [Railway for Agents](/agents): the broader agent setup with the CLI, MCP, and skills.

--- a/content/guides/ai-agent-workers.md
+++ b/content/guides/ai-agent-workers.md
@@ -54,7 +54,7 @@ Both databases will be available to all services in the project via [reference v
    - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from Postgres.
    - [Reference](/variables#referencing-another-services-variable) `REDIS_URL` from Redis.
    - Add your LLM API key (e.g., `OPENAI_API_KEY` or `ANTHROPIC_API_KEY`).
-3. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings → Networking → Public Networking**.
+3. Generate a [public domain](/networking/domains) under **Settings → Networking → Public Networking**.
 4. Run database migrations via a [pre-deploy command](/deployments/pre-deploy-command).
 
 ### API endpoints
@@ -117,3 +117,4 @@ Railway does not currently offer GPU instances. This architecture assumes your a
 - [PostgreSQL on Railway](/databases/postgresql) - Connection pooling, backups, and configuration.
 - [Redis on Railway](/databases/redis) - Persistence settings and memory management.
 - [Choose Between SSE and WebSockets](/guides/sse-vs-websockets) - Options for streaming agent progress to clients.
+- [Build and Deploy Your Own MCP Server](/guides/mcp-server) - Expose your agent's capabilities as tools other AI assistants can call.

--- a/content/guides/ai-api-hosted-inference.md
+++ b/content/guides/ai-api-hosted-inference.md
@@ -1,0 +1,262 @@
+---
+title: Build an AI API on Hosted Inference Providers
+description: Build and deploy an AI API on Railway that calls hosted inference providers for model output. Covers provider selection, OpenAI-compatible endpoints, streaming, timeouts, and provider fallback.
+date: "2026-07-29"
+tags:
+  - ai
+  - api
+  - inference
+  - typescript
+topic: ai
+---
+
+An AI API is an HTTP service you own that takes requests from your users, calls a hosted inference provider to run the model, and returns the result. Your service handles authentication, prompts, validation, and response shaping. The provider handles the GPUs.
+
+This split matters because Railway does not offer GPU instances. You cannot run model inference locally on a Railway service, and you should not try to serve even small models on CPU. Instead, the pattern that works is: Railway runs your API on CPU, and inference happens over HTTPS on a provider's infrastructure. This is also how most production AI products are built, regardless of host, because managing GPU capacity is its own job.
+
+This guide builds that pattern: a small AI API in TypeScript, deployed on Railway. It also covers the operational details: which provider to use, how to stream long generations within Railway's request limits, and how to fail over when a provider has an outage.
+
+## Which inference provider should you use?
+
+Hosted inference providers fall into two groups.
+
+**Proprietary model providers.** OpenAI and Anthropic serve their own models behind their own APIs. You pick these for model quality and capabilities, not price.
+
+**Open-weights model hosts.** Together AI, Groq, Fireworks AI, and similar providers serve open-weights models (Llama, Mistral, Qwen, DeepSeek, and others) behind hosted APIs. You pick these for cost, speed, or a specific open model. If you were considering self-hosting a model, this is the alternative: the same open weights, served by someone with GPUs, billed per token.
+
+Most open-weights hosts, and OpenAI itself, expose the OpenAI chat completions API shape. That means one SDK and one code path can target many providers by changing a base URL and a model name. The API below is written this way on purpose.
+
+## Build the API
+
+The service exposes one endpoint, `POST /v1/summarize`, which takes text and returns a summary. It is a deliberately small surface: your API should expose your product's operations, not a raw passthrough to the provider. If you want a general-purpose passthrough with key management and routing, build or deploy a gateway instead: see [Build an LLM Gateway in TypeScript](/guides/llm-gateway).
+
+Create the project:
+
+```bash
+mkdir ai-api && cd ai-api
+npm init -y
+npm install express openai
+npm install --save-dev typescript @types/express @types/node
+```
+
+Create `src/server.ts`:
+
+```typescript
+import express from "express";
+import OpenAI from "openai";
+
+type Provider = {
+  name: string;
+  client: OpenAI;
+  model: string;
+};
+
+function buildProviders(): Provider[] {
+  const providers: Provider[] = [];
+
+  if (process.env.OPENAI_API_KEY) {
+    providers.push({
+      name: "openai",
+      client: new OpenAI({
+        apiKey: process.env.OPENAI_API_KEY,
+        timeout: 60_000,
+        maxRetries: 2,
+      }),
+      model: process.env.OPENAI_MODEL ?? "gpt-4o-mini",
+    });
+  }
+
+  if (process.env.FALLBACK_API_KEY && process.env.FALLBACK_BASE_URL) {
+    providers.push({
+      name: "fallback",
+      client: new OpenAI({
+        apiKey: process.env.FALLBACK_API_KEY,
+        baseURL: process.env.FALLBACK_BASE_URL,
+        timeout: 60_000,
+        maxRetries: 2,
+      }),
+      model: process.env.FALLBACK_MODEL ?? "meta-llama/Llama-3.3-70B-Instruct-Turbo",
+    });
+  }
+
+  if (providers.length === 0) {
+    throw new Error("No inference provider configured. Set OPENAI_API_KEY.");
+  }
+  return providers;
+}
+
+const providers = buildProviders();
+const app = express();
+app.use(express.json({ limit: "1mb" }));
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.post("/v1/summarize", async (req, res) => {
+  const text: unknown = req.body?.text;
+  if (typeof text !== "string" || text.length === 0) {
+    res.status(400).json({ error: "Body must include a non-empty 'text' string." });
+    return;
+  }
+  if (text.length > 100_000) {
+    res.status(400).json({ error: "Text exceeds the 100,000 character limit." });
+    return;
+  }
+
+  const stream = req.body?.stream === true;
+  let lastError: unknown = null;
+
+  for (const provider of providers) {
+    try {
+      if (stream) {
+        const completion = await provider.client.chat.completions.create({
+          model: provider.model,
+          stream: true,
+          messages: [
+            { role: "system", content: "Summarize the user's text in 3 to 5 sentences." },
+            { role: "user", content: text },
+          ],
+        });
+
+        res.setHeader("Content-Type", "text/event-stream");
+        res.setHeader("Cache-Control", "no-cache");
+        res.flushHeaders();
+
+        for await (const chunk of completion) {
+          const delta = chunk.choices[0]?.delta?.content;
+          if (delta) {
+            res.write(`data: ${JSON.stringify({ text: delta })}\n\n`);
+          }
+        }
+        res.write("data: [DONE]\n\n");
+        res.end();
+        return;
+      }
+
+      const completion = await provider.client.chat.completions.create({
+        model: provider.model,
+        messages: [
+          { role: "system", content: "Summarize the user's text in 3 to 5 sentences." },
+          { role: "user", content: text },
+        ],
+      });
+
+      res.json({
+        provider: provider.name,
+        model: provider.model,
+        summary: completion.choices[0]?.message?.content ?? "",
+      });
+      return;
+    } catch (err) {
+      lastError = err;
+      console.error(`Provider ${provider.name} failed:`, err);
+      if (res.headersSent) {
+        // A stream already started; we cannot switch providers mid-response.
+        res.end();
+        return;
+      }
+    }
+  }
+
+  console.error("All providers failed:", lastError);
+  res.status(502).json({ error: "All inference providers failed. Try again shortly." });
+});
+
+const port = Number(process.env.PORT ?? 3000);
+app.listen(port, () => {
+  console.log(`AI API listening on port ${port}`);
+});
+```
+
+Add a `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}
+```
+
+And set the scripts in `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  }
+}
+```
+
+Three design points:
+
+- **The provider list is ordered.** The first configured provider is primary; the second is a fallback that only handles a request when the primary throws. The fallback targets any OpenAI-compatible base URL, so it can be an open-weights host serving a comparable model.
+- **The SDK retries transient failures.** `maxRetries: 2` handles rate limits and momentary errors before the request ever falls through to the next provider.
+- **Fallback cannot happen mid-stream.** Once you have written response headers, the request is committed to one provider. Failover only applies before the first byte.
+
+## Deploy on Railway
+
+Create a project and deploy from your repository, or use the CLI:
+
+```bash
+railway init
+railway up
+```
+
+Railway detects the Node app, runs `npm run build`, and starts it with `npm start`. The service reads `PORT` from the environment, which Railway injects automatically.
+
+Set your provider keys as service variables in the Railway dashboard, or with the CLI:
+
+```bash
+railway variables --set "OPENAI_API_KEY=sk-..." \
+  --set "FALLBACK_API_KEY=..." \
+  --set "FALLBACK_BASE_URL=https://api.together.xyz/v1"
+```
+
+Keys live in Railway [variables](/variables), not in code or in the repository.
+
+Then configure two things in service settings:
+
+1. **Healthcheck path**: set it to `/health`. Railway waits for the healthcheck to pass before routing traffic to a new deploy, which gives you [zero-downtime deployments](/deployments/healthchecks).
+2. **Public networking**: generate a domain. Your API is served at `https://<service>.up.railway.app`.
+
+If only other services in your project call this API, skip the public domain and use [private networking](/networking/private-networking) instead: services in the same environment reach it at `http://<service>.railway.internal:<PORT>` with no egress cost.
+
+## Handle long generations
+
+Railway closes an HTTP request after 5 minutes with no data transferred. Requests that keep transferring data can run up to 15 minutes. See [specs and limits](/networking/public-networking/specs-and-limits).
+
+For an AI API this has one practical consequence: a long generation behind a non-streaming endpoint transfers nothing until the model finishes, so a slow request can hit the 5-minute idle cutoff. Streaming fixes this, because tokens flow as they are generated and the connection never goes idle. The `stream: true` path in the code above does this with Server-Sent Events. For frontend consumption patterns, see [Stream AI Responses to a Frontend with Server-Sent Events](/guides/streaming-ai-responses).
+
+For jobs that run longer than 15 minutes (batch summarization, document pipelines), do not hold the HTTP request open at all. Accept the job, return an ID, process in a background worker, and let the client poll or receive a webhook. The worker pattern is covered in [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers).
+
+## What this costs
+
+You pay two bills. The first is Railway's: compute for the API service (RAM at $10/GB-month, CPU at $20/vCPU-month, prorated by the minute) plus $0.05/GB egress, which includes the responses you send to clients. The second is the inference provider's, billed per token. For a typical AI API this second bill dominates: the Railway service is a thin I/O-bound process that idles at low CPU while waiting on provider responses, so it runs cheaply even under real traffic.
+
+If your API has quiet periods, enable [serverless](/deployments/serverless) on the service. Railway puts the service to sleep after 10 minutes without outbound traffic and wakes it on the next request. Outbound traffic includes database connections and telemetry, which will keep a service awake.
+
+## Common mistakes
+
+**Trying to run the model on Railway.** There are no GPUs, and CPU inference for anything beyond trivial models is too slow to serve requests. If you want an open-weights model, use a hosted provider that serves it.
+
+**Passing provider keys to the client.** The browser or mobile app should call your API, never the provider directly. Your API is where keys stay secret and where you enforce per-user limits.
+
+**No timeout on provider calls.** A hung provider connection holds your request open and ties up capacity. The 60-second SDK timeout in the code above turns a hang into a fast failover.
+
+**One provider, no fallback.** Provider outages happen. With OpenAI-compatible hosts, adding a fallback takes a base URL and a model name.
+
+## Next steps
+
+- [Stream AI Responses to a Frontend with Server-Sent Events](/guides/streaming-ai-responses)
+- [Build an LLM Gateway in TypeScript](/guides/llm-gateway)
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers)
+- [Deploy an AI-Powered SaaS App on Railway](/guides/deploy-ai-saas)

--- a/content/guides/ai-api-proxy.md
+++ b/content/guides/ai-api-proxy.md
@@ -1,7 +1,7 @@
 ---
-title: Deploy an AI API Gateway
-description: Deploy LiteLLM Proxy on Railway as a unified gateway for multiple LLM providers. Covers model routing, cost tracking, API key management, caching with Redis, and private networking.
-date: "2026-04-14"
+title: Deploy an LLM Gateway with LiteLLM
+description: Deploy LiteLLM Proxy on Railway as an LLM gateway for multiple providers. Covers model routing, cost tracking, API key management, caching with Redis, and private networking.
+date: "2026-07-29"
 tags:
   - gateway
   - api
@@ -12,7 +12,7 @@ topic: ai
 
 As AI applications scale, managing multiple LLM providers becomes complex. Different services may use different providers, API keys rotate, costs are hard to track, and a single provider outage can take down your entire application.
 
-An AI API gateway sits between your services and LLM providers. It provides a single endpoint with a unified API, model routing, cost tracking, rate limiting, and provider failover.
+An LLM gateway (sometimes called an AI API gateway) sits between your services and LLM providers. It provides a single endpoint with a unified API, model routing, cost tracking, rate limiting, and provider failover.
 
 [LiteLLM Proxy](https://docs.litellm.ai/docs/simple_proxy) is the most widely used open-source option. It exposes an OpenAI-compatible API that routes requests to 100+ LLM providers.
 
@@ -44,7 +44,7 @@ model_list:
 
   - model_name: claude-sonnet
     litellm_params:
-      model: anthropic/claude-sonnet-4-20250514
+      model: anthropic/claude-opus-4-8
       api_key: os.environ/ANTHROPIC_API_KEY
 
   - model_name: gpt-4o-mini
@@ -139,6 +139,7 @@ LiteLLM automatically creates its logging tables on first connection. Access cos
 
 ## Next steps
 
+- [Build an LLM Gateway in TypeScript](/guides/llm-gateway): the build-your-own route, when the logic you need is small and specific.
 - [Deploy an AI-Powered SaaS App](/guides/deploy-ai-saas): Build a product that uses the gateway.
 - [Private Networking](/networking/private-networking): How services communicate within a project.
 - [Redis on Railway](/databases/redis): Persistence settings and memory management.

--- a/content/guides/alerts-crashes-failed-deploys.md
+++ b/content/guides/alerts-crashes-failed-deploys.md
@@ -1,0 +1,201 @@
+---
+title: Set Up Alerts for Crashes, Restarts, and Failed Deploys
+description: Configure Railway webhooks and monitors to get notified in Slack, Discord, or your own service when a deployment fails, crashes, or a resource threshold is crossed.
+date: "2026-07-29"
+tags:
+  - alerts
+  - webhooks
+  - monitoring
+  - observability
+topic: infrastructure
+---
+
+Railway has two native alerting mechanisms: project webhooks, which push deployment status changes and alert events to any URL, and monitors, which watch resource metrics and notify you when a threshold is crossed. Together they cover failed builds, crashed deployments, and resource exhaustion, so you hear about a crashed service before your users do. This guide sets up both, routes alerts to Slack and Discord, and builds a small receiver service for custom handling.
+
+## What Railway alerts on natively
+
+Railway emits events through [project webhooks](/observability/webhooks) for:
+
+- **Deployment status changes**: every state transition, including `Failed` (build or deploy error) and `Crashed` (a running deployment exited unexpectedly). The full list of states is in the [deployments reference](/deployments/reference).
+- **Volume usage alerts**: a volume approaching capacity.
+- **CPU/RAM monitor alerts**: a monitor threshold you configured was exceeded.
+
+Separately, [monitors](/observability) on the Observability Dashboard send email and in-app notifications when CPU, RAM, disk usage, or network egress crosses a threshold you set, and that feature requires the Pro plan. Webhooks fire for monitor alerts too, so one webhook URL can receive everything.
+
+For billing rather than infrastructure, you can also set a [custom email alert on usage](/pricing/cost-control) that emails you when workspace spend reaches an amount you choose.
+
+## Set up a project webhook
+
+Webhooks are configured per project and fire across all environments in that project.
+
+1. Open your project on Railway.
+2. Click **Settings** in the top right corner.
+3. Go to the **Webhooks** tab.
+4. Enter the URL that should receive events.
+5. Optionally select which events to receive.
+6. Click **Save Webhook**.
+
+Use the **Test Webhook** button to send a test payload. Test payloads are sent from your browser, so CORS restrictions on the receiving end can make a working endpoint look like a delivery failure. So trigger a real deployment to confirm end to end.
+
+## Send alerts to Slack or Discord
+
+Railway detects Slack and Discord webhook URLs and transforms the payload to match what those platforms expect, in what Railway calls a Muxer. You do not need any middleware.
+
+For Slack:
+
+1. Enable incoming webhooks for your Slack workspace and create a `hooks.slack.com` webhook URL for the channel that should receive alerts.
+2. Paste that URL into your Railway project's Webhooks tab and save.
+
+For Discord:
+
+1. In your Discord server, open the channel settings, go to **Integrations**, then **Webhooks**, and create a webhook.
+2. Copy the webhook URL and paste it into your Railway project's Webhooks tab and save.
+
+From then on, deployment status changes for that project post directly to the channel.
+
+## Understand the webhook payload
+
+For non-Muxer URLs, Railway sends JSON whose `type` field identifies the event, for example `Deployment.failed`, and whose `resource` block tells you which workspace, project, environment, service, and deployment the event belongs to:
+
+```json
+{
+  "type": "Deployment.failed",
+  "details": {
+    "id": "8107edff-4b8e-44fc-b43a-04566e847a2a",
+    "source": "GitHub",
+    "branch": "main",
+    "commitHash": "abc123",
+    "commitAuthor": "octocat",
+    "commitMessage": "fix: handle null response"
+  },
+  "resource": {
+    "workspace": { "id": "...", "name": "..." },
+    "project": { "id": "...", "name": "my-project" },
+    "environment": { "id": "...", "name": "production", "isEphemeral": false },
+    "service": { "id": "...", "name": "api" },
+    "deployment": { "id": "..." }
+  },
+  "severity": "WARNING",
+  "timestamp": "2025-11-21T23:48:42.311Z"
+}
+```
+
+## Build a custom alert receiver
+
+Slack and Discord cover most cases. Build your own receiver when you want to filter noise (for example, only production failures), page an on-call rotation, or feed events into another system.
+
+Create a new project:
+
+```bash
+mkdir railway-alert-receiver && cd railway-alert-receiver
+npm init -y
+npm install express
+```
+
+Create `server.js`:
+
+```javascript
+const express = require("express");
+
+const app = express();
+app.use(express.json());
+
+// Event types that should trigger an alert.
+// Railway sends types like "Deployment.failed" for deployment
+// state changes, plus volume and monitor alert events.
+const ALERT_SUFFIXES = ["failed", "crashed"];
+
+function shouldAlert(event) {
+  const type = (event.type || "").toLowerCase();
+  return ALERT_SUFFIXES.some((suffix) => type.endsWith(suffix));
+}
+
+app.post("/railway-webhook", async (req, res) => {
+  const event = req.body;
+
+  // Acknowledge immediately so Railway does not see a slow endpoint.
+  res.status(200).json({ received: true });
+
+  if (!shouldAlert(event)) {
+    console.log(`Ignoring event: ${event.type}`);
+    return;
+  }
+
+  const project = event.resource?.project?.name ?? "unknown project";
+  const service = event.resource?.service?.name ?? "unknown service";
+  const environment = event.resource?.environment?.name ?? "unknown env";
+
+  // Only alert for production. Drop this check to alert on every environment.
+  if (environment !== "production") {
+    console.log(`Skipping non-production event in ${environment}`);
+    return;
+  }
+
+  const message = `${event.type}: ${service} in ${project} (${environment}) at ${event.timestamp}`;
+  console.error(message);
+
+  // Forward anywhere: a paging service, an internal API, a queue.
+  if (process.env.FORWARD_URL) {
+    try {
+      await fetch(process.env.FORWARD_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: message, event }),
+      });
+    } catch (err) {
+      console.error("Failed to forward alert:", err);
+    }
+  }
+});
+
+app.get("/health", (_req, res) => res.status(200).send("ok"));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Alert receiver listening on port ${port}`);
+});
+```
+
+The handler acknowledges with a 200 before doing any work, filters to failure and crash events in production, and optionally forwards a formatted message to `FORWARD_URL`.
+
+## Deploy the receiver on Railway
+
+The receiver is a normal service. Deploy it in its own project so an outage in the project you are monitoring cannot take your alerting down with it.
+
+1. Push the code to a GitHub repository and create a new Railway project from it, or run `railway init` and `railway up` from the directory with the [CLI](/cli).
+2. Railway detects Node and builds it with no extra configuration. The app reads the `PORT` environment variable, which Railway injects.
+3. Generate a public domain for the service in its settings. You get a `*.up.railway.app` domain.
+4. Set `FORWARD_URL` as a [service variable](/variables) if you want forwarding.
+5. In the project you want to monitor, add `https://<your-receiver-domain>/railway-webhook` as the webhook URL.
+
+Add a [health check](/deployments/healthchecks) pointing at `/health` so deploys of the receiver itself only go live once the server is accepting traffic. That check is HTTP only.
+
+## Add monitors for resource thresholds
+
+Webhooks tell you after something failed. Monitors can tell you before: a service climbing toward its memory limit is often a crash you can still prevent.
+
+1. Open the **Observability** tab in your project and make sure you are in the right environment.
+2. Create a widget for the metric you care about (CPU, memory, disk, or network) if you do not have one.
+3. Click the three dot menu on the widget and select **Add monitor**.
+4. Configure the threshold. Monitors can trigger above or below a limit for CPU, RAM, disk usage, and network egress.
+
+Monitor alerts arrive by email and in-app notification, and also fire your project webhook, so they land in the same Slack or Discord channel as deployment failures.
+
+This requires the Pro plan, and the Observability Dashboard is scoped per environment, so set up monitors in each environment you want covered.
+
+## Restarts: what Railway already handles
+
+Alerting complements the [restart policy](/deployments/restart-policy) rather than replacing it. By default, Railway restarts a crashed service automatically (`On Failure`, up to 10 restarts). With multiple [replicas](/deployments/scaling), only the crashed replica restarts while the others keep serving traffic.
+
+That restart policy means a single transient crash often self-heals before anyone reacts. A useful alerting posture builds on it:
+
+- Let the restart policy absorb one-off crashes.
+- Alert on `Deployment.failed` immediately: a failed build or deploy never self-heals.
+- Treat repeated crash events for the same service in a short window as a page, not a log line. The receiver above is the place to add that counting logic.
+
+## Next steps
+
+- [Webhooks reference](/observability/webhooks): payload details, Muxers, and troubleshooting.
+- [Connect a Third-Party Observability Tool](/guides/third-party-observability): ship logs and metrics to Datadog, Grafana, or similar for alerting with longer retention.
+- [Deploy an OpenTelemetry Collector and Backend on Railway](/guides/deploy-an-otel-collector-stack): application-level traces and metrics beyond platform events.
+- [GitHub Actions Post-Deploy](/guides/github-actions-post-deploy): run checks and notifications from CI after a deployment.

--- a/content/guides/autoscale-horizontally.md
+++ b/content/guides/autoscale-horizontally.md
@@ -1,0 +1,309 @@
+---
+title: Autoscale a Service Horizontally Based on Load
+description: Build an autoscaler on Railway that measures load in your application and adjusts replica counts through the Public API, the CLI, or a cron schedule.
+date: "2026-07-29"
+tags:
+  - autoscaling
+  - replicas
+  - scaling
+  - api
+topic: infrastructure
+---
+
+Horizontal scaling means running more copies of your service and spreading traffic across them. On Railway those copies are called replicas. This guide builds an autoscaler: a small Node service that measures load in your application and adjusts the replica count through Railway's Public API.
+
+Railway scales each container vertically on its own, growing CPU and memory toward your plan limits as demand rises. Instead, the replica count is a setting you control, and by default it stays where you set it. So Railway exposes it through the Public API and the CLI, letting an autoscaler change it in response to load without touching the dashboard.
+
+If you are deciding between vertical and horizontal scaling, or you want to read metrics to find your bottleneck, start with [Scaling your application](/guides/scaling-your-application). This guide assumes you already know you want more replicas under load and fewer when things are quiet.
+
+## How replicas behave on Railway
+
+Before automating anything, know what a replica change does:
+
+- Each replica is a full copy of your service with access to the full resources of your plan. Two replicas on a plan with 24 vCPU and 24 GB RAM limits can use up to 48 vCPU and 48 GB RAM combined.
+- Within a single region, Railway distributes public traffic randomly across replicas. With multi-region replicas, traffic routes to the nearest region first, then randomly within it.
+- Replica changes do not rebuild your app. New replicas start from the existing deployment image, and removed replicas are drained gracefully.
+- There are no sticky sessions. Any request can land on any replica, so your service must be stateless: keep sessions in a database or cache, not in process memory.
+- The metrics tab sums usage across all replicas. Two replicas each using 100 MB show as 200 MB.
+- Railway supports a maximum of 50 total replicas across all regions.
+- Every replica gets a `RAILWAY_REPLICA_ID` environment variable you can include in logs to tell instances apart.
+
+Full details are in the [scaling reference](/deployments/scaling).
+
+## Prerequisites
+
+1. A stateless target service deployed on Railway.
+2. A [healthcheck](/deployments/healthchecks) configured on the target service. Healthchecks guarantee zero-downtime deployments, and they matter more once traffic is spread across instances that come and go.
+3. A Railway API token. A project token scoped to the target environment is the safest choice for automation. Create one from the tokens page in your project settings. Note that project tokens authenticate with the `Project-Access-Token` header, not the `Authorization: Bearer` header used by account and workspace tokens. See the [Public API docs](/integrations/api) for token types.
+4. The target service ID and environment ID. Both appear in the dashboard URL when you open the service, or you can query them through the API.
+
+## Pick a load signal
+
+Railway does not expose per-replica utilization through the Public API, so the most reliable load signal comes from inside your application. Good candidates:
+
+- **In-flight requests**: how many requests the process is handling right now. Simple and directly tied to capacity.
+- **Queue depth**: for workers, the number of jobs waiting in your queue.
+- **p95 latency**: measured by your own middleware or an external probe.
+
+This guide uses in-flight requests. Add a counter and a small endpoint to the target service. For an Express app:
+
+```bash
+npm install express
+```
+
+```javascript
+// server.js (target service)
+const express = require("express");
+
+const app = express();
+let inflight = 0;
+
+app.use((req, res, next) => {
+  inflight++;
+  res.once("close", () => {
+    inflight--;
+  });
+  next();
+});
+
+app.get("/load", (req, res) => {
+  res.json({ inflight, replicaId: process.env.RAILWAY_REPLICA_ID ?? null });
+});
+
+app.get("/health", (req, res) => {
+  res.json({ status: "ok" });
+});
+
+app.get("/", (req, res) => {
+  res.send("hello");
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`listening on ${port}`);
+});
+```
+
+Railway distributes requests randomly across replicas, so each call to `/load` samples a single replica. The autoscaler below takes several samples and averages them, treating the result as per-replica load.
+
+If your load endpoint should not be public, put it on a separate port and reach it over [private networking](/networking/private-networking) at `<service>.railway.internal`. Private networking is scoped per environment, so run the autoscaler in the same environment as the target.
+
+## Build the autoscaler
+
+The autoscaler is a small Node service with no dependencies beyond the runtime (Node 18 or later ships `fetch`). It loops forever: sample load, compute a desired replica count, clamp it, and apply it through the Public API.
+
+The core mutation is `serviceInstanceUpdate` with `numReplicas`:
+
+```graphql
+mutation ($serviceId: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
+  serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
+}
+```
+
+Here is the complete autoscaler:
+
+```javascript
+// autoscaler.js
+const API = "https://backboard.railway.com/graphql/v2";
+
+const {
+  RAILWAY_API_TOKEN,
+  TARGET_SERVICE_ID,
+  TARGET_ENVIRONMENT_ID,
+  TARGET_LOAD_URL, // e.g. https://myapp.up.railway.app/load
+} = process.env;
+
+for (const [name, value] of Object.entries({
+  RAILWAY_API_TOKEN,
+  TARGET_SERVICE_ID,
+  TARGET_ENVIRONMENT_ID,
+  TARGET_LOAD_URL,
+})) {
+  if (!value) throw new Error(`Missing required env var: ${name}`);
+}
+
+// Tuning knobs
+const TARGET_INFLIGHT_PER_REPLICA = 25; // scale to keep each replica near this
+const MIN_REPLICAS = 1;
+const MAX_REPLICAS = 10;
+const POLL_INTERVAL_MS = 60_000; // evaluate once per minute
+const SCALE_DOWN_COOLDOWN_MS = 5 * 60_000; // wait 5 min between scale-downs
+const SAMPLES = 5; // load samples per evaluation
+
+async function gql(query, variables) {
+  const res = await fetch(API, {
+    method: "POST",
+    headers: {
+      // Project tokens use this header. For an account or workspace
+      // token, use `Authorization: Bearer <token>` instead.
+      "Project-Access-Token": RAILWAY_API_TOKEN,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query, variables }),
+  });
+  if (!res.ok) throw new Error(`API returned ${res.status}`);
+  const { data, errors } = await res.json();
+  if (errors) throw new Error(JSON.stringify(errors));
+  return data;
+}
+
+async function getReplicas() {
+  const data = await gql(
+    `query ($serviceId: String!, $environmentId: String!) {
+      serviceInstance(serviceId: $serviceId, environmentId: $environmentId) {
+        numReplicas
+      }
+    }`,
+    { serviceId: TARGET_SERVICE_ID, environmentId: TARGET_ENVIRONMENT_ID }
+  );
+  return data.serviceInstance.numReplicas ?? 1;
+}
+
+async function setReplicas(numReplicas) {
+  await gql(
+    `mutation ($serviceId: String!, $environmentId: String!, $input: ServiceInstanceUpdateInput!) {
+      serviceInstanceUpdate(serviceId: $serviceId, environmentId: $environmentId, input: $input)
+    }`,
+    {
+      serviceId: TARGET_SERVICE_ID,
+      environmentId: TARGET_ENVIRONMENT_ID,
+      input: { numReplicas },
+    }
+  );
+}
+
+// Each request to /load lands on one random replica, so average
+// several samples to estimate per-replica load.
+async function sampleLoad() {
+  const samples = [];
+  for (let i = 0; i < SAMPLES; i++) {
+    try {
+      const res = await fetch(TARGET_LOAD_URL);
+      const { inflight } = await res.json();
+      samples.push(inflight);
+    } catch (err) {
+      console.error("load sample failed:", err.message);
+    }
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  if (samples.length === 0) return null;
+  return samples.reduce((a, b) => a + b, 0) / samples.length;
+}
+
+function clamp(n) {
+  return Math.max(MIN_REPLICAS, Math.min(MAX_REPLICAS, n));
+}
+
+let lastScaleDownAt = 0;
+
+async function evaluate() {
+  const current = await getReplicas();
+  const perReplicaLoad = await sampleLoad();
+  if (perReplicaLoad === null) {
+    console.warn("no load samples, skipping this cycle");
+    return;
+  }
+
+  // If each replica is above target, we need proportionally more replicas.
+  const desired = clamp(
+    Math.ceil((perReplicaLoad / TARGET_INFLIGHT_PER_REPLICA) * current)
+  );
+
+  console.log(
+    `replicas=${current} perReplicaLoad=${perReplicaLoad.toFixed(1)} desired=${desired}`
+  );
+
+  if (desired > current) {
+    // Scale up immediately.
+    console.log(`scaling up: ${current} -> ${desired}`);
+    await setReplicas(desired);
+  } else if (desired < current) {
+    // Scale down slowly: one step at a time, with a cooldown.
+    const now = Date.now();
+    if (now - lastScaleDownAt < SCALE_DOWN_COOLDOWN_MS) {
+      console.log("scale-down suppressed by cooldown");
+      return;
+    }
+    const next = current - 1;
+    console.log(`scaling down: ${current} -> ${next}`);
+    await setReplicas(next);
+    lastScaleDownAt = now;
+  }
+}
+
+async function main() {
+  console.log("autoscaler started");
+  while (true) {
+    try {
+      await evaluate();
+    } catch (err) {
+      console.error("evaluation failed:", err.message);
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+}
+
+main();
+```
+
+Three design choices are worth calling out:
+
+- **Scale up fast, scale down slow.** Scaling up is cheap and fixes a real problem. Scaling down too eagerly causes flapping, where replicas are added and removed in a loop. The cooldown and one-step-down rule prevent that.
+- **Clamp everything.** `MIN_REPLICAS` keeps you serving traffic even if the load signal breaks. `MAX_REPLICAS` caps cost if traffic spikes beyond what you planned for.
+- **Fail safe.** If sampling fails, the autoscaler skips the cycle rather than scaling on bad data.
+
+## Deploy the autoscaler on Railway
+
+Run the autoscaler as its own service in the same project:
+
+1. Create a new service from the repo containing `autoscaler.js`, with `node autoscaler.js` as the start command.
+2. Set the environment variables: `RAILWAY_API_TOKEN`, `TARGET_SERVICE_ID`, `TARGET_ENVIRONMENT_ID`, and `TARGET_LOAD_URL`.
+3. Do not add a public domain. The autoscaler makes only outbound requests.
+
+It is a long-running worker, so leave serverless off. Its steady outbound polling would prevent sleep anyway.
+
+Note that `numReplicas` sets the replica count for the service's configured region. If you assign replicas across multiple regions, manage the per-region counts with the dashboard or the `railway scale` CLI command instead.
+
+## Alternative: scale on a schedule with cron
+
+If your load is predictable, for example high during business hours and near zero overnight, you do not need a feedback loop. Deploy two [cron jobs](/cron-jobs) that call `setReplicas` with fixed values:
+
+```javascript
+// scale-up.js: run at 08:00 UTC with numReplicas = 5
+// scale-down.js: run at 20:00 UTC with numReplicas = 1
+```
+
+Keep the cron constraints in mind: schedules run in UTC, the minimum interval between runs is 5 minutes, the process must exit when its work is done, and if a previous run is still going when the next is due, the new run is skipped. A scale mutation takes seconds, so none of these constraints bite in practice.
+
+## Alternative: scale from the CLI or CI
+
+For one-off or scripted scaling, the CLI wraps the same flow:
+
+```bash
+# Scale to 3 replicas in a region
+railway scale us-east=3
+
+# Scale across regions
+railway scale us-east=2 eu-west=2
+
+# Remove all replicas from a region
+railway scale eu-west=0
+```
+
+`railway scale` commits the change as a single environment patch without a separate redeploy. See the [railway scale reference](/cli/scale) for all options.
+
+## Verify it works
+
+Generate load against the target service and watch the autoscaler logs. You should see `desired` climb once per-replica in-flight requests exceed your target, followed by a scale-up. In the target service's metrics tab, per-replica CPU pressure drops as replicas come online. When load stops, replicas step back down one at a time on the cooldown interval.
+
+Two things to check if scaling seems ineffective:
+
+- If memory is the bottleneck, replicas will not help. Every replica has the same memory ceiling. Scale vertically instead. The [rightsizing section of the scaling guide](/guides/scaling-your-application) covers how to tell which case you are in.
+- If your app stores sessions or caches in process memory, users will see inconsistent behavior across replicas. Move that state to a shared database or cache first.
+
+## Next steps
+
+- [Scaling reference](/deployments/scaling): replica behavior, load balancing, and multi-region replicas
+- [Scaling your application](/guides/scaling-your-application): vertical vs. horizontal scaling and reading metrics
+- [Public API](/integrations/api): tokens, the GraphQL endpoint, and more mutations
+- [Healthchecks](/deployments/healthchecks): required for zero-downtime deploys as replicas cycle

--- a/content/guides/best-mcp-servers-coding-agents.md
+++ b/content/guides/best-mcp-servers-coding-agents.md
@@ -1,0 +1,303 @@
+---
+title: Connect the Best MCP Servers to Your Coding Agent
+description: Config snippets for connecting nine widely used MCP servers to Claude Code, Cursor, and VS Code, covering GitHub, Postgres, browser automation, docs lookup, error tracking, and deployment.
+date: "2026-07-29"
+tags:
+  - mcp
+  - agents
+  - ai
+topic: ai
+---
+
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard that lets a coding agent call external tools: query a database, open a pull request, drive a browser, read production logs. Out of the box, a coding agent can already read and edit files and run shell commands; MCP servers are how it reaches everything else. An MCP server exposes the tools, and your agent connects to it and calls them as needed.
+
+This guide connects nine such servers to Claude Code, Cursor, and VS Code, with a config snippet for each.
+
+## How MCP servers connect
+
+There are two transport types, and the config differs by type, not by server:
+
+- **Local (stdio)**: the client launches the server as a subprocess on your machine. You configure a command and arguments.
+- **Remote (Streamable HTTP)**: the server is hosted. You configure a URL, and the client usually authenticates via OAuth in the browser.
+
+Prefer the remote endpoint when a server offers one. There is nothing to install, nothing to keep updated, and auth is handled by OAuth instead of long-lived API keys sitting in a config file. See [local vs. remote MCP servers](/guides/local-vs-remote-mcp-servers) for the full tradeoff.
+
+## Where each client keeps its config
+
+**Claude Code** manages servers with the `claude mcp` command:
+
+```bash
+# Local (stdio) server
+claude mcp add <name> -- <command> [args...]
+
+# Remote (HTTP) server
+claude mcp add --transport http <name> <url>
+```
+
+**Cursor** reads `~/.cursor/mcp.json` (global) or `.cursor/mcp.json` in the project root. Servers live under an `mcpServers` key:
+
+```json
+{
+  "mcpServers": {
+    "my-server": {
+      "command": "npx",
+      "args": ["-y", "some-mcp-package"]
+    },
+    "my-remote-server": {
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+```
+
+**VS Code** (with GitHub Copilot) reads `.vscode/mcp.json` in the workspace. Servers live under a `servers` key and declare a `type`:
+
+```json
+{
+  "servers": {
+    "my-server": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "some-mcp-package"]
+    },
+    "my-remote-server": {
+      "type": "http",
+      "url": "https://example.com/mcp"
+    }
+  }
+}
+```
+
+The snippets below show the Claude Code command and the Cursor JSON for each server. Translating to VS Code is mechanical: same command or URL, `servers` key instead of `mcpServers`, plus a `type` field.
+
+## 1. GitHub
+
+The official GitHub MCP server gives your agent tools for issues, pull requests, code search, CI runs, and repository management. The win is closing the loop: the agent writes the fix, opens the PR, reads the failing check, and pushes the follow-up commit without you tabbing to the browser.
+
+GitHub hosts a remote endpoint, so there is nothing to install:
+
+```bash
+claude mcp add --transport http github https://api.githubcopilot.com/mcp/
+```
+
+```json
+{
+  "mcpServers": {
+    "github": {
+      "url": "https://api.githubcopilot.com/mcp/"
+    }
+  }
+}
+```
+
+The client opens a browser window for OAuth on first use. If your organization blocks the remote endpoint, GitHub also ships the server as a Docker image (`ghcr.io/github/github-mcp-server`) you can run locally with a personal access token.
+
+## 2. Filesystem
+
+The reference filesystem server (`@modelcontextprotocol/server-filesystem`) gives an agent scoped read/write access to directories you name explicitly. Coding agents can already touch the project they run in; this server matters when the agent needs a directory outside its working tree, such as a shared notes folder or a second repository, without granting access to your whole disk.
+
+Requires Node.js. The paths you pass as arguments are the only ones the server will touch:
+
+```bash
+claude mcp add filesystem -- npx -y @modelcontextprotocol/server-filesystem ~/notes ~/other-repo
+```
+
+```json
+{
+  "mcpServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@modelcontextprotocol/server-filesystem",
+        "/Users/you/notes",
+        "/Users/you/other-repo"
+      ]
+    }
+  }
+}
+```
+
+## 3. Postgres
+
+Postgres MCP Pro (`postgres-mcp`) lets an agent inspect schemas, run queries, and analyze slow query plans. This changes debugging: the agent reads your real schema instead of working from your description of it, and when a query is slow it runs `EXPLAIN` itself.
+
+Requires Python with [uv](https://docs.astral.sh/uv/) installed. Run it in restricted mode so the agent gets read-only access:
+
+```bash
+claude mcp add postgres \
+  --env DATABASE_URI=postgresql://user:pass@localhost:5432/mydb \
+  -- uvx postgres-mcp --access-mode=restricted
+```
+
+```json
+{
+  "mcpServers": {
+    "postgres": {
+      "command": "uvx",
+      "args": ["postgres-mcp", "--access-mode=restricted"],
+      "env": {
+        "DATABASE_URI": "postgresql://user:pass@localhost:5432/mydb"
+      }
+    }
+  }
+}
+```
+
+Point `DATABASE_URI` at a development database. Giving an agent unrestricted access to production data is a decision to make deliberately, not a default.
+
+## 4. Playwright
+
+Microsoft's Playwright MCP server (`@playwright/mcp`) drives a real browser: navigate, click, fill forms, take screenshots, read the accessibility tree. For frontend work this closes the verification gap. The agent makes a UI change, loads the page, and checks the result instead of assuming the change worked because it compiled.
+
+Requires Node.js:
+
+```bash
+claude mcp add playwright -- npx -y @playwright/mcp@latest
+```
+
+```json
+{
+  "mcpServers": {
+    "playwright": {
+      "command": "npx",
+      "args": ["-y", "@playwright/mcp@latest"]
+    }
+  }
+}
+```
+
+By default it operates on the accessibility snapshot rather than screenshots, which is faster and cheaper in tokens. Pass `--headless` if you do not want a browser window appearing while the agent works.
+
+## 5. Fetch
+
+The reference fetch server (`mcp-server-fetch`) retrieves a URL and converts the page to markdown. It is the simplest server on this list and one of the most used: pulling a changelog, a GitHub issue thread, or an API's documentation page into context without you copy-pasting it.
+
+Requires Python with uv installed:
+
+```bash
+claude mcp add fetch -- uvx mcp-server-fetch
+```
+
+```json
+{
+  "mcpServers": {
+    "fetch": {
+      "command": "uvx",
+      "args": ["mcp-server-fetch"]
+    }
+  }
+}
+```
+
+Some clients ship a built-in fetch tool. If yours does, skip this one.
+
+## 6. Railway
+
+The [Railway MCP server](/ai/mcp-server) connects your agent to your Railway projects and infrastructure: create projects, deploy services, provision databases from templates, pull environment variables, read deploy logs, and hand multi-step debugging to Railway's own agent. It turns "deploy this and tell me why staging is failing" into something the agent does rather than something it explains to you.
+
+If you have the [Railway CLI](/cli) installed, one command configures your detected clients:
+
+```bash
+railway setup agent          # local MCP through the CLI
+railway setup agent --remote # hosted remote MCP
+```
+
+Or wire it manually. The remote endpoint authenticates via OAuth:
+
+```bash
+claude mcp add --transport http railway https://mcp.railway.com
+```
+
+```json
+{
+  "mcpServers": {
+    "railway": {
+      "url": "https://mcp.railway.com"
+    }
+  }
+}
+```
+
+The local variant runs through the CLI (`command: "railway"`, `args: ["mcp"]`) and shares the CLI's authentication and linked-project context, which is convenient when your agent works inside a repo already linked to a Railway project. The remote endpoint, by contrast, needs no local install and includes the `railway-agent` tool for multi-step operations like log analysis and failure diagnosis. Full tool lists and per-editor tables for both are in the [MCP server docs](/ai/mcp-server).
+
+## 7. Context7
+
+Context7 (by Upstash) fetches version-specific library documentation into the agent's context. Models are trained on a snapshot of the ecosystem; when you are on a framework version newer than the model's training data, Context7 supplies current, accurate API docs instead of letting the agent hallucinate from an older release.
+
+It offers a remote endpoint:
+
+```bash
+claude mcp add --transport http context7 https://mcp.context7.com/mcp
+```
+
+```json
+{
+  "mcpServers": {
+    "context7": {
+      "url": "https://mcp.context7.com/mcp"
+    }
+  }
+}
+```
+
+A local variant exists as `npx -y @upstash/context7-mcp` if you prefer stdio; either way, higher rate limits require an API key from context7.com.
+
+## 8. Sentry
+
+Sentry's hosted MCP server gives an agent access to your error tracking: search issues, read stack traces and breadcrumbs, and pull the full event context for a crash. Pasting a stack trace into a chat loses the surrounding data; letting the agent query Sentry directly keeps release, environment, and frequency attached to the error it is fixing.
+
+```bash
+claude mcp add --transport http sentry https://mcp.sentry.dev/mcp
+```
+
+```json
+{
+  "mcpServers": {
+    "sentry": {
+      "url": "https://mcp.sentry.dev/mcp"
+    }
+  }
+}
+```
+
+Authentication is OAuth against your Sentry organization. The agent sees only the projects your account can see.
+
+## 9. Memory
+
+The reference memory server (`@modelcontextprotocol/server-memory`) maintains a local knowledge graph the agent can write to and read across sessions. Facts you would otherwise repeat every session, such as architecture decisions, naming conventions, or the reason a workaround exists, persist between conversations.
+
+Requires Node.js:
+
+```bash
+claude mcp add memory -- npx -y @modelcontextprotocol/server-memory
+```
+
+```json
+{
+  "mcpServers": {
+    "memory": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-memory"]
+    }
+  }
+}
+```
+
+By default the graph is stored in a JSON file alongside the package; set the `MEMORY_FILE_PATH` environment variable to keep it somewhere durable. Many agents now have their own persistent memory features, so check what your client already does before adding this.
+
+## Keep the tool list small
+
+Every connected server adds tool definitions to the agent's context on every request, and that cost compounds fast: connect a dozen servers and you pay for thousands of tokens of tool schemas before the conversation even starts, while the agent gets worse at picking the right one. So connect only the three or four servers your current work actually needs, scope them per project where your client supports it, and remove the ones you stop using.
+
+Two other habits worth keeping:
+
+- **Review before approving.** MCP tools act with your credentials. Clients prompt before tool calls by default; keep it that way for anything that writes, deploys, or deletes.
+- **Prefer OAuth over pasted keys.** Remote servers with OAuth issue short-lived, revocable tokens. A key in a JSON config file is neither.
+
+## Next steps
+
+- [Build and deploy your own MCP server](/guides/mcp-server) when no existing server covers your app's data.
+- [Choose between local and remote MCP servers](/guides/local-vs-remote-mcp-servers) for the transport tradeoffs in depth.
+- [Railway MCP server reference](/ai/mcp-server) for the full tool list and per-editor config tables.
+- [Running agents on Railway](/guides/running-agents-on-railway) to host the agent itself, not just its tools.

--- a/content/guides/build-time-vs-runtime-secrets.md
+++ b/content/guides/build-time-vs-runtime-secrets.md
@@ -1,0 +1,150 @@
+---
+title: Handle Build-Time vs Runtime Secrets in Docker Builds
+description: When Docker builds on Railway can see your variables, how to pass build secrets with ARG, and why runtime secrets should never be baked into the image.
+date: "2026-07-29"
+tags:
+  - docker
+  - secrets
+  - builds
+  - environment-variables
+topic: infrastructure
+---
+
+A build-time secret is a value your Dockerfile needs while the image is being built, such as a private registry token or an npm auth token. A runtime secret is a value your application reads after the container starts, such as a database URL or a Stripe key. Mixing the two up causes one of two failure modes: a build that fails because a variable is `undefined`, or a secret permanently baked into image layers where anyone with the image can read it.
+
+Avoiding both starts with knowing how Railway exposes variables to Docker builds, how to consume them at each phase, and how to keep runtime secrets out of the final image.
+
+## How Railway injects variables
+
+Railway makes your [service variables](/variables) available in two places:
+
+- **The build process.** Every variable you define, plus [Railway-provided variables](/variables#railway-provided-variables) like `RAILWAY_ENVIRONMENT`, is available while your service builds.
+- **The running deployment.** The same variables are injected as plain environment variables into the container at start.
+
+There is one difference between build systems:
+
+- **Railpack builds** (Railway's default builder) expose variables to the build automatically.
+- **Dockerfile builds** do not. Docker isolates the build from the host environment by design. To use a Railway variable during a Dockerfile build, you must opt in with an `ARG` instruction.
+
+At runtime there is no difference. Your process reads `process.env.DATABASE_URL` (or the equivalent in your language) regardless of how the image was built.
+
+## Use a variable at build time with ARG
+
+Declare the variable with `ARG` in your Dockerfile. Railway matches the `ARG` name against your service variables and passes the value in:
+
+```dockerfile
+FROM node:22-slim AS build
+
+WORKDIR /app
+
+# Opt in to the Railway variable for this build stage
+ARG NPM_TOKEN
+
+COPY package.json package-lock.json ./
+RUN echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc \
+    && npm ci \
+    && rm .npmrc
+
+COPY . .
+RUN npm run build
+
+FROM node:22-slim
+
+WORKDIR /app
+COPY --from=build /app/dist ./dist
+COPY --from=build /app/node_modules ./node_modules
+COPY package.json ./
+
+CMD ["node", "dist/server.js"]
+```
+
+Two rules:
+
+1. **`ARG` is scoped to a build stage.** In a multi-stage build, declare the `ARG` inside the stage that uses it. An `ARG` declared before the first `FROM` is not visible inside any stage unless you redeclare it.
+2. **`ARG` values do not persist into the running container.** Unlike `ENV`, an `ARG` disappears when the build finishes. That is exactly what you want for build-only secrets.
+
+```dockerfile
+FROM node:22-slim
+
+# Correct: declared inside the stage that needs it
+ARG RAILWAY_ENVIRONMENT
+RUN echo "Building for ${RAILWAY_ENVIRONMENT}"
+```
+
+## Keep secrets out of the final image
+
+Docker image layers are an archive of everything that happened during the build. That's why a secret written to a file in one `RUN` instruction and deleted in a later one still exists in the earlier layer. The same holds for `ARG` values used in `RUN` commands: they're recorded in image metadata too, where `docker history` can show them.
+
+To limit exposure:
+
+- **Use multi-stage builds.** Do secret-dependent work (dependency installation, private git clones) in an early stage, then `COPY --from` only the artifacts you need into the final stage. Layers from earlier stages are not shipped with the final image.
+- **Create and remove the secret in a single `RUN`.** Writing and deleting `.npmrc` in one instruction, as in the example above, keeps the token out of any committed layer in that stage.
+- **Never promote a secret with `ENV`.** `ENV NPM_TOKEN=${NPM_TOKEN}` stores the value in the image config permanently. Use `ENV` only for non-sensitive configuration.
+
+## Runtime secrets need no Dockerfile changes
+
+Runtime secrets should not appear in your Dockerfile at all. Instead, Railway injects every service variable into the container environment when it starts, and your application reads them directly:
+
+```js
+// server.js
+const http = require("http");
+
+const port = process.env.PORT || 3000;
+const databaseUrl = process.env.DATABASE_URL;
+
+if (!databaseUrl) {
+  console.error("DATABASE_URL is not set");
+  process.exit(1);
+}
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ status: "ok" }));
+});
+
+server.listen(port, () => {
+  console.log(`Listening on ${port}`);
+});
+```
+
+Nothing needs to be declared in the Dockerfile, and nothing is baked into the image. This also means you can change a runtime secret and redeploy without rebuilding the image, and the same image works across environments because each environment supplies its own variable values.
+
+## Volumes are not available at build time
+
+A common mistake is trying to read or write persistent data during the build. [Volumes](/volumes), though, are mounted to your service's container only when it starts, not during the build, so anything written to the mount path in a `RUN` instruction lands in the image layer instead of the volume, and won't persist.
+
+Volumes are also not mounted during the pre-deploy command. If a step needs volume data, run it as part of the start command.
+
+The same logic applies to secrets stored as files: you cannot stage a credentials file on a volume and expect the build to read it. Pass build credentials through `ARG` instead.
+
+## Sealed variables work in both phases
+
+If a secret should never be readable again after you set it, seal it. [Sealed variables](/variables#sealed-variables) are provided to builds and deployments like any other variable, but their values can never be viewed in the dashboard or retrieved through the API afterward. Sealing changes visibility, not availability: a sealed `NPM_TOKEN` still flows into a Dockerfile `ARG` at build time.
+
+Note the constraints: sealed variables cannot be un-sealed, and they are not copied when duplicating an environment or service.
+
+## Quick reference
+
+| Need | Mechanism | Where it lives |
+| --- | --- | --- |
+| Private package install during build | `ARG` in the build stage | Discarded after build |
+| Value your app reads while running | Service variable, read from process env | Injected at container start |
+| Non-sensitive config baked into image | `ENV` | Stored in image config |
+| Persistent files | Volume | Mounted at container start, never during build |
+
+## Common failure modes
+
+**Variable is empty during the build.** You did not declare a matching `ARG`, or you declared it in a different build stage. Add `ARG MY_VAR` to the stage that uses it.
+
+**Secret visible in the image.** You used `ENV` for a secret, or wrote it to a file and deleted it in a separate `RUN` instruction. Move the secret handling into a single `RUN` inside an early stage of a multi-stage build.
+
+**Changed a variable but the app still sees the old value.** If the value was consumed at build time, it is frozen in the image until the next build. Deploy again to rebuild. Runtime variables do not have this problem; they are injected fresh at every start.
+
+**Build writes to a volume path but data is missing at runtime.** Expected behavior. Volumes are attached only to the running container. Generate the data in your start command instead.
+
+## Next steps
+
+- [Dockerfiles on Railway](/builds/dockerfiles) covers custom Dockerfile paths, cache mounts, and build-time variables.
+- [Using Variables](/variables) explains service, shared, reference, and sealed variables.
+- [Managing Secrets on Railway](/guides/managing-secrets-on-railway) walks through choosing the right variable scope for each secret.
+- [Frontend Environment Variables](/guides/frontend-environment-variables) covers the build-time vs runtime split in Vite, Next.js, and other frontend frameworks.

--- a/content/guides/bullmq-jobs-retry-dlq.md
+++ b/content/guides/bullmq-jobs-retry-dlq.md
@@ -1,0 +1,245 @@
+---
+title: Schedule, Retry, and Dead-Letter Jobs with BullMQ
+description: Run BullMQ on Railway with a Redis service and an always-on worker. Covers repeatable job schedules, retries with exponential backoff, and a dead-letter queue pattern.
+date: "2026-07-29"
+tags:
+  - queues
+  - workers
+  - redis
+  - architecture
+topic: architecture
+---
+
+BullMQ is a Redis-backed job queue for Node.js. A producer adds jobs to a queue in Redis, and one or more workers pull jobs off the queue and process them. On top of that, this guide sets up the three features most production queues need: scheduled (repeatable) jobs, automatic retries with backoff, and a dead-letter queue for jobs that exhaust their retries.
+
+On Railway, the setup is two services in one project: a Redis database and an always-on worker service. A third service (your API) usually acts as the producer.
+
+## Set up Redis and the worker service
+
+1. Create a project and add Redis: click **+ New → Database → Redis**. See [Redis on Railway](/databases/redis).
+2. Create a [service](/services) for your worker, deployed from [GitHub](/deployments/github-autodeploys) or the [Railway CLI](/cli).
+3. In the worker's variables, add a [reference variable](/variables#referencing-another-services-variable) so it can reach Redis over [private networking](/networking/private-networking):
+
+```
+REDIS_URL=${{Redis.REDIS_URL}}
+```
+
+Private networking is per environment, and services resolve each other at `<service>.railway.internal`. Traffic between the worker and Redis over the private network does not count as egress.
+
+Do not enable [serverless](/deployments/serverless) on the worker. A queue worker needs to run continuously to pick up jobs, and a BullMQ worker's persistent Redis connection keeps the service awake anyway, so serverless would save nothing.
+
+Install the dependencies:
+
+```bash
+npm install bullmq ioredis
+```
+
+BullMQ uses `ioredis` for its Redis connections. On Railway's private network, those connections need `family: 0` set in the options so the client can resolve both IPv6 and IPv4 endpoints. See [private networking library configuration](/networking/private-networking/library-configuration).
+
+## Create a shared connection module
+
+Both the producer and the worker need the same connection settings. Put them in one module.
+
+```typescript
+// connection.ts
+import { RedisOptions } from "ioredis";
+
+const redisURL = new URL(process.env.REDIS_URL!);
+
+export const connection: RedisOptions = {
+  family: 0,
+  host: redisURL.hostname,
+  port: Number(redisURL.port),
+  username: redisURL.username || undefined,
+  password: redisURL.password || undefined,
+  maxRetriesPerRequest: null,
+};
+
+export const QUEUE_NAME = "emails";
+export const DLQ_NAME = "emails-dlq";
+```
+
+`maxRetriesPerRequest: null` is required by BullMQ workers; it tells ioredis to keep commands queued during a reconnect instead of failing them.
+
+## Add jobs with retry options
+
+The producer is any process that enqueues work, typically your API service, and it can configure retries per job or as queue defaults.
+
+```typescript
+// producer.ts
+import { Queue } from "bullmq";
+import { connection, QUEUE_NAME } from "./connection";
+
+export const emailQueue = new Queue(QUEUE_NAME, {
+  connection,
+  defaultJobOptions: {
+    attempts: 5,
+    backoff: {
+      type: "exponential",
+      delay: 3000,
+    },
+    removeOnComplete: { age: 3600, count: 1000 },
+    removeOnFail: false,
+  },
+});
+
+export async function enqueueWelcomeEmail(to: string) {
+  await emailQueue.add("welcome-email", { to });
+}
+```
+
+What these options do:
+
+- `attempts: 5` runs the job up to 5 times total before marking it failed.
+- `backoff` with `type: "exponential"` and `delay: 3000` waits 3s, 6s, 12s, 24s between retries.
+- `removeOnComplete` prunes completed jobs so Redis memory stays bounded.
+- `removeOnFail: false` keeps failed jobs in Redis so the dead-letter handler can inspect them.
+
+## Schedule repeatable jobs
+
+BullMQ job schedulers create repeatable jobs from a cron expression or an interval. `upsertJobScheduler` is idempotent, so it is safe to call on every deploy.
+
+```typescript
+// schedules.ts
+import { emailQueue } from "./producer";
+
+export async function registerSchedules() {
+  // Every day at 08:00 UTC
+  await emailQueue.upsertJobScheduler(
+    "daily-digest",
+    { pattern: "0 8 * * *" },
+    { name: "daily-digest", data: {} }
+  );
+
+  // Every 10 minutes
+  await emailQueue.upsertJobScheduler(
+    "reconcile",
+    { every: 10 * 60 * 1000 },
+    { name: "reconcile", data: {} }
+  );
+}
+```
+
+Because the worker is always on, BullMQ schedules can run every few seconds. Railway's native [cron jobs](/cron-jobs) are a lighter alternative for tasks that run infrequently: the service starts on a schedule, executes, and exits, so you pay nothing between runs. Railway cron has a 5 minute minimum frequency, evaluates schedules in UTC, and skips a run if the previous one is still active. Use Railway cron for a nightly cleanup script; use BullMQ schedulers when scheduled work should flow through the same queue, retry logic, and dead-letter handling as everything else.
+
+## Process jobs and dead-letter failures
+
+BullMQ has no built-in dead-letter queue. The standard pattern is to listen for the `failed` event and, when a job has exhausted its attempts, copy it into a second queue that no worker consumes. That queue becomes your dead-letter queue: a durable, inspectable record of permanently failed work.
+
+```typescript
+// worker.ts
+import { Queue, Worker, Job } from "bullmq";
+import { connection, QUEUE_NAME, DLQ_NAME } from "./connection";
+import { registerSchedules } from "./schedules";
+
+const deadLetterQueue = new Queue(DLQ_NAME, { connection });
+
+const worker = new Worker(
+  QUEUE_NAME,
+  async (job: Job) => {
+    switch (job.name) {
+      case "welcome-email":
+        await sendEmail(job.data.to);
+        break;
+      case "daily-digest":
+        await sendDigest();
+        break;
+      case "reconcile":
+        await reconcile();
+        break;
+      default:
+        throw new Error(`Unknown job: ${job.name}`);
+    }
+  },
+  { connection, concurrency: 10 }
+);
+
+worker.on("failed", async (job, err) => {
+  if (!job) return;
+  const maxAttempts = job.opts.attempts ?? 1;
+  if (job.attemptsMade >= maxAttempts) {
+    await deadLetterQueue.add(job.name, job.data, {
+      jobId: `dlq-${job.id}`,
+      removeOnComplete: false,
+    });
+    console.error(`Dead-lettered ${job.name} (${job.id}): ${err.message}`);
+  }
+});
+
+worker.on("completed", (job) => {
+  console.log(`Completed ${job.name} (${job.id})`);
+});
+
+async function main() {
+  await registerSchedules();
+  console.log("Worker started");
+}
+
+async function shutdown() {
+  await worker.close();
+  await deadLetterQueue.close();
+  process.exit(0);
+}
+
+process.on("SIGTERM", shutdown);
+process.on("SIGINT", shutdown);
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+
+// Replace with your real implementations
+async function sendEmail(to: string) {}
+async function sendDigest() {}
+async function reconcile() {}
+```
+
+Two details matter here:
+
+- The `failed` event fires on every failed attempt, not just the last one. Checking `job.attemptsMade >= maxAttempts` ensures only terminal failures reach the dead-letter queue.
+- The `SIGTERM` handler calls `worker.close()`, which waits for in-flight jobs to finish before exiting. Railway sends `SIGTERM` on redeploys, but by default the old deployment gets 0 seconds to shut down before `SIGKILL`. Set a [draining time](/deployments/deployment-teardown) (via the service settings or the `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` variable) long enough for your slowest job so in-flight work can finish. Jobs that do get interrupted are marked stalled by BullMQ and retried automatically.
+
+## Replay dead-lettered jobs
+
+Because the dead-letter queue is a normal BullMQ queue, replaying is just moving jobs back.
+
+```typescript
+// replay.ts
+import { Queue } from "bullmq";
+import { connection, QUEUE_NAME, DLQ_NAME } from "./connection";
+
+async function replay() {
+  const dlq = new Queue(DLQ_NAME, { connection });
+  const mainQueue = new Queue(QUEUE_NAME, { connection });
+
+  const jobs = await dlq.getJobs(["waiting", "delayed", "failed"]);
+  for (const job of jobs) {
+    await mainQueue.add(job.name, job.data);
+    await job.remove();
+  }
+
+  console.log(`Replayed ${jobs.length} jobs`);
+  await dlq.close();
+  await mainQueue.close();
+  process.exit(0);
+}
+
+replay();
+```
+
+Run this as a one-off task after fixing the underlying bug. You can also wire it to a Railway [cron job](/cron-jobs) if you want periodic automatic replays; a replay script exits when done, which is what Railway cron expects.
+
+## Operational notes
+
+- **Redis memory is the queue's only storage.** Set `removeOnComplete` and prune the dead-letter queue, or Redis will grow until it hits its memory limit and starts evicting or rejecting writes.
+- **Scale workers horizontally.** BullMQ guarantees each job is processed by one worker at a time, so you can run multiple [replicas](/deployments/scaling) of the worker service against the same queue.
+- **Monitor the failed and dead-letter counts.** `queue.getJobCounts("failed", "waiting", "delayed")` gives you the numbers to export or alert on.
+- **Do not run the worker as a Railway cron job.** A BullMQ worker holds an open Redis connection and never exits, which violates the cron requirement that the process terminates; subsequent cron runs would be skipped.
+
+## Next steps
+
+- [Choose between cron jobs, workers, and queues](/guides/cron-workers-queues) for when a queue is the right pattern at all.
+- [Redis on Railway](/databases/redis) for backups and connecting externally.
+- [Private networking](/networking/private-networking) for how services reach Redis without egress fees.
+- [Cron jobs](/cron-jobs) for scheduled tasks that should not run through a queue.

--- a/content/guides/cache-headers-cdn.md
+++ b/content/guides/cache-headers-cdn.md
@@ -1,0 +1,209 @@
+---
+title: Speed Up a Global App with Cache-Control Headers and a CDN
+description: Set Cache-Control headers correctly for static assets, HTML, and API responses, then put a CDN in front of your Railway service to serve users from the nearest edge.
+date: "2026-07-29"
+tags:
+  - caching
+  - cdn
+  - performance
+  - networking
+topic: infrastructure
+---
+
+A user in Singapore requesting a page from a service in US West waits on every round trip. Caching fixes most of that wait. The browser caches what it already downloaded, and a CDN caches responses at edge locations near your users, so repeat requests don't cross the ocean.
+
+Both layers are driven by one header: `Cache-Control`, which your service sets on each response to declare who may cache it and for how long. Get that right first: a CDN with wrong headers either caches nothing (no speedup) or caches too much (users see each other's data).
+
+## How Cache-Control works
+
+`Cache-Control` is a comma-separated list of directives. The ones that matter in practice:
+
+| Directive | Meaning |
+| --------- | ------- |
+| `public` | Any cache (browser or CDN) may store the response. |
+| `private` | Only the end user's browser may store it. CDNs must not. |
+| `no-store` | Nobody caches it. Every request hits your service. |
+| `max-age=N` | The response is fresh for N seconds. |
+| `s-maxage=N` | Freshness for shared caches (CDNs) only. Overrides `max-age` at the edge. |
+| `immutable` | The content at this URL never changes, so the browser skips revalidation. |
+| `stale-while-revalidate=N` | For N seconds after expiry, serve the stale copy instantly and refresh in the background. |
+| `stale-if-error=N` | For N seconds after expiry, serve the stale copy if the origin returns an error. |
+
+A response with no `Cache-Control` header gets whatever each client decides: browsers apply heuristics and CDNs apply their own defaults. Set headers explicitly.
+
+## Choose a policy per response type
+
+Different responses need different lifetimes: four categories cover most apps.
+
+### Hashed static assets: cache forever
+
+Bundlers like Vite, webpack, and esbuild write asset filenames with a content hash (`app.4f8a2c.js`). When the content changes, the filename changes, so the old URL never goes stale. Cache these as long as possible:
+
+```
+Cache-Control: public, max-age=31536000, immutable
+```
+
+That is one year. `immutable` tells browsers to skip revalidation entirely.
+
+### HTML: short TTL with stale-while-revalidate
+
+HTML URLs are stable (`/`, `/pricing`), so you cannot cache them forever. A short freshness window plus `stale-while-revalidate` gives you edge-speed responses without stale pages:
+
+```
+Cache-Control: public, max-age=0, s-maxage=60, stale-while-revalidate=300
+```
+
+Browsers revalidate every time (`max-age=0`), the CDN serves it for 60 seconds, and for 5 minutes after that it serves the cached copy instantly while fetching a fresh one in the background.
+
+### Public API responses: short shared cache
+
+JSON that is the same for every user (a public catalog, a status endpoint) can take a short `s-maxage` so bursts of traffic collapse into one origin request:
+
+```
+Cache-Control: public, s-maxage=30, stale-while-revalidate=60
+```
+
+### Personalized or sensitive responses: keep them out of shared caches
+
+Anything that depends on who is asking must never land in a CDN cache:
+
+```
+Cache-Control: private, no-store
+```
+
+Use this for account pages, dashboards, and any response after login. Railway's CDN adds two protections of its own: requests with an `Authorization` header bypass the cache, and responses with a `Set-Cookie` header are never cached.
+
+## Complete example: Express with per-route cache headers
+
+This server applies all four policies. Create a project and install the dependency:
+
+```bash
+mkdir cache-demo && cd cache-demo
+npm init -y
+npm install express
+```
+
+Create `server.js`:
+
+```javascript
+const express = require("express");
+const path = require("path");
+
+const app = express();
+
+// 1. Hashed static assets: cache for a year.
+//    Build tools put content hashes in these filenames,
+//    so a URL's content never changes.
+app.use(
+  "/assets",
+  express.static(path.join(__dirname, "dist/assets"), {
+    immutable: true,
+    maxAge: "365d",
+    etag: true,
+  })
+);
+
+// 2. HTML: short shared-cache TTL with stale-while-revalidate.
+app.get("/", (req, res) => {
+  res.set(
+    "Cache-Control",
+    "public, max-age=0, s-maxage=60, stale-while-revalidate=300"
+  );
+  res.type("html").send("<h1>Cached at the edge for 60 seconds</h1>");
+});
+
+// 3. Public API data: brief shared caching to absorb bursts.
+app.get("/api/products", (req, res) => {
+  res.set("Cache-Control", "public, s-maxage=30, stale-while-revalidate=60");
+  res.json([
+    { id: 1, name: "Widget" },
+    { id: 2, name: "Gadget" },
+  ]);
+});
+
+// 4. Personalized data: never cached anywhere shared.
+app.get("/api/me", (req, res) => {
+  res.set("Cache-Control", "private, no-store");
+  res.json({ user: "current-user", plan: "pro" });
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Listening on ${port}`);
+});
+```
+
+Run it locally with `node server.js` and inspect the headers:
+
+```bash
+curl -sI http://localhost:3000/ | grep -i cache-control
+curl -sI http://localhost:3000/api/me | grep -i cache-control
+```
+
+Deploy it to Railway from the project directory:
+
+```bash
+railway init
+railway up
+```
+
+Railway detects the Node app and builds it with [Railpack](/builds/build-configuration). Generate a public domain from the service's settings, or with `railway domain`.
+
+## Enable Railway's built-in CDN
+
+Railway includes a [CDN](/networking/cdn) that caches responses at edge locations worldwide. It is available on all plans at no extra cost, off by default, and enabled per service. Once it's on, cache hits are served entirely from the edge: they use none of your service's compute and incur no [network egress](/pricing/understanding-your-bill) charges.
+
+Enable it in the service's **Settings** under the **Edge** section, or from the CLI:
+
+```bash
+railway cdn enable --service web
+```
+
+It applies to all of the service's domains, both the Railway-provided `*.up.railway.app` domain and custom domains, with no DNS changes.
+
+### How the CDN reads your headers
+
+The headers you set above map directly onto the CDN's behavior:
+
+- **Static assets** (identified by response `Content-Type`, such as `image/*`, `text/css`, `application/javascript`) are cached even without headers, using your `max-age` when present and a configurable default TTL otherwise. Your one-year `immutable` header means they are fetched from your service once.
+- **HTML** is cached in the default **Auto** mode only when you send a `max-age` or `s-maxage`, which the example does. The CDN resolves the TTL from `s-maxage` first, then `max-age`.
+- **`stale-while-revalidate`** is honored by default: within the window, the edge answers instantly from cache and refreshes in the background, coalescing a burst of requests into a single origin fetch.
+- **`private` and `no-store`** responses are never cached, and neither is any response carrying `Set-Cookie`.
+- **JSON and other non-HTML, non-static responses** are cached only with an explicit `max-age` or `s-maxage`, so the `/api/products` policy works and unheadered API routes stay dynamic.
+
+### Verify it is working
+
+Request the same URL twice and read the `x-cache` response header:
+
+```bash
+curl -sI https://your-app.up.railway.app/ | grep -i x-cache
+curl -sI https://your-app.up.railway.app/ | grep -i x-cache
+```
+
+The first request returns `x-cache: MISS`, the second `x-cache: HIT`. A third result, `DYNAMIC`, means the response was not cacheable, usually a missing freshness directive on HTML. You can also hit `/.railway/cdn-trace` on any CDN-enabled domain to see which edge location is serving you.
+
+### Handle deploys
+
+By default, Railway purges cached HTML on each successful deploy, so a new page version cannot reference old asset URLs while your hashed assets stay cached. You can also purge manually:
+
+```bash
+railway cdn purge html
+railway cdn purge all
+```
+
+## Using an external CDN instead
+
+The same headers work with any CDN. Point the CDN's origin at your Railway service's domain and it will respect `s-maxage`, `stale-while-revalidate`, and `private` the same way. This is the right choice when you need per-URL invalidation, custom edge logic, or a CDN your organization already standardizes on. For a full walkthrough with a managed distribution, see [Add a CDN using Amazon CloudFront](/guides/add-a-cdn-using-cloudfront).
+
+If you use an external CDN, leave Railway's CDN off for that service so you are not debugging two cache layers.
+
+## Move the origin closer too
+
+Caching hides origin latency for repeat requests, but cache misses and dynamic routes still travel to your service, so pick a [deployment region](/deployments/regions) near your largest user base. Railway's [edge network](/networking/edge-networking) routes each request to the nearest entry point regardless of where the service runs.
+
+## Next steps
+
+- [CDN](/networking/cdn) for the full reference on cache eligibility, TTL resolution, and purging
+- [Edge networking](/networking/edge-networking) for how requests reach your service
+- [Add a CDN using Amazon CloudFront](/guides/add-a-cdn-using-cloudfront) for an external CDN integration
+- [Optimize performance](/deployments/optimize-performance) for scaling your service's resources

--- a/content/guides/claude-agent-sdk-app.md
+++ b/content/guides/claude-agent-sdk-app.md
@@ -1,0 +1,219 @@
+---
+title: Deploy a Claude Agent SDK App
+description: Deploy a Claude Agent SDK service on Railway that runs agent tasks over HTTP, streams progress as NDJSON, and stays inside the platform's request limits.
+date: "2026-07-29"
+tags:
+  - ai
+  - agents
+  - claude
+  - typescript
+topic: ai
+---
+
+In this guide we deploy an HTTP service on Railway that accepts a task prompt, runs a Claude agent against it, and streams progress back while the agent works. That agent runs on the Claude Agent SDK (`@anthropic-ai/claude-agent-sdk` for TypeScript, `claude-agent-sdk` for Python), Claude Code packaged as a library. It ships the full agent harness: the reasoning loop, built-in tools for reading and writing files, running bash commands, searching code, and fetching the web, plus context management and session handling. You call `query()` with a prompt, and the SDK drives the loop against the Anthropic API until the task is done.
+
+This is different from the plain Anthropic API SDK (`@anthropic-ai/sdk`), where you define your own tools and either write the agent loop yourself or use the SDK tool runner. The Agent SDK gives you a batteries-included coding and filesystem agent. The tradeoff is that it needs somewhere to run: a real filesystem, a shell, and a long-lived process. That is what we set up here.
+
+This is a CPU workload: the agent calls the Anthropic API over HTTP and never runs models locally, so it needs no GPU. Railway doesn't offer GPU instances anyway, and this architecture never asks for one.
+
+## What you will build
+
+A TypeScript service with two endpoints:
+
+- `GET /health` for Railway health checks.
+- `POST /agent` accepts a task prompt, runs the agent, and streams progress back as newline-delimited JSON.
+
+Streaming matters here: Railway closes an HTTP request after 5 minutes with no data transfer, but allows up to 15 minutes total as long as bytes keep flowing. An agent task can think for minutes between visible steps, so writing each SDK message to the response as it arrives keeps the connection alive for the full window.
+
+## Prerequisites
+
+- A Railway account and project. See the [quick start](/quick-start) if you need one.
+- An Anthropic API key from the [Anthropic Console](https://platform.claude.com).
+- Node.js 18 or later locally.
+
+## Set up the project
+
+```bash
+mkdir claude-agent-service && cd claude-agent-service
+npm init -y
+npm install @anthropic-ai/claude-agent-sdk express
+npm install --save-dev typescript @types/express @types/node
+npx tsc --init
+```
+
+Set `"type": "module"` in `package.json` and add build and start scripts:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/server.js"
+  }
+}
+```
+
+In `tsconfig.json`, target modern Node:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
+    "outDir": "dist",
+    "strict": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+## Write the agent service
+
+Create `src/server.ts`:
+
+```typescript
+import express from "express";
+import { mkdirSync } from "node:fs";
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const app = express();
+app.use(express.json());
+
+const WORKSPACE = "/tmp/agent-workspace";
+mkdirSync(WORKSPACE, { recursive: true });
+
+app.get("/health", (_req, res) => {
+  res.status(200).json({ status: "ok" });
+});
+
+app.post("/agent", async (req, res) => {
+  const prompt: unknown = req.body?.prompt;
+  if (typeof prompt !== "string" || prompt.length === 0) {
+    res.status(400).json({ error: "Body must include a 'prompt' string" });
+    return;
+  }
+
+  // Stream newline-delimited JSON so the connection stays active
+  // while the agent works. Railway closes requests idle for 5 minutes.
+  res.setHeader("Content-Type", "application/x-ndjson");
+  res.setHeader("Cache-Control", "no-cache");
+
+  const write = (obj: Record<string, unknown>) => {
+    res.write(JSON.stringify(obj) + "\n");
+  };
+
+  try {
+    for await (const message of query({
+      prompt,
+      options: {
+        model: "claude-opus-5",
+        cwd: WORKSPACE,
+        allowedTools: ["Read", "Write", "Edit", "Bash", "Glob", "Grep"],
+        permissionMode: "bypassPermissions",
+        maxTurns: 30,
+      },
+    })) {
+      if (message.type === "assistant") {
+        for (const block of message.message.content) {
+          if (block.type === "text") {
+            write({ type: "progress", text: block.text });
+          } else if (block.type === "tool_use") {
+            write({ type: "tool", name: block.name });
+          }
+        }
+      } else if (message.type === "result") {
+        write({
+          type: "result",
+          subtype: message.subtype,
+          result: message.subtype === "success" ? message.result : null,
+          turns: message.num_turns,
+          cost_usd: message.total_cost_usd,
+        });
+      }
+    }
+  } catch (error) {
+    write({
+      type: "error",
+      message: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  res.end();
+});
+
+const port = Number(process.env.PORT) || 3000;
+app.listen(port, () => {
+  console.log(`Agent service listening on port ${port}`);
+});
+```
+
+A few decisions worth calling out:
+
+- **`permissionMode: "bypassPermissions"`** lets the agent run tools without interactive approval, which is required for a headless service. The agent can then execute arbitrary shell commands inside your container. Only run prompts you trust, keep the service off the public internet or behind authentication, and scope `allowedTools` down to what the task needs.
+- **`cwd` points at a scratch directory.** That's because Railway's container filesystem is ephemeral: everything the agent writes disappears on the next deploy or restart. If task outputs must persist, attach a [volume](/volumes) and point `cwd` at its mount path instead. Volumes are mounted at runtime only, not during builds or pre-deploy commands.
+- **`maxTurns` caps the loop.** Without it, a stuck agent can burn tokens indefinitely.
+- **The SDK reads `ANTHROPIC_API_KEY` from the environment.** No key appears in code.
+
+Test locally:
+
+```bash
+export ANTHROPIC_API_KEY=sk-ant-...
+npm run build && npm start
+curl -N -X POST http://localhost:3000/agent \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Create a file called notes.md summarizing what tools you have available."}'
+```
+
+## Deploy to Railway
+
+Push the project to a GitHub repository, then create a service from it:
+
+1. In your Railway project, choose **New Service** and select the repository. Railpack detects Node.js, runs `npm install` and `npm run build`, and starts the service with `npm start`.
+2. Open the service's **Variables** tab and add `ANTHROPIC_API_KEY`. Variables are made available to your service as environment variables at runtime, so the key never appears in your code or repository. See [Variables](/variables).
+3. Under **Settings → Networking**, generate a public domain. Railway assigns a `*.up.railway.app` URL and routes traffic to the `PORT` your service listens on.
+4. Configure `/health` as the [health check path](/deployments/healthchecks) so deploys only go live once the server is accepting traffic. Health checks are HTTP only, and a configured health check is what enables zero-downtime deploys.
+
+Once deployed, run a task against the public URL:
+
+```bash
+curl -N -X POST https://your-service.up.railway.app/agent \
+  -H "Content-Type: application/json" \
+  -d '{"prompt": "Write a haiku about deployment logs to haiku.txt, then read it back."}'
+```
+
+Progress lines stream as the agent thinks and calls tools, ending with a `result` line that includes turn count and cost.
+
+## Handle long-running agent tasks
+
+Agent tasks are unpredictable in duration, so plan around Railway's request lifecycle.
+
+**Requests stream for up to 15 minutes.** As long as your response keeps transferring data, Railway holds the connection open for up to 15 minutes, and closes it after 5 minutes of silence. The NDJSON streaming above satisfies the activity requirement for most tasks. If your agent can go quiet for long stretches, write a heartbeat line every 30 to 60 seconds.
+
+**Tasks longer than 15 minutes need a different shape.** Two options:
+
+- **WebSockets** are exempt from the HTTP timeout. Accept the task over a WebSocket connection and push progress events for as long as the agent runs.
+- **A worker pattern.** Have the HTTP endpoint enqueue the task and return an ID immediately, then run the agent in a separate worker service and poll for status. This also lets multiple tasks run concurrently without tying up request handlers. See [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers).
+
+**Leave serverless off for agent services.** Railway's [serverless mode](/deployments/serverless) sleeps a service after 10 minutes without outbound traffic and wakes it on the next request. An idle agent service sends no outbound traffic, so it will sleep, and the first task after a wake pays cold-start latency. That cold start is why agent workloads are usually better served by an always-on service, which is the default.
+
+**Scheduled agent runs work with cron.** If the agent should run on a schedule instead of on demand, configure a [cron schedule](/cron-jobs) on a service that runs one task and exits. Cron granularity is 5 minutes at minimum, schedules are evaluated in UTC, and if a previous run is still executing when the next tick arrives, the new run is skipped rather than stacked. Long agent runs on a tight schedule will silently skip ticks, so size the interval generously.
+
+## Control resource usage and cost
+
+Railway bills by usage: RAM at $10 per GB-month, CPU at $20 per vCPU-month, and egress at $0.05 per GB, billed by the minute while the service runs. Within that, the Agent SDK process itself is light, typically well under 1 GB of RAM, but bash tool calls inherit the container's resources, so a task that compiles a large project consumes what that compile needs. Set [resource limits](/deployments/optimize-performance) on the service, and remember the dominant cost of an agent service is usually Anthropic API tokens, not Railway compute. The `total_cost_usd` field in each result line gives you per-task token spend to log and monitor.
+
+For a fuller cost model covering compute, tokens, and storage together, see [Estimate AI Agent Costs](/guides/estimate-ai-agent-costs).
+
+## Use Python instead
+
+The same architecture works with the Python SDK. Install `claude-agent-sdk` from PyPI, wrap `query()` in a FastAPI streaming endpoint, and deploy the same way; Railpack detects Python projects automatically. The options, tool set, and message stream mirror the TypeScript API. See the [Claude Agent SDK documentation](https://code.claude.com/docs/en/agent-sdk) for the Python reference.
+
+## Next steps
+
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers) for tasks that outlive a single HTTP request.
+- [Running Agents on Railway](/guides/running-agents-on-railway) for a webhook-driven autonomous agent example.
+- [Estimate AI Agent Costs](/guides/estimate-ai-agent-costs) to model compute and token spend before launch.
+- [Stream AI Responses](/guides/streaming-ai-responses) for streaming patterns with the plain Anthropic API.

--- a/content/guides/clickhouse-analytics.md
+++ b/content/guides/clickhouse-analytics.md
@@ -1,0 +1,207 @@
+---
+title: Run ClickHouse for Product Analytics
+description: Deploy ClickHouse on Railway from the template or the official Docker image, size its volume for event data, and ingest and query analytics events from a Node.js service.
+date: "2026-07-29"
+tags:
+  - clickhouse
+  - analytics
+  - databases
+  - volumes
+topic: integrations
+---
+
+ClickHouse is a columnar OLAP database built for analytics. It stores each column separately, compresses aggressively, and scans billions of rows per second on modest hardware. That fits product analytics: you ingest events at high volume and aggregate across all of them cheaply. This guide deploys ClickHouse on Railway, sizes its volume for that event data, and connects a Node.js service that writes and reads those events over private networking.
+
+## Deploy from the template
+
+The fastest path is the [ClickHouse template](https://railway.com/deploy/clickhouse):
+
+1. Open the template page and click **Deploy Now**.
+2. Railway creates a project with a ClickHouse service, an attached volume, and generated credentials.
+3. Once the deployment is live, the service's **Variables** tab holds the connection details.
+
+The template gives you a single ClickHouse server. That is the right shape for product analytics at most scales; a single node handles billions of rows before you need anything more complicated.
+
+## Deploy from the Docker image
+
+If you want full control over configuration, deploy the official image directly:
+
+1. In your project, create a new service and choose **Docker Image** as the source.
+2. Enter `clickhouse/clickhouse-server` (optionally pin a version, for example `clickhouse/clickhouse-server:24.8`).
+3. Set these variables on the service before the first deploy:
+
+```bash
+CLICKHOUSE_DB=analytics
+CLICKHOUSE_USER=analytics_user
+CLICKHOUSE_PASSWORD=<generate a strong password>
+```
+
+4. Attach a volume to the service (right-click the canvas or use the command palette) and set the mount path to `/var/lib/clickhouse`. Without a volume, all data is lost on every redeploy.
+
+The official image listens on all interfaces by default, so it works with Railway's private networking without extra configuration. It exposes two ports that matter here:
+
+- **8123**: the HTTP interface, used by the official language clients.
+- **9000**: the native TCP protocol, used by `clickhouse-client` and some drivers.
+
+## Connect over private networking
+
+Services in the same project environment reach each other at `SERVICE_NAME.railway.internal`. That private network is scoped per environment, carries no egress cost, and never exposes traffic to the public internet.
+
+If your ClickHouse service is named `clickhouse`, your application connects to:
+
+```
+http://clickhouse.railway.internal:8123
+```
+
+Set the connection details as variables on your application service, referencing the ClickHouse service:
+
+```bash
+CLICKHOUSE_URL=http://clickhouse.railway.internal:8123
+CLICKHOUSE_USER=${{clickhouse.CLICKHOUSE_USER}}
+CLICKHOUSE_PASSWORD=${{clickhouse.CLICKHOUSE_PASSWORD}}
+CLICKHOUSE_DB=${{clickhouse.CLICKHOUSE_DB}}
+```
+
+Keep ClickHouse off the public internet. If you need external access, for example from a BI tool or a local `clickhouse-client`, enable [TCP Proxy](/networking/tcp-proxy) on port 9000 in the service's networking settings. Railway generates a public `domain:port` pair that proxies to the service.
+
+## Size the volume
+
+Volume sizing for analytics comes down to three numbers: events per day, bytes per event on disk, and retention.
+
+ClickHouse compresses columnar event data well: a typical product analytics event (timestamp, user ID, event name, a handful of properties) that weighs 150 to 300 bytes as JSON usually lands at 20 to 60 bytes on disk after compression. Ratios of 5x to 10x are common for this workload.
+
+A worked example:
+
+- 10 million events per day at roughly 200 bytes raw is about 2 GB per day of raw data.
+- At 7x compression, that is roughly 300 MB per day on disk.
+- With 90-day retention, steady state is around 27 GB. Add headroom for merges and growth and provision 50 GB.
+
+Railway volumes cost $0.15 per GB per month, and you are only charged for the storage your volume actually uses, so a 50 GB volume holding 27 GB of data bills for the 27 GB. Two operational details matter:
+
+- Volumes can be grown on paid plans, including live resizes with zero downtime. Resizing increases capacity only, so start modest and grow when usage crosses 70 to 80 percent.
+- A new volume reserves roughly 2 to 3 percent of its capacity for filesystem metadata, so it never starts at zero used.
+
+Enforce retention inside ClickHouse with a `TTL` clause rather than manual deletes. The schema below drops rows automatically after 90 days, which keeps volume growth flat once you reach steady state.
+
+Memory matters more than CPU for ClickHouse: aggregation queries hold intermediate state in RAM, and Railway bills memory at $10 per GB per month on usage-based pricing. Give the service enough headroom for your largest `GROUP BY`; if queries fail with memory-limit errors, raise the service's limits in settings.
+
+## Create the events table
+
+Connect with any ClickHouse client and create a MergeTree table. This schema covers the standard product analytics shape:
+
+```sql
+CREATE TABLE analytics.events
+(
+    event_time  DateTime,
+    event_name  LowCardinality(String),
+    user_id     String,
+    session_id  String,
+    properties  String
+)
+ENGINE = MergeTree
+PARTITION BY toYYYYMM(event_time)
+ORDER BY (event_name, user_id, event_time)
+TTL event_time + INTERVAL 90 DAY;
+```
+
+Design notes:
+
+- `ORDER BY` is the primary index. Leading with `event_name` makes per-event aggregations fast, and those are the queries dashboards run most.
+- `LowCardinality(String)` is the right type for event names, which repeat constantly.
+- `PARTITION BY` month keeps TTL drops cheap: expired partitions are removed wholesale.
+- `properties` holds arbitrary JSON as a string. Extract fields at query time with `JSONExtractString(properties, 'key')`.
+
+## Ingest and query from Node.js
+
+Install the official client:
+
+```bash
+npm install @clickhouse/client
+```
+
+The example below inserts a batch of events and runs a daily-active-users query. ClickHouse strongly prefers batched inserts: buffer events in your application and flush every few seconds or every few thousand events rather than inserting one row at a time.
+
+```typescript
+import { createClient } from "@clickhouse/client";
+
+const clickhouse = createClient({
+  url: process.env.CLICKHOUSE_URL ?? "http://clickhouse.railway.internal:8123",
+  username: process.env.CLICKHOUSE_USER ?? "analytics_user",
+  password: process.env.CLICKHOUSE_PASSWORD ?? "",
+  database: process.env.CLICKHOUSE_DB ?? "analytics",
+});
+
+interface AnalyticsEvent {
+  event_time: string;
+  event_name: string;
+  user_id: string;
+  session_id: string;
+  properties: string;
+}
+
+export async function trackEvents(events: AnalyticsEvent[]): Promise<void> {
+  await clickhouse.insert({
+    table: "events",
+    values: events,
+    format: "JSONEachRow",
+  });
+}
+
+interface DauRow {
+  day: string;
+  daily_active_users: string;
+}
+
+export async function dailyActiveUsers(days: number): Promise<DauRow[]> {
+  const result = await clickhouse.query({
+    query: `
+      SELECT
+        toDate(event_time) AS day,
+        uniqExact(user_id) AS daily_active_users
+      FROM events
+      WHERE event_time >= now() - INTERVAL {days: UInt32} DAY
+      GROUP BY day
+      ORDER BY day
+    `,
+    query_params: { days },
+    format: "JSONEachRow",
+  });
+  return result.json<DauRow>();
+}
+
+async function main(): Promise<void> {
+  await trackEvents([
+    {
+      event_time: new Date().toISOString().replace("T", " ").slice(0, 19),
+      event_name: "page_view",
+      user_id: "user_123",
+      session_id: "sess_abc",
+      properties: JSON.stringify({ path: "/pricing", referrer: "google" }),
+    },
+  ]);
+
+  const dau = await dailyActiveUsers(7);
+  console.log(dau);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+Deploy this as a separate service in the same project. Because both services share the environment's private network, the insert and query traffic never leaves Railway and incurs no egress charges.
+
+## Operational notes
+
+- **Backups**: Railway volumes support scheduled [backups](/volumes/backups). Enable them on the ClickHouse volume before you depend on the data.
+- **Redeploys**: the volume persists across redeploys and image upgrades. Pin a specific image tag and upgrade deliberately; ClickHouse upgrades are generally forward-compatible but read the release notes before jumping major versions.
+- **One writer**: run a single ClickHouse replica. MergeTree tables on a single volume do not support multiple concurrent server instances.
+- **Monitoring**: watch disk usage in the service's metrics. If the volume fills completely, ClickHouse stops accepting inserts and the automatic offline resize will restart the service.
+
+## Next steps
+
+- [Using volumes](/volumes) for mount paths, resizing, and backup details
+- [Private networking](/networking/private-networking) for how internal DNS and environment isolation work
+- [Right-size CPU and memory from real metrics](/guides/right-size-cpu-memory) to set limits that fit your query load
+- [Deploy an OpenTelemetry collector stack](/guides/deploy-an-otel-collector-stack) to feed telemetry into your analytics pipeline

--- a/content/guides/code-execution-sandboxes.md
+++ b/content/guides/code-execution-sandboxes.md
@@ -1,0 +1,124 @@
+---
+title: Run Code-Execution Sandboxes for AI Agents
+description: Run AI-generated code in isolated, disposable sandboxes on Railway. What a code-execution sandbox is, why agents need one, and how to create, checkpoint, fork, and destroy sandboxes from the CLI or the TypeScript SDK.
+date: "2026-07-29"
+tags:
+  - sandboxes
+  - agents
+  - code-execution
+  - security
+topic: ai
+---
+
+<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+A code-execution sandbox is an isolated, short-lived environment where an AI agent can run code without putting anything else at risk. The agent writes code, the sandbox executes it, the results come back, and the environment is destroyed. Nothing the code does inside the sandbox touches your machine, your production services, or the next task's sandbox.
+
+In this guide we cover why agents need sandboxes, what a sandbox has to provide, and how to run one on Railway.
+
+## Why agents need a sandbox
+
+An agent that only reads and writes text is safe by construction. An agent that executes code is not. Generated code can delete files, exfiltrate environment variables, install malware, or loop forever. It does not have to be malicious to be dangerous; it only has to be wrong.
+
+Running that code on the machine that hosts the agent means every mistake lands somewhere that matters. A sandbox moves execution somewhere that does not. The blast radius of a bad `rm`, a hostile dependency, or an infinite loop is one disposable environment.
+
+Sandboxes also solve a second problem: reproducibility. An agent that runs tasks in fresh, identical environments produces results that do not depend on leftover state from the last run.
+
+## What a sandbox has to provide
+
+Four properties matter, whatever provider you use:
+
+- **Isolation.** The sandbox cannot reach the host or other tenants. Filesystem, processes, and network are separate.
+- **Fast boot.** Agents create sandboxes per task. An environment that takes minutes to provision breaks the loop.
+- **Snapshot and restore.** Setup is expensive (clone, install, authenticate). A sandbox you can snapshot once and boot many times amortizes it.
+- **Guaranteed teardown.** Sandboxes that outlive their task leak money. Destruction should be explicit and also automatic when you forget.
+
+## Sandboxes on Railway
+
+A Railway [sandbox](/sandboxes) is a short-lived, isolated Linux environment you create on demand, run commands in, and destroy. The default image ships git, Node, npm, and the common agent harnesses. Sandboxes live in a Railway [environment](/environments), so they can optionally join the same [private network](/networking/private-networking) as your other services, or run fully isolated from it.
+
+The lifecycle maps directly onto the four properties above:
+
+```txt
+create -> exec -> checkpoint -> create/fork -> destroy
+```
+
+An [idle timeout](/sandboxes#idle-timeout) tears down sandboxes you forget about.
+
+## Run one from the CLI
+
+With the [Railway CLI](/cli) installed and a project linked:
+
+```bash
+railway sandbox create
+railway sandbox exec -- bash -lc 'echo "print(2+2)" > task.py && python3 task.py'
+railway sandbox destroy
+```
+
+That is the whole loop: an environment appears, runs untrusted code, and disappears. The [`railway sandbox`](/cli/sandbox) reference covers every subcommand, including `ssh`, `fork`, and port forwarding.
+
+## Run one from the TypeScript SDK
+
+When the sandbox belongs inside an application, for example an agent backend that executes generated code per request, use the [TypeScript SDK](/sandboxes#typescript-sdk):
+
+```ts
+import { Sandbox } from "railway";
+
+const sandbox = await Sandbox.create();
+
+const result = await sandbox.exec("bash -lc 'python3 -c \"print(2+2)\"'");
+console.log(result.stdout, result.exitCode);
+
+await sandbox.destroy();
+```
+
+`Sandbox.create()` reads `RAILWAY_API_TOKEN` and `RAILWAY_ENVIRONMENT_ID` from the environment and resolves once the sandbox accepts commands. `exec` does not throw on a non-zero exit code; inspect `exitCode` and `stderr` yourself, since exit codes are signal, not failure, when the code under test is the thing being evaluated.
+
+Wrap execution in `try`/`finally` so the sandbox is destroyed even when a run throws:
+
+```ts
+const sandbox = await Sandbox.create();
+try {
+  const result = await sandbox.exec("bash -lc 'cd /root/workspace && npm test'", {
+    timeoutSec: 600,
+  });
+  return { passed: result.exitCode === 0, output: result.stdout };
+} finally {
+  await sandbox.destroy().catch(() => {});
+}
+```
+
+## Amortize setup with checkpoints
+
+Most agent tasks share setup: clone the repository, install dependencies, configure tools. Do it once, snapshot it, and boot every task from the snapshot:
+
+```bash
+railway sandbox create
+railway sandbox exec -- bash -lc 'git clone https://github.com/your-org/your-repo /root/workspace && cd /root/workspace && npm ci'
+railway sandbox checkpoint create repo-ready
+```
+
+Every subsequent task starts from the prepared state:
+
+```bash
+railway sandbox create --checkpoint repo-ready
+```
+
+A [checkpoint](/sandboxes#checkpoints) is stored server-side and outlives the sandbox it was taken from. When work branches mid-task, [fork](/sandboxes#forking) the running sandbox instead: a fork clones the filesystem into a new independent sandbox, so two approaches can run in parallel from the same prepared state.
+
+## Control what the sandbox can reach
+
+Isolation is a choice per sandbox. By default, keep execution cut off from your infrastructure. When the agent's task is to test against real services, create the sandbox on the project's private network so it can reach Postgres, Redis, and internal APIs:
+
+```bash
+railway sandbox create --checkpoint repo-ready --private-network
+```
+
+Untrusted code with database access is a bigger blast radius. Point networked sandboxes at a development [environment](/environments), not production.
+
+## Next steps
+
+- [Use Agents in Railway Sandboxes](/guides/agents-in-sandboxes): the full development loop, including driving sandboxes from Claude Code and fanning out one sandbox per agent.
+- [Sandboxes](/sandboxes): concepts, SDK reference, networking, and limits.
+- [Running Agents on Railway](/guides/running-agents-on-railway): deploy the agent itself as an always-on service.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): queue sandbox-running tasks behind an API.

--- a/content/guides/connection-pooling-pgbouncer.md
+++ b/content/guides/connection-pooling-pgbouncer.md
@@ -1,0 +1,165 @@
+---
+title: Add Connection Pooling to Postgres with PgBouncer
+description: Why Postgres needs a connection pooler, how to add PgBouncer to a Railway Postgres service, and how to configure your application for pooled and unpooled connections.
+date: "2026-07-29"
+tags:
+  - postgres
+  - pgbouncer
+  - database
+  - infrastructure
+topic: infrastructure
+---
+
+Connection pooling puts a proxy between your application and Postgres. The proxy accepts thousands of cheap client connections and multiplexes them onto a small, fixed set of real server connections. PgBouncer is the standard tool for this.
+
+Pooling is not built into Railway's standard Postgres template: a fresh Postgres service accepts direct connections only. To add it, you layer PgBouncer on top, either through Railway's built-in Connection Pooling feature or as a separate service you run yourself. This guide sets up both, then makes the application-side changes that pooling requires.
+
+## Why Postgres needs a connection pooler
+
+Every Postgres connection is a forked backend process on the server. Each one costs memory and scheduling overhead whether it is running a query or sitting idle. Postgres caps the total with `max_connections`, and once you hit the cap new clients get `FATAL: sorry, too many clients already`.
+
+You hit this limit faster than you expect:
+
+- **Horizontal scaling.** Ten app replicas with a pool of 20 connections each is 200 server connections doing mostly nothing.
+- **Serverless and short-lived workers.** Each cold start opens fresh connections. Under a traffic spike, connection churn alone can take the database down.
+- **ORMs with per-request connections.** Some frameworks open a connection per request and hold it for the request's lifetime.
+
+PgBouncer fixes this by decoupling client count from server count: a single instance can hold 1,000 client connections open while using only 20 real connections to Postgres. Clients then queue for a free server connection instead of failing.
+
+## Add PgBouncer with Railway's Connection Pooling feature
+
+Railway can deploy and manage PgBouncer for you, in front of either a standalone Postgres service or a [Postgres HA cluster](/databases/postgresql-ha).
+
+1. Open your Postgres service.
+2. Go to **Database → Config → Connection Pooling**.
+3. Click **Add PgBouncer**.
+4. Pick a pool mode (see the next section), then deploy the staged changes.
+
+Railway automatically rewrites variable references within your project so services that used your Postgres variables now point at PgBouncer. Connection strings hardcoded outside Railway must be updated by hand.
+
+After deployment you get four connection variables:
+
+| Variable | Points to | Use for |
+|---|---|---|
+| `DATABASE_URL` | PgBouncer, private network | Normal application queries from inside Railway |
+| `DATABASE_PUBLIC_URL` | PgBouncer, TCP proxy | Connections from outside Railway |
+| `DATABASE_UNPOOLED_URL` | Postgres (or HAProxy for HA), private network | Operations that need a dedicated session |
+| `DATABASE_PUBLIC_UNPOOLED_URL` | Postgres (or HAProxy for HA), TCP proxy | Unpooled connections from outside Railway |
+
+The full reference for this feature, including scaling PgBouncer replicas and removing the pooler, is in the [PostgreSQL Connection Pooling docs](/databases/postgresql-pgbouncer).
+
+## Choose a pool mode
+
+Pool mode controls when PgBouncer hands a server connection back to the pool. It is the most important setting you will pick.
+
+| Mode | Server connection is released | Tradeoff |
+|---|---|---|
+| **Transaction** (default) | After each transaction | Best multiplexing. Session-scoped features break. |
+| **Session** | When the client disconnects | Session-scoped features work, but pooling only helps if clients disconnect. |
+| **Statement** | After each statement | Maximum reuse. Multi-statement transactions are not allowed. |
+
+Transaction mode is right for most web applications. The features it breaks are the ones that assume your session and your server connection are the same thing:
+
+- `SET` values that must persist across statements
+- `LISTEN` / `NOTIFY`
+- Advisory locks (`pg_advisory_lock`)
+- Session-level prepared statements created with SQL `PREPARE`
+
+If your application depends on any of these, use session mode, or route just those code paths through `DATABASE_UNPOOLED_URL`.
+
+## Connect your application
+
+Nothing about the wire protocol changes. Point your driver at the pooled URL and keep your driver-side pool small, since PgBouncer does the multiplexing now.
+
+Install the driver:
+
+```bash
+npm install pg
+```
+
+```js
+// db.js
+import pg from "pg";
+
+// DATABASE_URL points at PgBouncer once pooling is enabled.
+export const pool = new pg.Pool({
+  connectionString: process.env.DATABASE_URL,
+  // Keep this modest: PgBouncer multiplexes for you.
+  max: 10,
+  idleTimeoutMillis: 30_000,
+});
+
+export async function getUserCount() {
+  const { rows } = await pool.query("SELECT count(*) AS n FROM users");
+  return Number(rows[0].n);
+}
+```
+
+One caveat for transaction mode: named prepared statements created by the driver can fail with `prepared statement "..." does not exist`, because consecutive queries from one client may run on different server connections. If you see that error, switch the affected workload to session mode or the unpooled URL, or configure your driver to avoid named prepared statements.
+
+### Prisma
+
+Prisma supports the pooled/unpooled split directly. Queries go through PgBouncer, while migrations use a direct connection:
+
+```prisma
+datasource db {
+  provider  = "postgresql"
+  url       = env("DATABASE_URL")
+  directUrl = env("DATABASE_UNPOOLED_URL")
+}
+```
+
+Append `?pgbouncer=true` to the pooled URL so Prisma disables features that are incompatible with transaction pooling.
+
+## Route migrations around the pooler
+
+Schema migrations are the most common thing that breaks behind transaction-mode PgBouncer. Most migration tools wrap the entire run in one transaction, take advisory locks, or run `CREATE INDEX CONCURRENTLY`, all of which need a dedicated server connection.
+
+Migrations need that dedicated connection: application traffic uses `DATABASE_URL`, while migrations use `DATABASE_UNPOOLED_URL`.
+
+```bash
+# Example: run migrations against the direct connection
+DATABASE_URL=$DATABASE_UNPOOLED_URL npx prisma migrate deploy
+```
+
+## Run PgBouncer as a separate service
+
+If you want full control over `pgbouncer.ini`, or you are pooling a Postgres you deployed from a custom image, run PgBouncer as its own Railway service from a Docker image.
+
+1. In your project, create a new service and set its source to the Docker image `edoburu/pgbouncer`.
+2. Configure it through service variables:
+
+```bash
+DB_HOST=postgres.railway.internal
+DB_PORT=5432
+DB_USER=postgres
+DB_PASSWORD=${{Postgres.PGPASSWORD}}
+POOL_MODE=transaction
+DEFAULT_POOL_SIZE=20
+MAX_CLIENT_CONN=1000
+AUTH_TYPE=scram-sha-256
+```
+
+3. Point your application services at the pooler over [private networking](/networking/private-networking): `postgresql://postgres:PASSWORD@pgbouncer.railway.internal:5432/railway`.
+
+Private networking is scoped per environment, so the pooler, the database, and your application must live in the same project environment. Traffic between them stays on the internal network and does not count as egress.
+
+Keep the built-in feature as your default. Run a separate PgBouncer service only when you need configuration the managed pooler does not expose.
+
+## Size the pool
+
+Two numbers matter:
+
+- **`DEFAULT_POOL_SIZE`**: real server connections PgBouncer opens to Postgres. Start at 20. More is not better; Postgres throughput usually peaks at a small multiple of your CPU count.
+- **`MAX_CLIENT_CONN`**: how many application connections PgBouncer will accept. Default 1000.
+
+Keep total server connections (pool size times the number of PgBouncer replicas or instances) below your Postgres `max_connections`, with headroom for migrations and admin sessions on the unpooled URL.
+
+Watch for clients spending long periods waiting for a server connection. That means queries are holding connections too long. Fix the slow queries first; only raise the pool size if the database has capacity to spare.
+
+## Next steps
+
+- [PostgreSQL Connection Pooling reference](/databases/postgresql-pgbouncer) for pool modes, replica scaling, and removal
+- [PostgreSQL on Railway](/databases/postgresql) for the standard template and its variables
+- [Postgres HA](/databases/postgresql-ha) to pair pooling with a replicated cluster
+- [Private networking](/networking/private-networking) for how services reach each other inside an environment

--- a/content/guides/cron-workers-queues.md
+++ b/content/guides/cron-workers-queues.md
@@ -1,7 +1,7 @@
 ---
 title: Choose Between Cron Jobs, Background Workers, and Queues
 description: When to use cron jobs, always-on workers, and message queues for background processing. Covers tradeoffs, failure modes, and how to run each pattern on Railway.
-date: "2026-03-30"
+date: "2026-07-29"
 tags:
   - architecture
   - cron
@@ -100,6 +100,16 @@ The worker runs continuously. It does not need a public domain unless you want t
 3. In your API service, enqueue jobs to Redis using your chosen queue library.
 4. In your worker service, dequeue and process jobs from Redis.
 5. Configure retry behavior and dead-letter handling in your queue library.
+
+## Which pattern fits an AI agent
+
+Agent workloads map onto the same three patterns:
+
+- **A scheduled agent** (nightly report writer, periodic summarizer) is a cron job. One constraint matters more for agents than for most tasks: if a run has not finished when the next is scheduled, the next run is skipped, and Railway does not terminate the previous one. An agent that hangs on an LLM call can silently block every future run. Set a hard timeout in the task code.
+- **An on-demand agent** (a user submits a task, the agent takes minutes to finish) is a queue plus a worker. HTTP requests are capped at 15 minutes even when data keeps flowing, so the request that triggers the agent cannot also wait for it. Enqueue, return a task id, and let the client poll or subscribe.
+- **An always-listening agent** (reacts to webhooks, watches a feed, processes a stream) is a background worker.
+
+For the full on-demand architecture, an API, a Redis queue, workers, and Postgres for state, see [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers).
 
 ## Combining patterns
 

--- a/content/guides/cut-idle-costs-serverless.md
+++ b/content/guides/cut-idle-costs-serverless.md
@@ -1,0 +1,137 @@
+---
+title: Cut Idle Costs with Serverless Mode
+description: Enable Serverless on Railway to sleep idle services and stop paying for compute they do not use. Covers the outbound-traffic sleep trigger and the cold boot tradeoff.
+date: "2026-07-29"
+tags:
+  - serverless
+  - cost optimization
+  - scaling
+  - pricing
+topic: infrastructure
+---
+
+Railway bills by usage: RAM at $10 per GB per month and CPU at $20 per vCPU per month, metered by the minute. A service that runs 24/7 but only handles traffic a few hours a day still pays for every idle minute. Serverless mode fixes this by putting inactive services to sleep and waking them on the next request.
+
+Serverless is a per-service toggle. When enabled, Railway watches the service for activity and stops it after 10 minutes of inactivity. A slept service accrues no compute charges. Its first request wakes it back up, and that wake-up cycle is what this guide covers: how the sleep trigger works, which workloads benefit, and how to write your application so it can sleep.
+
+## How the sleep trigger works
+
+Railway detects inactivity based on **outbound** traffic, not inbound requests. Most surprises with Serverless trace back to this detail.
+
+If your service sends no outbound packets for 10 minutes, it is considered inactive and goes to sleep. Outbound packets include more than API responses:
+
+- Open database connections (connection poolers keep sockets alive)
+- Framework telemetry, such as Next.js phoning home
+- Polling a queue, a webhook endpoint, or any external API
+- Requests to other services in your project over the [private network](/networking/private-networking)
+- NTP and other background network chatter
+
+Any of these resets the 10-minute timer, so a worker that holds a persistent Postgres connection or polls a queue every 30 seconds never sleeps, even if it receives zero requests. Enabling Serverless on it changes nothing except adding cold boot risk.
+
+One caveat: the networking graph in the metrics tab only shows public internet traffic. Private network traffic does not appear there, but it still counts as outbound and still prevents sleep. If a service refuses to sleep and the metrics graph looks quiet, look at private network calls first.
+
+## The cold boot tradeoff
+
+Waking is not free. When a request hits a slept service:
+
+- The first response is delayed while the container spins up (cold boot time).
+- The first request may return a 502 Bad Gateway before the service is ready. Clients should retry.
+- Slept services are de-prioritized on Railway's infrastructure. In rare cases a wake requires a rebuild.
+
+Serverless also applies across all [replicas](/deployments/scaling) of the service. You cannot keep one replica warm and sleep the rest.
+
+## Which workloads fit
+
+Good fits are request-driven services with real idle gaps:
+
+- Staging and preview environments that only see traffic during work hours
+- Internal dashboards and admin tools
+- Low-traffic APIs, demos, and side projects
+- Webhook receivers that fire a few times a day
+
+Bad fits:
+
+- Anything latency-sensitive on the first request (checkout flows, health-checked production APIs)
+- Workers that hold database connections or poll queues (they never sleep anyway)
+- Websocket servers with long-lived clients
+- Databases
+
+For scheduled work, [cron jobs](/cron-jobs) are usually a better model than a sleeping service: the service starts on a crontab schedule, runs its task, and exits. Note that Railway cron schedules run in UTC, the minimum interval is 5 minutes, and if a previous run is still active the next run is skipped, never terminated.
+
+## Enable Serverless
+
+1. Open your service and go to Settings > Deploy > Serverless.
+2. Toggle "Enable Serverless".
+3. Toggle it again to disable.
+
+Full details are in [cost controls](/pricing/cost-control#enabling-serverless).
+
+## Make your app sleep-friendly
+
+Enabling the toggle is not enough if your code emits background traffic. Two changes cover most cases.
+
+### Close idle database connections
+
+A pooled connection that stays open counts as outbound activity. Configure your pool to release idle connections quickly and to let the process go quiet between requests. With `node-postgres`:
+
+```bash
+npm install express pg
+```
+
+```js
+const express = require("express");
+const { Pool } = require("pg");
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  // Close connections after 10 seconds of inactivity so the
+  // service stops emitting keepalive traffic between requests.
+  idleTimeoutMillis: 10_000,
+  // Allow the pool to drop to zero connections when idle.
+  allowExitOnIdle: true,
+});
+
+const app = express();
+
+app.get("/users/:id", async (req, res) => {
+  // Connections are created lazily on first query, so a slept
+  // service reconnects cleanly after waking.
+  const { rows } = await pool.query("SELECT * FROM users WHERE id = $1", [
+    req.params.id,
+  ]);
+  if (rows.length === 0) {
+    return res.status(404).json({ error: "not found" });
+  }
+  res.json(rows[0]);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`listening on ${port}`);
+});
+```
+
+The pool creates connections on demand and closes them after 10 seconds idle. Between requests the service emits nothing, so the 10-minute sleep timer can run down.
+
+### Disable framework telemetry
+
+Frameworks that report telemetry generate periodic outbound requests. For Next.js, set this in your service variables:
+
+```bash
+NEXT_TELEMETRY_DISABLED=1
+```
+
+Check any SDKs you use (error trackers, analytics, feature flag clients) for background polling or heartbeat behavior. An error tracker that flushes on an interval, for instance, will keep the service awake.
+
+## Estimate the savings
+
+The math is direct. A service using 0.5 GB RAM and 0.25 vCPU costs about $10 per month running 24/7 (0.5 x $10 + 0.25 x $20). If it is only active 8 hours a day on weekdays, that is roughly 24% of the month, so the same service costs about $2.40 with Serverless enabled. Across five staging environments and internal tools at that profile, that is $50 a month down to about $12.
+
+Egress is billed separately at $0.05 per GB either way; Serverless only affects compute charges.
+
+## Next steps
+
+- [Serverless reference](/deployments/serverless): full behavior details and caveats
+- [Cost controls](/pricing/cost-control): usage limits, alerts, and resource caps
+- [Scaling your application](/guides/scaling-your-application): vertical and horizontal scaling on Railway
+- [Cron jobs](/cron-jobs): run scheduled tasks without an always-on service

--- a/content/guides/debug-production-incident.md
+++ b/content/guides/debug-production-incident.md
@@ -1,0 +1,227 @@
+---
+title: Debug a Production Incident with Logs, Metrics, and Traces
+description: A step-by-step incident debugging workflow using Railway's built-in observability surfaces. Confirm scope with metrics, find the failure in HTTP and deployment logs, correlate requests, and mitigate with a rollback.
+date: "2026-07-29"
+tags:
+  - observability
+  - incident-response
+  - logs
+  - metrics
+topic: infrastructure
+---
+
+A production incident is any user-visible failure in a deployed service: elevated error rates, slow responses, crashes, or a dependency that stopped answering. This guide debugs one with Railway's built-in observability tools, in the order you would use them during a live incident. Debugging one is a narrowing exercise: you start from a broad signal (an alert, a user report), confirm the scope, find what changed, and isolate the failing request path.
+
+Railway gives you several built-in surfaces for this work:
+
+- **Metrics**: CPU, memory, disk, and network per service, with deployment markers on every graph.
+- **Logs**: build, deployment, environment-wide, HTTP, and DNS logs, all queryable with the same filter syntax.
+- **Observability dashboard**: a per-environment view that combines metrics and logs, with configurable monitors.
+- **Deployment actions**: rollback and restart, your fastest mitigations.
+
+Railway does not collect distributed traces natively. The last section covers what you get instead: request-level HTTP logs, log correlation with request IDs, and how to add real tracing with OpenTelemetry.
+
+## Step 1: Confirm the scope
+
+Before reading a single log line, establish what is actually broken and how widely.
+
+Open the **Observability** tab in your project's top navigation and make sure you are in the right environment (for example, `production`). The [Observability dashboard](/observability) is scoped per environment. If you have not set it up, click "Start with a simple dashboard" and Railway autogenerates widgets for spend, service metrics, and logs.
+
+Questions to answer here:
+
+- **One service or several?** If multiple services show errors at once, suspect a shared dependency: the database, a cache, or an upstream API.
+- **When did it start?** Fix the time window now. Every query you run later should use it.
+- **Is it resource pressure?** Click the affected service on the project canvas and open the **Metrics** tab. Look for memory climbing toward the limit, CPU pinned, or disk filling up. Railway keeps up to 30 days of metrics per project, so you can compare against last week's baseline.
+
+If the service runs multiple replicas, switch the metrics view from **Sum** to **Replica**. One replica pinned at 100% CPU while the others idle points at a bad instance or uneven load, not a code bug.
+
+## Step 2: Find what changed
+
+Most incidents follow a change. Railway's metrics graphs draw a dotted line at every deployment, so a spike that starts at a dotted line is strong evidence the deploy caused it.
+
+Check, in order:
+
+1. **A recent deployment.** The metrics graph shows which commit each deployment came from. If the incident started at a deploy marker, read that commit.
+2. **A crashed deployment.** Railway automatically restarts crashed deployments up to 10 times depending on your [restart policy](/deployments/restart-policy). After that, the deployment status changes to `Crashed` and project members are notified. A service stuck in a crash loop shows this pattern clearly in its deploy logs.
+3. **A dependency change.** No deploy on your side does not mean no change. A database that filled its disk or an external API that started timing out will not show up in your git history, but it will show up in logs.
+
+If a fresh deploy is the obvious cause, skip ahead to [Step 6](#step-6-mitigate) and roll back first. Debug the root cause after users stop seeing errors.
+
+## Step 3: Query HTTP logs for the failing requests
+
+For services behind a public domain, HTTP logs are the fastest way to characterize the failure. Open the deployment, click the **Network** tab, or query HTTP logs from the Log Explorer in the Observability tab.
+
+Railway's [filter syntax](/observability/logs#filtering-logs) supports attribute filters, boolean operators, and numeric comparisons. Useful incident queries:
+
+Find all server errors:
+
+```text
+@httpStatus:500..599
+```
+
+Find errors on a specific endpoint:
+
+```text
+@path:/api/checkout AND @httpStatus:>=500
+```
+
+Find slow requests, which often precede errors when a dependency is degrading:
+
+```text
+@responseTime:>1000
+```
+
+Find requests that errored and were slow, the usual timeout signature:
+
+```text
+@totalDuration:>5000 @httpStatus:>=500
+```
+
+Check whether the app failed to respond at all. The `@responseDetails` attribute is only populated when the application fails to respond, so its presence is itself a signal:
+
+```text
+@responseDetails:"connection refused"
+```
+
+Check whether the problem is limited to one region by filtering on edge region:
+
+```text
+@httpStatus:>=500 AND @edgeRegion:europe-west4-drams3a
+```
+
+What these queries tell you:
+
+- **Errors on every path**: the process itself is unhealthy (crash loop, out of memory, cannot reach the database).
+- **Errors on one path**: a specific handler or the dependency only that handler uses.
+- **Slow responses without errors yet**: a saturating dependency. You caught it early.
+- **`@responseDetails` populated**: requests never reached a healthy process. Look at deploy logs next.
+
+## Step 4: Drill into deployment logs
+
+HTTP logs tell you requests failed. Deployment logs tell you why. Click the deployment in the service window to see its logs, or use the Log Explorer to search across the whole environment.
+
+Start with errors in your fixed time window:
+
+```text
+@level:error
+```
+
+Narrow by message once you see the shape of the failure:
+
+```text
+@level:error AND "ECONNREFUSED"
+```
+
+When you find a relevant line, right-click it and select **View in Context** to see the surrounding logs. Stack traces and the requests that triggered them usually sit within a few lines of each other.
+
+For incidents spanning services, environment logs let you query everything in one place and cut noise with service filters:
+
+```text
+@level:error AND -@service:<postgres_service_id>
+```
+
+Two things make this step more effective, and both are code changes worth making before your next incident:
+
+**Emit structured logs.** Logs printed as single-line JSON get parsed into queryable attributes:
+
+```json
+{ "level": "error", "message": "payment failed", "orderId": "ord_123", "userId": 456 }
+```
+
+Then `@orderId:ord_123` finds every log line for that order. Libraries like Winston (Node.js) or structlog (Python) emit this format for you. The JSON must be on a single line to be parsed.
+
+**Mind the logging rate limit.** Railway drops log lines beyond 500 per second per replica and prints a warning when it happens. An incident that triggers verbose error logging can hit this limit exactly when you need logs most. Prefer sampling over raw verbosity.
+
+## Step 5: Check DNS logs for dependency failures
+
+If deployment logs show connection errors to another service, DNS logs settle whether the problem is name resolution or the service itself. Railway logs every DNS lookup by default, including lookups over the [private network](/networking/private-networking). Open a deployment, click the **Network** tab, and select the **DNS** view.
+
+Find all failed lookups:
+
+```text
+@status:failed
+```
+
+Check private network resolution specifically. Private networking is scoped per environment, and services resolve at `<service>.railway.internal`:
+
+```text
+@zone:internal AND @status:failed
+```
+
+Find failures for one dependency:
+
+```text
+@domain:api.stripe.com AND @status:failed
+```
+
+Interpretation:
+
+- **`NXDOMAIN` on an internal name**: the target service does not exist in this environment, or the name is misspelled. Common after copying config between environments.
+- **`TIMEOUT` or `SERVFAIL` on external names**: an upstream DNS or network problem, not your code.
+- **DNS resolves fine but connections still fail**: the dependency is up at the network level but refusing or dropping connections. Go look at that service's own logs and metrics.
+
+## Step 6: Mitigate
+
+Once you know (or strongly suspect) the cause, mitigate before you finish the diagnosis.
+
+**Roll back a bad deploy.** In the service's deployment list, click the three dots on a previous successful deployment and confirm the rollback. Railway restores both the Docker image and the custom variables from that deployment, so a rollback also reverts a bad variable change. That restore only works within your plan's image retention window, so the option only appears on eligible deployments. See [deployment actions](/deployments/deployment-actions) for details.
+
+**Restart a crashed service.** A deployment marked `Crashed` (past its automatic restart limit) shows a **Restart** button inline on the deployment. Restarting restores the exact original image and configuration.
+
+**Redeploy.** If the cause was transient (a dependency outage that has recovered), redeploying the current version gives you a clean process without reverting code.
+
+For future incidents, configure a [health check](/deployments/healthchecks) on your service. Railway health checks are HTTP-only, and with one configured, new deployments only receive traffic after they report healthy. That converts a category of bad deploys from "incident" into "failed deploy that never took traffic."
+
+## Tracing options
+
+Railway does not run a tracing backend, and container metrics do not include application-level data like per-endpoint latency histograms. You have three options, in increasing order of effort:
+
+**1. Use HTTP logs as request-level traces.** Every HTTP log line carries `@requestId`, `@totalDuration`, `@responseTime` (time to first byte), and `@upstreamRqDuration`. For a single service, this answers most "where did the time go" questions: a large gap between `@responseTime` and `@totalDuration` means the response body streamed slowly, while a high `@upstreamRqDuration` means your process was slow to answer.
+
+**2. Correlate logs with your own request ID.** Generate an ID per request, attach it to every structured log line that request produces, and return it in a response header so users can report it:
+
+```javascript
+const { randomUUID } = require("node:crypto");
+
+function withRequestId(handler) {
+  return async (req, res) => {
+    const requestId = randomUUID();
+    res.setHeader("x-request-id", requestId);
+    const log = (level, message, extra = {}) =>
+      console.log(JSON.stringify({ level, message, requestId, ...extra }));
+    try {
+      await handler(req, res, log);
+    } catch (err) {
+      log("error", err.message, { stack: err.stack });
+      res.statusCode = 500;
+      res.end("internal error");
+    }
+  };
+}
+
+module.exports = { withRequestId };
+```
+
+This uses only the Node.js standard library, so there is nothing to install. During an incident, one filter returns every log line a request produced:
+
+```text
+@requestId:3f8a2c1e-9b4d-4f6a-8c2d-1e5b7a9c3d2f
+```
+
+**3. Add real distributed tracing.** For multi-service request flows, deploy an OpenTelemetry collector as a Railway service and instrument your apps with OTel SDKs, or use a vendor SDK directly. See [Deploy an OpenTelemetry Collector Stack](/guides/deploy-an-otel-collector-stack) and [Connect a Third-Party Observability Tool](/guides/third-party-observability). This is also the answer for log retention beyond your plan's window (7 days on Hobby, 30 on Pro, up to 90 on Enterprise).
+
+## Prepare for the next incident
+
+Ten minutes of setup makes the next incident shorter:
+
+- **Create monitors.** On the Observability dashboard (Pro plan), add a monitor to any widget via its three-dot menu. Monitors alert by email and in-app notification when CPU, RAM, disk usage, or network egress crosses a threshold.
+- **Wire up webhooks.** Project settings include a [Webhooks](/observability/webhooks) tab. Webhooks fire on deployment status changes, volume usage alerts, and CPU/RAM monitor alerts, and Railway automatically formats payloads for Discord and Slack URLs. One of those, a deployment failure alert in your team channel, beats a user report by minutes.
+- **Adopt structured logging everywhere.** Attribute filters only work on logs emitted as single-line JSON.
+- **Configure health checks and a restart policy.** They handle the mechanical mitigations automatically.
+
+## Next steps
+
+- [Logs](/observability/logs): the full filter syntax reference for deployment, HTTP, and DNS logs.
+- [Metrics](/observability/metrics): reading service metrics, including per-replica views.
+- [Deploy an OpenTelemetry Collector Stack](/guides/deploy-an-otel-collector-stack): add distributed tracing across services.
+- [Connect a Third-Party Observability Tool](/guides/third-party-observability): longer retention and application-level metrics.

--- a/content/guides/embeddings-pipeline.md
+++ b/content/guides/embeddings-pipeline.md
@@ -1,0 +1,236 @@
+---
+title: Run an Embeddings Pipeline with an External API and pgvector
+description: Deploy a batch worker on Railway that generates embeddings through an external API and stores them in Postgres with pgvector. Covers schema design, safe concurrent processing, and the psycopg2 vector adaptation gotcha.
+date: "2026-07-29"
+tags:
+  - embeddings
+  - pgvector
+  - workers
+  - python
+topic: ai
+---
+
+An embeddings pipeline on Railway needs three pieces: Postgres with the pgvector extension for storage, an external embedding API for vector generation, and a long-running Python worker between them. Rows arrive without embeddings, the worker picks them up in batches, calls the embedding API, and writes the vectors back. Search and RAG features then query those vectors with pgvector.
+
+This guide covers the ingestion side. For the query and generation side, see the [RAG pipeline guide](/guides/rag-pipeline-pgvector).
+
+Railway runs CPU workloads only, with no GPU support, so embedding models can't run locally. The worker instead calls an external API (OpenAI in this guide, but any embedding provider works) over HTTP. That call is I/O-bound from the worker's perspective, so a small CPU instance handles high throughput.
+
+## How the pipeline works
+
+The pipeline has two services in one Railway project:
+
+- **Postgres with pgvector** stores rows and their embedding vectors. Deployed from Railway's pgvector template.
+- **Batch worker** polls for rows without embeddings, calls the embedding API in batches, and writes vectors back. It runs continuously and needs no public domain.
+
+Your application inserts rows with a `NULL` embedding. The worker fills them in asynchronously. This decouples writes from embedding latency: inserts stay fast, and API failures or rate limits don't block your application.
+
+## Prerequisites
+
+- A Railway account
+- An API key from [OpenAI](https://platform.openai.com/api-keys) or another embedding provider
+
+## 1. Deploy Postgres with pgvector
+
+Railway's standard Postgres image does not include pgvector. Deploy the pgvector template instead:
+
+1. Click the button below:
+
+   [![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/3jJFCA)
+
+2. After the template deploys, note the `DATABASE_URL` connection string in the service's **Variables** tab.
+
+## 2. Create the schema
+
+Connect to the database (use the **Data** tab on the service, or `psql "$DATABASE_URL"` locally) and run:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE items (
+    id BIGSERIAL PRIMARY KEY,
+    content TEXT NOT NULL,
+    embedding VECTOR(1536),
+    embedded_at TIMESTAMPTZ
+);
+
+-- Partial index so the worker finds pending rows fast,
+-- even when the table has millions of embedded rows.
+CREATE INDEX items_pending_idx ON items (id) WHERE embedding IS NULL;
+```
+
+The `embedding` column is nullable by design: a `NULL` value means "pending". Its dimension (1536 here) must match your embedding model: `text-embedding-3-small` produces 1536 dimensions, `text-embedding-3-large` produces 3072.
+
+Hold off on creating a vector similarity index until after the initial backfill. Building an HNSW index on a full table is much faster than maintaining it row by row during a large backfill.
+
+## 3. Set up the worker project
+
+Create a project directory with two files.
+
+### requirements.txt
+
+```
+openai
+psycopg2-binary
+pgvector
+```
+
+Install locally with `pip install -r requirements.txt`.
+
+### worker.py
+
+```python
+# worker.py
+import os
+import time
+
+import psycopg2
+from openai import OpenAI
+from pgvector import Vector
+from pgvector.psycopg2 import register_vector
+
+client = OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+DATABASE_URL = os.environ["DATABASE_URL"]
+
+BATCH_SIZE = 100
+POLL_INTERVAL = 10  # seconds to wait when no rows are pending
+EMBEDDING_MODEL = "text-embedding-3-small"
+
+
+def embed(texts: list[str]) -> list[list[float]]:
+    response = client.embeddings.create(model=EMBEDDING_MODEL, input=texts)
+    return [item.embedding for item in response.data]
+
+
+def process_batch(conn) -> int:
+    with conn.cursor() as cur:
+        cur.execute(
+            """
+            SELECT id, content FROM items
+            WHERE embedding IS NULL
+            ORDER BY id
+            LIMIT %s
+            FOR UPDATE SKIP LOCKED
+            """,
+            (BATCH_SIZE,),
+        )
+        rows = cur.fetchall()
+        if not rows:
+            conn.commit()
+            return 0
+
+        ids = [row[0] for row in rows]
+        texts = [row[1] for row in rows]
+        embeddings = embed(texts)
+
+        for item_id, emb in zip(ids, embeddings):
+            cur.execute(
+                """
+                UPDATE items
+                SET embedding = %s, embedded_at = now()
+                WHERE id = %s
+                """,
+                (Vector(emb), item_id),
+            )
+    conn.commit()
+    return len(rows)
+
+
+def main() -> None:
+    conn = psycopg2.connect(DATABASE_URL)
+    register_vector(conn)
+    print("Embeddings worker started")
+    while True:
+        try:
+            count = process_batch(conn)
+        except Exception as exc:
+            conn.rollback()
+            print(f"Batch failed, retrying in 30s: {exc}")
+            time.sleep(30)
+            continue
+        if count:
+            print(f"Embedded {count} rows")
+        else:
+            time.sleep(POLL_INTERVAL)
+
+
+if __name__ == "__main__":
+    main()
+```
+
+A few design decisions:
+
+- **Batching.** One API call embeds up to `BATCH_SIZE` texts. This is far cheaper in request overhead and rate-limit budget than one call per row.
+- **`FOR UPDATE SKIP LOCKED`.** Each worker locks the rows it is processing and skips rows locked by others. You can scale to multiple worker replicas without double-embedding rows.
+- **Claim and write in one transaction.** If the API call fails, the transaction rolls back and the rows stay pending. No row is ever marked done without a vector.
+- **Failure handling.** On any error the worker rolls back, waits 30 seconds, and retries. Rate-limit errors from the API resolve themselves this way.
+
+## The psycopg2 vector adaptation gotcha
+
+psycopg2 does not know pgvector's `vector` type, and this fails in confusing ways.
+
+If you pass a plain Python list as a query parameter, psycopg2 adapts it to a Postgres array (`ARRAY[0.1, 0.2, ...]`, type `double precision[]`). Plain `INSERT` and `UPDATE` statements may appear to work because pgvector defines assignment casts from arrays to `vector`. But the same list in a similarity expression fails:
+
+```
+operator does not exist: vector <=> double precision[]
+```
+
+And if you pass a numpy array without registering anything, psycopg2 raises:
+
+```
+can't adapt type 'numpy.ndarray'
+```
+
+There are two reliable fixes:
+
+1. **Register the type (used in this guide).** Call `register_vector(conn)` from the `pgvector` package after connecting, and wrap values in `Vector(...)` when passing them as parameters. Registration also makes `SELECT` return `Vector` objects instead of strings. Note that `register_vector` adapts `Vector` objects and numpy arrays, not plain lists, which is why the worker wraps each embedding in `Vector(emb)`.
+2. **Send a string.** `str(embedding)` produces `[0.1, 0.2, ...]`, which Postgres parses as an untyped literal and casts to `vector`. This works without the `pgvector` package but gives you strings back on read, and it silently masks dimension mistakes until query time.
+
+## 4. Deploy the worker
+
+1. Push the project to a GitHub repository.
+2. In your Railway project, create a new service from that repository. Railpack detects Python from `requirements.txt` and installs dependencies automatically.
+3. Set the start command to `python worker.py` in the service settings.
+4. In the service's **Variables** tab:
+   - Add `OPENAI_API_KEY`.
+   - [Reference](/variables#referencing-another-services-variable) `DATABASE_URL` from the pgvector service: `${{Postgres.DATABASE_URL}}`. `DATABASE_URL` connects over [private networking](/networking/private-networking), so traffic stays internal and avoids egress fees; avoid `DATABASE_PUBLIC_URL`, which routes over the public TCP proxy and is billed as egress.
+
+Do not generate a public domain for this service. The worker makes only outbound calls and exposes nothing.
+
+To backfill existing data, deploy the worker: it drains all pending rows, then settles into polling. To process more rows per minute, raise `BATCH_SIZE` or add replicas; `SKIP LOCKED` keeps them from colliding.
+
+### Alternative: run it as a cron job
+
+If new rows arrive in slow trickles, a continuously running worker wastes little (Railway bills actual usage, and an idle Python process consumes a few MB of RAM), but you can run the same script as a [cron job](/cron-jobs) instead. Change the loop to exit when `process_batch` returns 0, close the database connection before exiting, and set a cron schedule on the service. The minimum interval is 5 minutes, schedules run in UTC, and if a run is still going when the next one is due, Railway skips the new run rather than terminating the old one.
+
+## 5. Index after the backfill
+
+Once the initial backfill finishes, create a similarity index so queries stay fast:
+
+```sql
+CREATE INDEX items_embedding_idx ON items
+USING hnsw (embedding vector_cosine_ops);
+```
+
+Then query nearest neighbors from your application:
+
+```sql
+SELECT id, content, 1 - (embedding <=> %s) AS similarity
+FROM items
+WHERE embedding IS NOT NULL
+ORDER BY embedding <=> %s
+LIMIT 10;
+```
+
+Pass the query embedding as a `Vector(...)` parameter, the same way the worker writes them. The `WHERE embedding IS NOT NULL` filter excludes rows the worker has not reached yet.
+
+## Handling model changes
+
+Embeddings from different models are not comparable. If you switch models, re-embed everything: the pipeline already handles this. To do that, run `UPDATE items SET embedding = NULL;`, drop the HNSW index, update `EMBEDDING_MODEL` in the worker, and let it re-drain the table. If the new model has a different dimension, alter the column type first (`ALTER TABLE items ALTER COLUMN embedding TYPE VECTOR(3072);`).
+
+## Next steps
+
+- [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector): add the query endpoint and LLM generation on top of these embeddings.
+- [Build Hybrid Search with Postgres and pgvector](/guides/hybrid-search-postgres-pgvector): combine vector similarity with full-text search.
+- [Cron Jobs, Workers, and Queues](/guides/cron-workers-queues): pick the right background-processing pattern.
+- [PostgreSQL on Railway](/databases/postgresql): database management, backups, and extensions.

--- a/content/guides/estimate-ai-agent-costs.md
+++ b/content/guides/estimate-ai-agent-costs.md
@@ -1,0 +1,91 @@
+---
+title: Estimate the Cost of Running AI Agents
+description: What an always-on AI agent costs to run. How to calculate LLM API spend per run, what the hosting compute actually costs on Railway's usage-based pricing, and where the money goes as you scale.
+date: "2026-07-29"
+tags:
+  - agents
+  - cost
+  - pricing
+  - ai
+topic: ai
+---
+
+An AI agent generates two bills: the LLM provider's bill for tokens, and the hosting bill for the compute the agent runs on. For most agents the token bill dominates, often by an order of magnitude, so estimate it first and estimate it per run. The hosting bill is smaller and easier to predict, but it is the one you control by architecture.
+
+In this guide we build the estimate for both, with Railway's actual rates for the hosting half.
+
+## The token bill
+
+The cost of one agent run is:
+
+```txt
+cost per run = LLM calls per run × (input tokens × input rate + output tokens × output rate)
+```
+
+Agents multiply tokens in two ways that simple chat does not. Each reasoning step is a separate LLM call, and each call re-sends the accumulated context, so input tokens grow with every step. A 10-step agent run does not cost 10× a single call; it costs more, because step 10 carries the transcript of steps 1 through 9.
+
+A worked example, using $3 per million input tokens and $15 per million output tokens (example rates; check your provider's current pricing):
+
+- 10 calls per run, context growing from 2K to 20K input tokens, averaging 11K
+- 500 output tokens per call
+- Input: 10 × 11,000 × $3/M = $0.33
+- Output: 10 × 500 × $15/M = $0.075
+- **≈ $0.40 per run.** At 500 runs a day, about $200 a day, or $6,000 a month.
+
+That number is why token spend deserves caps before it deserves optimization. An [LLM gateway](/guides/llm-gateway) that enforces per-key daily budgets turns a runaway agent from a bill into a 429.
+
+## The hosting bill
+
+Railway bills compute by [usage](/pricing/plans): $10 per GB of RAM per month and $20 per vCPU per month, metered per minute, plus $0.05 per GB of network egress. You are charged for what the service actually consumes, not what it could consume.
+
+This matters for agents specifically, because an agent worker's profile is spiky: it holds memory constantly but burns CPU only while a run is active. The RAM line is usually the bigger one.
+
+A typical always-on agent worker:
+
+- 300 MB resident memory: 0.3 GB × $10 = $3.00/month
+- Averaging 0.05 vCPU across idle and active periods: 0.05 × $20 = $1.00/month
+- **≈ $4 a month** to keep one worker alive around the clock.
+
+The supporting cast, at the same rates:
+
+- A small API service in front: another $3 to $5 a month.
+- [Postgres](/databases/postgresql) for run state: its own service consuming RAM and CPU, plus [volume storage](/volumes) at $0.15 per GB-month.
+- Artifacts in a [storage bucket](/storage-buckets): $0.015 per GB-month, with free egress and free API operations. Storing a thousand 1 MB reports costs about a cent and a half a month.
+
+A complete agent stack (API, worker, Postgres, Redis, bucket) commonly lands in the $10 to $30 a month range while the [Hobby plan includes $5](/pricing/plans) and the Pro plan includes $20 of usage in the subscription.
+
+## Where the estimate goes wrong
+
+Three things break naive estimates, all in the same direction:
+
+- **Concurrency.** One worker at $4 a month becomes ten replicas at $40 when you [scale horizontally](/deployments/scaling). Worker replicas scale with queue depth, and queue depth scales with success. Estimate at target load, not launch load.
+- **Context bloat.** Agents accumulate tools, system prompts, and memory files. The per-run input token count drifts up over months. Re-measure it; do not trust the number from the design doc.
+- **Retries.** Failed runs that retry pay full token price for each attempt. A 10% failure rate with 3 retries adds roughly 30% to the token bill.
+
+## Cutting the idle cost
+
+If your agent is bursty rather than always-listening, [Serverless](/deployments/serverless) puts the service to sleep after 10 minutes without outbound traffic and wakes it on the next request, so a nightly agent does not pay for a day of idling. Note the trigger is *outbound* traffic: a worker holding open a database connection or polling a queue never goes idle by this definition, so serverless fits request-driven agents, not queue-pollers.
+
+For everything else, the levers are the standard ones: [cost controls](/pricing/cost-control) with usage limits and alerts at the workspace level, response caching in front of the LLM, and pruning context before it snowballs.
+
+## A worksheet
+
+For a monthly estimate, fill in six numbers:
+
+```txt
+runs per day × cost per run × 30            = token bill
+worker GB × $10 + worker avg vCPU × $20     = per-worker compute
+  × replica count                            = worker bill
++ API/database services (measure, ~$5-15)   = base services
++ artifact GB × $0.015 + volume GB × $0.15  = storage
++ egress GB × $0.05                          = egress
+```
+
+Run the agent for a week, read the real numbers from the [usage page](/pricing/understanding-your-bill) and your provider dashboard, and replace the estimate. The measured number is the estimate that matters.
+
+## Next steps
+
+- [Build an LLM Gateway](/guides/llm-gateway): per-key budgets that cap the token bill before the invoice does.
+- [Cost Controls](/pricing/cost-control): usage limits, alerts, and serverless configuration.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): the architecture these numbers describe.
+- [Understanding Your Bill](/pricing/understanding-your-bill): reading actual usage per service.

--- a/content/guides/external-secrets-manager.md
+++ b/content/guides/external-secrets-manager.md
@@ -1,0 +1,190 @@
+---
+title: Sync Secrets from an External Secrets Manager
+description: Keep Doppler, Infisical, or Vault as your source of truth and push secrets into Railway variables with the Public API, a sync script, or a vendor integration.
+date: "2026-07-29"
+tags:
+  - secrets
+  - variables
+  - integrations
+  - security
+topic: integrations
+---
+
+## Overview
+
+A secrets sync is a one-way pipeline: your secrets manager (Doppler, Infisical, HashiCorp Vault, or similar) holds the canonical values, and a sync process writes those values into Railway variables. Those variables are all your services ever see: they never talk to the secrets manager at runtime, and they read plain environment variables the same way they would if you had typed the values into the dashboard.
+
+The split matters because Railway injects variables into builds and deployments automatically. Once a value lands in Railway, reference variables, per-environment scoping, and PR environments all work with it. On the other side of that split, the external manager adds a single source of truth across clouds, rotation policies, and audit logs.
+
+Railway does not require an external secrets manager: service, shared, and sealed variables cover most teams already. Reach for a sync instead when secrets already live somewhere else, when one manager feeds multiple platforms, or when compliance requires centralized rotation and audit.
+
+## Choose a sync strategy
+
+There are three ways to get external secrets into Railway, in increasing order of control:
+
+1. **Vendor integration.** Doppler maintains a Railway integration that syncs a Doppler config to a Railway environment automatically. Zero code, but you follow the vendor's mapping rules.
+2. **Sync script against the Public API.** Export from the manager's CLI, push with the `variableCollectionUpsert` mutation. Full control over mapping, works with any manager, runs anywhere: CI, a laptop, or a Railway cron service.
+3. **Fetch at boot.** The service pulls secrets from the manager when the process starts. No sync step, but now every service needs manager credentials and network access to it, and a manager outage blocks deploys. Use this only when values must never rest outside the manager.
+
+The rest of this guide covers options 1 and 2. Default to option 2; it is portable across managers.
+
+## Use the Doppler integration
+
+Doppler's integration syncs a Doppler project and config to a Railway project, environment, and optional service. Set it up from the Doppler dashboard; instructions live in the Doppler docs at `docs.doppler.com/docs/railway`. After the initial sync, changes you save in Doppler propagate to Railway automatically.
+
+The integration needs a Railway API token to act on your behalf. Create one from the [tokens page](https://railway.com/account/tokens). Prefer a workspace token over an account token: it is scoped to a single workspace and can be revoked without breaking your personal access.
+
+For other managers, including Infisical and Vault, check the vendor's own documentation for a Railway integration, or use the sync script in the next section; it works with any manager whose CLI can export secrets as JSON.
+
+## Sync with the Public API
+
+Railway's Public API is GraphQL at `https://backboard.railway.com/graphql/v2`. The `variableCollectionUpsert` mutation writes many variables in one call, which makes a sync script short.
+
+### Step 1: create a token and collect IDs
+
+Create a workspace token from the [tokens page](https://railway.com/account/tokens). You also need the project ID, environment ID, and service ID you are syncing into. All three appear in the URL when you open a service in the dashboard, or you can query them via the API.
+
+### Step 2: export from your manager
+
+Each manager's CLI can emit secrets as JSON:
+
+```bash
+# Doppler: flat JSON object of KEY: value
+doppler secrets download --no-file --format json > secrets.json
+
+# Infisical
+infisical export --format=json > secrets.json
+
+# Vault KV v2: unwrap the nested data field with jq
+vault kv get -format=json secret/myapp | jq '.data.data' > secrets.json
+```
+
+Each command produces the same shape, a flat object:
+
+```json
+{
+  "DATABASE_URL": "postgres://...",
+  "STRIPE_SECRET_KEY": "sk_live_..."
+}
+```
+
+### Step 3: push to Railway
+
+The script below reads that JSON from stdin and upserts every key into one Railway service and environment. It uses Node's built-in `fetch`, so there is nothing to install; it runs on Node 18 or later.
+
+```javascript
+// sync-secrets.js
+// Usage: cat secrets.json | node sync-secrets.js
+const RAILWAY_API = "https://backboard.railway.com/graphql/v2";
+
+const token = process.env.RAILWAY_API_TOKEN;
+const projectId = process.env.RAILWAY_PROJECT_ID;
+const environmentId = process.env.RAILWAY_ENVIRONMENT_ID;
+const serviceId = process.env.RAILWAY_SERVICE_ID;
+
+if (!token || !projectId || !environmentId || !serviceId) {
+  console.error(
+    "Set RAILWAY_API_TOKEN, RAILWAY_PROJECT_ID, RAILWAY_ENVIRONMENT_ID, RAILWAY_SERVICE_ID"
+  );
+  process.exit(1);
+}
+
+async function readStdin() {
+  let data = "";
+  for await (const chunk of process.stdin) data += chunk;
+  return data;
+}
+
+async function main() {
+  const secrets = JSON.parse(await readStdin());
+  const keys = Object.keys(secrets);
+  if (keys.length === 0) {
+    console.error("No secrets found on stdin, refusing to sync.");
+    process.exit(1);
+  }
+
+  const query = `
+    mutation variableCollectionUpsert($input: VariableCollectionUpsertInput!) {
+      variableCollectionUpsert(input: $input)
+    }
+  `;
+
+  const res = await fetch(RAILWAY_API, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      query,
+      variables: {
+        input: {
+          projectId,
+          environmentId,
+          serviceId,
+          variables: secrets,
+          // Set to false (or remove) to redeploy immediately on change.
+          skipDeploys: true,
+        },
+      },
+    }),
+  });
+
+  const body = await res.json();
+  if (body.errors) {
+    console.error("Sync failed:", JSON.stringify(body.errors, null, 2));
+    process.exit(1);
+  }
+  console.log(`Synced ${keys.length} variables to service ${serviceId}.`);
+}
+
+main();
+```
+
+Run it:
+
+```bash
+export RAILWAY_API_TOKEN=...
+export RAILWAY_PROJECT_ID=...
+export RAILWAY_ENVIRONMENT_ID=...
+export RAILWAY_SERVICE_ID=...
+
+doppler secrets download --no-file --format json | node sync-secrets.js
+```
+
+To write shared variables for the whole environment instead of one service, omit `serviceId` from the input.
+
+### Deploys and the replace flag
+
+Two input fields change the blast radius of a sync:
+
+- `skipDeploys` (default `false`): by default Railway redeploys the service after a variable change. The script sets `skipDeploys: true` so a scheduled sync does not restart your app every run. Trigger a deploy yourself when you rotate something that must take effect now.
+- `replace` (default `false`): with `replace: true`, Railway deletes every variable not present in the payload. That turns the sync into a mirror, which is usually what you want for a dedicated sync, but it will also delete variables you set by hand in the dashboard, including Railway reference variables. Leave it off unless the manager owns every variable on the service.
+
+## Run the sync on a schedule
+
+A sync script fits a Railway cron service: a service that runs your start command on a crontab schedule, does its work, and exits.
+
+1. Deploy the script as its own service in the same project.
+2. Set the start command to the pipeline, for example `sh -c "doppler secrets download --no-file --format json | node sync-secrets.js"`.
+3. Set the four `RAILWAY_*` variables plus your manager's credentials (for example `DOPPLER_TOKEN`) on the cron service.
+4. In service settings, set a cron schedule such as `0 * * * *` for hourly.
+
+Schedules run in UTC, and the process must exit cleanly when done: if a previous run is still alive when the next one is due, Railway skips the new run rather than terminating the old one. A sync that finishes in seconds won't hit this, but do not leave connections open.
+
+If you already run CI, a scheduled GitHub Actions workflow that runs the same pipeline works just as well. The script only needs the token and IDs.
+
+## Things to know
+
+- **Sealed variables are excluded from sync in one direction.** Railway never returns sealed values through the API or `railway run`, so nothing can export them out of Railway. Syncing *into* Railway is unaffected.
+- **One environment at a time.** Variables are scoped per environment. Map manager configs to Railway environments one to one (Doppler `prd` to Railway `production`, `stg` to `staging`) and run the sync once per pair.
+- **PR environments inherit.** New PR environments copy variables from the base environment, so synced values show up in previews without extra work.
+- **Local development does not need the manager.** `railway run npm start` injects your service's Railway variables into a local process, so teammates can develop against synced values without manager credentials.
+- **Keep the token narrow.** A workspace token can touch every project in the workspace. If the sync only serves one environment, a project token is tighter still; note that project tokens authenticate with the `Project-Access-Token` header instead of `Authorization: Bearer`.
+
+## Next steps
+
+- [Managing secrets on Railway](/guides/managing-secrets-on-railway) covers the native options: service, shared, reference, and sealed variables.
+- [Manage variables with the Public API](/integrations/api/manage-variables) documents every variable query and mutation used here.
+- [Cron jobs](/cron-jobs) explains schedules, UTC timing, and the skip behavior for overlapping runs.
+- [Variables](/variables) is the reference for how Railway injects variables into builds and deployments.

--- a/content/guides/host-documentation-site.md
+++ b/content/guides/host-documentation-site.md
@@ -1,0 +1,144 @@
+---
+title: Host a Documentation Site with Astro Starlight
+description: Build a documentation site with Astro Starlight and deploy it to Railway, with full-text search, a structured sidebar, and a custom domain.
+date: "2026-07-29"
+tags:
+  - documentation
+  - astro
+  - static
+  - deployment
+topic: frameworks
+---
+
+[Starlight](https://starlight.astro.build) is a documentation theme built on [Astro](https://astro.build). It turns a folder of Markdown files into a complete documentation site: navigation sidebar, full-text search, dark mode, mobile layout, and internationalization are all built in. The output is static HTML, so hosting it requires nothing more than a static file server.
+
+That simplicity still leaves the documentation-specific work: configuring the sidebar, getting search working, deploying the static output to Railway, and putting the site behind your own domain. This guide covers each one; for general Astro deployment patterns (SSR, Dockerfiles, one-click templates), see the [Astro guide](/guides/astro).
+
+## Create a Starlight project
+
+You need [Node.js](https://nodejs.org) installed. Scaffold a new project with the Starlight template:
+
+```bash
+npm create astro@latest my-docs -- --template starlight
+```
+
+Accept the defaults when prompted, then start the dev server:
+
+```bash
+cd my-docs
+npm run dev
+```
+
+Open `http://localhost:4321` to see the site. Documentation pages live in `src/content/docs/` as Markdown or MDX files. Each file becomes a route: `src/content/docs/guides/install.md` is served at `/guides/install`.
+
+Every page needs a `title` in its frontmatter:
+
+```markdown
+---
+title: Installation
+description: How to install the CLI.
+---
+
+Install the CLI with npm:
+
+...
+```
+
+## Configure the sidebar
+
+The sidebar is defined in `astro.config.mjs`. You can list pages explicitly, or point a group at a directory and let Starlight generate the entries from the files it finds.
+
+```js
+// astro.config.mjs
+import { defineConfig } from "astro/config";
+import starlight from "@astrojs/starlight";
+
+export default defineConfig({
+  integrations: [
+    starlight({
+      title: "My Product Docs",
+      sidebar: [
+        {
+          label: "Getting Started",
+          items: [
+            { label: "Installation", slug: "guides/install" },
+            { label: "Quick Start", slug: "guides/quick-start" },
+          ],
+        },
+        {
+          label: "Reference",
+          // Generate entries from every file in src/content/docs/reference/
+          items: [{ autogenerate: { directory: "reference" } }],
+        },
+      ],
+    }),
+  ],
+});
+```
+
+Explicit `items` give you full control over order and labels. `autogenerate` trades that control for less work as the docs grow: new files under the directory appear in the sidebar automatically, ordered by filename. Most docs sites split the difference: explicit entries for the getting-started path, autogeneration for reference sections.
+
+## Search works without a server
+
+Starlight ships with [Pagefind](https://pagefind.app), a static search library. When you run `astro build`, Pagefind indexes the rendered HTML and writes the index into the output directory. Search then runs entirely in the visitor's browser, with no search server to deploy and no per-query cost.
+
+Two things to know:
+
+- Search does not appear in `npm run dev`. The index only exists after a build. To test search locally, run `npm run build && npm run preview`.
+- The index is rebuilt on every deploy, so search results match the published content with nothing to invalidate or resync.
+
+## Deploy to Railway
+
+Starlight produces static files, so the deployed service is just a file server in front of the `dist/` directory. Add the [serve](https://www.npmjs.com/package/serve) package to handle that:
+
+```bash
+npm install serve
+```
+
+Then add a start script to `package.json`:
+
+```json
+{
+  "scripts": {
+    "dev": "astro dev",
+    "build": "astro build",
+    "preview": "astro preview",
+    "start": "serve dist -l $PORT"
+  }
+}
+```
+
+Railway injects the `PORT` environment variable at runtime, and `serve` listens on it. `serve` resolves clean URLs to the `folder/index.html` files Starlight generates, so `/guides/install` works without any rewrite rules.
+
+Push the project to GitHub, then:
+
+1. Go to [railway.com/new](https://railway.com/new) and select **Deploy from GitHub repo**.
+2. Choose your repository. Railway detects a Node.js project, runs `npm run build`, and starts the service with `npm start`.
+3. In the service settings, under **Networking**, click **Generate Domain** to get a public `*.up.railway.app` URL.
+
+Every push to the connected branch now rebuilds the site, including the search index, and deploys the new version.
+
+## Add a custom domain
+
+Documentation usually lives at a subdomain like `docs.example.com`:
+
+1. Open your service, go to **Settings**, and find the **Networking** section.
+2. Click **+ Custom Domain** and enter `docs.example.com`.
+3. Railway shows two records: a CNAME record and a TXT record that verifies domain ownership. Add both at your DNS provider; the domain will not verify with only the CNAME in place.
+4. Once both records are in place and verified, Railway provisions and renews the TLS certificate automatically.
+
+See [working with domains](/networking/domains) for provider-specific DNS details, including the Cloudflare proxying caveats.
+
+## Keep hosting costs near zero
+
+Railway pricing is usage based, and a static file server uses very little. Two settings help for a low-traffic docs site:
+
+- **Serverless**: enable it in the service settings and Railway puts the service to sleep after 10 minutes without outbound traffic, then wakes it on the next request. A static server makes no database connections or background calls, so it sleeps reliably. The first request after sleep pays a short cold-start delay. See [serverless](/deployments/serverless).
+- **PR environments**: enable them in your project settings and every pull request gets its own preview deployment of the docs, torn down when the PR closes. Reviewers can read the rendered pages instead of raw Markdown diffs. See [environments](/environments).
+
+## Next steps
+
+- [Deploy an Astro app](/guides/astro) for SSR, CLI, and Dockerfile deployment options.
+- [Deploy static sites](/guides/static-hosting) for multi-region replicas and CDN integration.
+- [Working with domains](/networking/domains) for DNS setup details.
+- [Serverless](/deployments/serverless) for how sleep and wake behavior works.

--- a/content/guides/hybrid-search-postgres-pgvector.md
+++ b/content/guides/hybrid-search-postgres-pgvector.md
@@ -1,0 +1,287 @@
+---
+title: Build Hybrid Search with Postgres Full-Text Search and pgvector
+description: Combine Postgres full-text search and pgvector similarity search in one database, then merge results with Reciprocal Rank Fusion. Includes schema, SQL, and a deployable Node API.
+date: "2026-07-29"
+tags:
+  - postgres
+  - pgvector
+  - search
+  - full-text-search
+topic: architecture
+---
+
+In this guide we build a hybrid search API on Railway: one Postgres service running pgvector, and one Node service that ingests documents, queries both indexes, and merges the rankings with Reciprocal Rank Fusion (RRF). By the end, `POST /documents` ingests and `GET /search` returns merged results, all from one database.
+
+Hybrid search runs two retrieval strategies over the same data and merges the results: lexical search, which matches the exact words in a query, and semantic search, which matches meaning through embedding vectors. Postgres does both. Full-text search (`tsvector`) handles the lexical side, and the pgvector extension handles the semantic side, so there is no separate search engine to run.
+
+If you want a full retrieval-augmented generation pipeline on top of this, see [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector). This guide focuses on the search layer itself.
+
+## Why combine full-text and vector search
+
+Each strategy fails in a different way.
+
+- **Full-text search** is precise on exact terms. A query for `ERR_CONNECTION_RESET` or a product SKU finds documents containing that string. It fails on paraphrases: "reduce cloud spend" will not match a document that only says "lower infrastructure costs".
+- **Vector search** matches meaning. Paraphrases score well. It fails on rare exact tokens: error codes, identifiers, and names that the embedding model has little signal for often rank below loosely related prose.
+
+Merging both rankings gives exact-match precision and paraphrase recall in the same result list. RRF is the standard merge: it needs no score normalization, only each document's rank position in each list.
+
+## Prerequisites
+
+- A Railway account
+- An [OpenAI API key](https://platform.openai.com/api-keys) for generating embeddings (any embedding provider works; the code isolates this in one function)
+- Node.js 20+ locally for development
+
+## 1. Deploy Postgres with pgvector
+
+Railway's standard Postgres image does not include pgvector. Deploy the pgvector template instead:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/3jJFCA)
+
+After it deploys, copy the `DATABASE_URL` from the service's **Variables** tab. You will use the public URL for local development and the [private network](/networking/private-networking) URL in production.
+
+## 2. Create the schema
+
+Connect with `psql` (or the [database view](/databases/database-view)) and run:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS vector;
+
+CREATE TABLE documents (
+  id BIGSERIAL PRIMARY KEY,
+  title TEXT NOT NULL,
+  content TEXT NOT NULL,
+  embedding vector(1536),
+  fts tsvector GENERATED ALWAYS AS (
+    setweight(to_tsvector('english', coalesce(title, '')), 'A') ||
+    setweight(to_tsvector('english', coalesce(content, '')), 'B')
+  ) STORED
+);
+
+CREATE INDEX idx_documents_fts ON documents USING gin (fts);
+
+CREATE INDEX idx_documents_embedding ON documents
+  USING hnsw (embedding vector_cosine_ops);
+```
+
+Three details matter here:
+
+- `fts` is a **generated column**. Postgres recomputes it on every insert and update, so the lexical index never drifts from the content.
+- `setweight` ranks title matches (`A`) above body matches (`B`) in `ts_rank_cd` scoring.
+- The HNSW index uses `vector_cosine_ops` to match the `<=>` cosine distance operator used in queries. Its dimension, `1536`, matches OpenAI's `text-embedding-3-small`, so change it if you use a different model.
+
+## 3. Write the hybrid query
+
+The query runs both searches as CTEs, takes the top 50 from each, and merges them with RRF. A document's RRF score is `1 / (k + rank)` summed across the lists it appears in, with `k = 60` as the conventional smoothing constant.
+
+```sql
+WITH lexical AS (
+  SELECT id,
+         row_number() OVER (ORDER BY ts_rank_cd(fts, query) DESC) AS rank
+  FROM documents, websearch_to_tsquery('english', $1) AS query
+  WHERE fts @@ query
+  ORDER BY ts_rank_cd(fts, query) DESC
+  LIMIT 50
+),
+semantic AS (
+  SELECT id,
+         row_number() OVER (ORDER BY embedding <=> $2::vector) AS rank
+  FROM documents
+  WHERE embedding IS NOT NULL
+  ORDER BY embedding <=> $2::vector
+  LIMIT 50
+)
+SELECT d.id,
+       d.title,
+       d.content,
+       coalesce(1.0 / (60 + lexical.rank), 0.0) +
+       coalesce(1.0 / (60 + semantic.rank), 0.0) AS score
+FROM lexical
+FULL OUTER JOIN semantic USING (id)
+JOIN documents d USING (id)
+ORDER BY score DESC
+LIMIT $3;
+```
+
+The `FULL OUTER JOIN` keeps documents found by only one strategy. A document ranked first in both lists scores `2/61 ≈ 0.0328`; a document found only by vector search at rank 10 scores `1/70 ≈ 0.0143`. On the lexical side feeding that join, `websearch_to_tsquery` parses the raw search string safely, including quoted phrases and `-exclusions`, so user input needs no manual escaping into tsquery syntax.
+
+## 4. Build the search API
+
+Create the project:
+
+```bash
+mkdir hybrid-search && cd hybrid-search
+npm init -y
+npm install express pg
+npm install --save-dev typescript @types/express @types/pg @types/node
+npx tsc --init --strict --module nodenext --moduleResolution nodenext --rootDir src --outDir dist
+```
+
+Create `src/index.ts`:
+
+```typescript
+import express from "express";
+import { Pool } from "pg";
+
+const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+const app = express();
+app.use(express.json());
+
+const OPENAI_API_KEY = process.env.OPENAI_API_KEY;
+const EMBEDDING_MODEL = "text-embedding-3-small";
+
+async function embed(text: string): Promise<number[]> {
+  const res = await fetch("https://api.openai.com/v1/embeddings", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${OPENAI_API_KEY}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model: EMBEDDING_MODEL, input: text }),
+  });
+  if (!res.ok) {
+    throw new Error(`Embedding request failed: ${res.status}`);
+  }
+  const data = (await res.json()) as {
+    data: { embedding: number[] }[];
+  };
+  const first = data.data[0];
+  if (!first) {
+    throw new Error("Embedding response contained no data");
+  }
+  return first.embedding;
+}
+
+// Ingest a document: store content, tsvector is generated automatically.
+app.post("/documents", async (req, res) => {
+  const { title, content } = req.body as { title?: string; content?: string };
+  if (!title || !content) {
+    res.status(400).json({ error: "title and content are required" });
+    return;
+  }
+  try {
+    const embedding = await embed(`${title}\n\n${content}`);
+    const result = await pool.query(
+      `INSERT INTO documents (title, content, embedding)
+       VALUES ($1, $2, $3::vector) RETURNING id`,
+      [title, content, JSON.stringify(embedding)]
+    );
+    res.status(201).json({ id: result.rows[0].id });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "ingestion failed" });
+  }
+});
+
+// Hybrid search: full-text + vector, merged with Reciprocal Rank Fusion.
+app.get("/search", async (req, res) => {
+  const q = req.query.q;
+  if (typeof q !== "string" || q.trim() === "") {
+    res.status(400).json({ error: "q query parameter is required" });
+    return;
+  }
+  const limit = Math.min(Number(req.query.limit) || 10, 50);
+  try {
+    const queryEmbedding = await embed(q);
+    const result = await pool.query(
+      `WITH lexical AS (
+         SELECT id,
+                row_number() OVER (ORDER BY ts_rank_cd(fts, query) DESC) AS rank
+         FROM documents, websearch_to_tsquery('english', $1) AS query
+         WHERE fts @@ query
+         ORDER BY ts_rank_cd(fts, query) DESC
+         LIMIT 50
+       ),
+       semantic AS (
+         SELECT id,
+                row_number() OVER (ORDER BY embedding <=> $2::vector) AS rank
+         FROM documents
+         WHERE embedding IS NOT NULL
+         ORDER BY embedding <=> $2::vector
+         LIMIT 50
+       )
+       SELECT d.id,
+              d.title,
+              left(d.content, 300) AS snippet,
+              coalesce(1.0 / (60 + lexical.rank), 0.0) +
+              coalesce(1.0 / (60 + semantic.rank), 0.0) AS score
+       FROM lexical
+       FULL OUTER JOIN semantic USING (id)
+       JOIN documents d USING (id)
+       ORDER BY score DESC
+       LIMIT $3`,
+      [q, JSON.stringify(queryEmbedding), limit]
+    );
+    res.json({ query: q, results: result.rows });
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: "search failed" });
+  }
+});
+
+app.get("/health", (_req, res) => {
+  res.json({ status: "ok" });
+});
+
+const port = Number(process.env.PORT) || 3000;
+app.listen(port, "0.0.0.0", () => {
+  console.log(`Hybrid search API listening on ${port}`);
+});
+```
+
+Add build and start scripts to `package.json`, and set `"type": "module"` since the compiler is configured for ES modules:
+
+```json
+{
+  "type": "module",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  }
+}
+```
+
+The embedding is passed to Postgres as a JSON string and cast with `::vector`, which pgvector accepts directly. No pgvector client library is required.
+
+## 5. Deploy to Railway
+
+Push the project to a GitHub repo, then in your Railway project click **Create** and select the repo. Railway detects Node and builds it with [Railpack](/builds/build-configuration).
+
+Set two variables on the service under **Variables**:
+
+- `DATABASE_URL`: reference the pgvector service's variable so it resolves over the private network, for example `${{Postgres.DATABASE_URL}}`. Private traffic between services in the same environment does not leave Railway.
+- `OPENAI_API_KEY`: your OpenAI key.
+
+Add a domain under **Settings → Networking** to expose the API at a `*.up.railway.app` URL. Set the [healthcheck path](/deployments/healthchecks) to `/health` so deploys only go live after the service responds.
+
+Test it:
+
+```bash
+curl -X POST https://your-app.up.railway.app/documents \
+  -H "Content-Type: application/json" \
+  -d '{"title": "Lowering infrastructure costs", "content": "Strategies for reducing compute and storage spend across environments."}'
+
+curl "https://your-app.up.railway.app/search?q=reduce+cloud+spend"
+```
+
+The query "reduce cloud spend" shares no keywords with the document, so full-text search misses it. The semantic branch finds it, and RRF surfaces it in the merged results.
+
+## Tuning the ranking
+
+- **Candidate depth.** The `LIMIT 50` in each CTE controls how deep each strategy contributes. Raise it for large corpora where relevant documents sit below rank 50 in one list.
+- **The `k` constant.** Lower `k` (for example 10) amplifies top-ranked results; higher `k` flattens the blend. The original RRF paper uses `k = 60`; start there.
+- **Weighting one side.** Multiply one branch's term, such as `1.5 * coalesce(1.0 / (60 + semantic.rank), 0.0)`, to bias toward semantic or lexical results. Tune against real queries from your own traffic.
+- **Language config.** `'english'` in `to_tsvector` and `websearch_to_tsquery` controls stemming and stop words. Use the config matching your content's language, or `'simple'` to disable stemming.
+- **Index recall.** HNSW is approximate. If vector recall matters more than latency, raise `hnsw.ef_search` per session: `SET hnsw.ef_search = 100;`.
+
+## Operational notes
+
+- Both indexes live in the same database, so ingestion is one transaction. There is no sync job between a search engine and a source of truth, which removes an entire failure class.
+- Embedding calls go to an external API. Railway services are CPU-based, so run embedding remotely rather than loading a local model.
+- Postgres full-text search and pgvector both scale vertically with the database. Resource usage on Railway is billed by actual consumption, so an idle search index costs only its storage.
+
+## Next steps
+
+- [Deploy a RAG Pipeline with pgvector](/guides/rag-pipeline-pgvector)
+- [PostgreSQL on Railway](/databases/postgresql)
+- [Private networking](/networking/private-networking)
+- [Variables and references](/variables)

--- a/content/guides/instrument-app-opentelemetry.md
+++ b/content/guides/instrument-app-opentelemetry.md
@@ -1,0 +1,242 @@
+---
+title: Instrument an App with OpenTelemetry
+description: Add OpenTelemetry traces and metrics to a Node.js or Python app on Railway, and send them to a collector over the private network.
+date: "2026-07-29"
+tags:
+  - opentelemetry
+  - observability
+  - tracing
+  - monitoring
+topic: infrastructure
+---
+
+Instrumentation is the code that makes your application emit telemetry: traces that follow a request across functions and services, metrics that count and measure what the app does, and logs with trace context attached. OpenTelemetry (OTel) is the vendor-neutral standard for producing that data, so you instrument once and point the output at any backend. This guide adds the OTel SDK to a Node.js or Python service on Railway, configures it with environment variables, and exports telemetry to an OpenTelemetry Collector over [private networking](/networking/private-networking).
+
+This guide covers the application side. For the infrastructure side, deploying the collector and a tracing backend, see [Deploy an OpenTelemetry Collector and Backend on Railway](/guides/deploy-an-otel-collector-stack).
+
+## Prerequisites
+
+- A Railway project with a service you want to instrument.
+- An OTLP endpoint to send telemetry to. The examples assume an OpenTelemetry Collector running as a service in the same project and environment, listening on port 4318 (OTLP over HTTP). The [collector guide](/guides/deploy-an-otel-collector-stack) sets this up, including a one-click template.
+
+You can also skip the collector and export directly to a vendor's OTLP endpoint over the public internet. A collector is still the better default: it batches, retries, and fans out to multiple backends without app changes, and app-to-collector traffic on the private network avoids [network egress charges](/pricing/cost-control).
+
+## Configure the SDK with environment variables
+
+Every OpenTelemetry SDK reads the same standard environment variables. Set them on the instrumented service in Railway, under the **Variables** tab, instead of hardcoding endpoints in code:
+
+```plaintext
+OTEL_EXPORTER_OTLP_ENDPOINT=http://${{OpenTelemetry Collector.RAILWAY_PRIVATE_DOMAIN}}:4318
+OTEL_SERVICE_NAME=${{RAILWAY_SERVICE_NAME}}
+OTEL_RESOURCE_ATTRIBUTES=service.version=${{RAILWAY_GIT_COMMIT_SHA}},deployment.environment.name=${{RAILWAY_ENVIRONMENT_NAME}}
+```
+
+What each line does:
+
+- `OTEL_EXPORTER_OTLP_ENDPOINT` points the exporter at the collector. `${{OpenTelemetry Collector.RAILWAY_PRIVATE_DOMAIN}}` is a [reference variable](/variables/reference) that resolves to the collector service's `<service>.railway.internal` hostname. Adjust the service name to match yours. Use `http`, not `https`: private network traffic is already encrypted in transit by Railway.
+- `OTEL_SERVICE_NAME` names the service in your traces. Referencing `RAILWAY_SERVICE_NAME` keeps it in sync with the service name in Railway.
+- `OTEL_RESOURCE_ATTRIBUTES` attaches key-value pairs to every span and metric. `RAILWAY_GIT_COMMIT_SHA` and `RAILWAY_ENVIRONMENT_NAME` are [Railway-provided variables](/variables/reference), so each trace records exactly which commit and environment produced it.
+
+Private networking is scoped per environment, so the app and the collector must run in the same project and environment for the internal hostname to resolve.
+
+## Instrument a Node.js app
+
+Install the SDK, the auto-instrumentation bundle, and the OTLP exporters:
+
+```bash
+npm install @opentelemetry/api @opentelemetry/sdk-node \
+  @opentelemetry/auto-instrumentations-node \
+  @opentelemetry/exporter-trace-otlp-http \
+  @opentelemetry/exporter-metrics-otlp-http \
+  @opentelemetry/sdk-metrics express
+```
+
+Of these, `express` is only for the example app; the auto-instrumentation bundle detects popular libraries (Express, Fastify, `http`, `pg`, `ioredis`, and others) and creates spans for them automatically.
+
+### Create the SDK setup file
+
+Create `instrumentation.js` at the project root:
+
+```javascript
+// instrumentation.js
+const { NodeSDK } = require("@opentelemetry/sdk-node");
+const {
+  getNodeAutoInstrumentations,
+} = require("@opentelemetry/auto-instrumentations-node");
+const {
+  OTLPTraceExporter,
+} = require("@opentelemetry/exporter-trace-otlp-http");
+const {
+  OTLPMetricExporter,
+} = require("@opentelemetry/exporter-metrics-otlp-http");
+const { PeriodicExportingMetricReader } = require("@opentelemetry/sdk-metrics");
+
+// Endpoint and service name come from OTEL_EXPORTER_OTLP_ENDPOINT
+// and OTEL_SERVICE_NAME, so nothing is hardcoded here.
+const sdk = new NodeSDK({
+  traceExporter: new OTLPTraceExporter(),
+  metricReader: new PeriodicExportingMetricReader({
+    exporter: new OTLPMetricExporter(),
+  }),
+  instrumentations: [getNodeAutoInstrumentations()],
+});
+
+sdk.start();
+
+// Flush telemetry before the container stops.
+process.on("SIGTERM", () => {
+  sdk
+    .shutdown()
+    .catch((err) => console.error("Error shutting down OpenTelemetry", err))
+    .finally(() => process.exit(0));
+});
+```
+
+The exporters are constructed with no arguments. They read `OTEL_EXPORTER_OTLP_ENDPOINT` and append the correct signal path (`/v1/traces`, `/v1/metrics`) themselves. That `SIGTERM` handler matters on Railway: deployments are replaced on every deploy, and flushing on shutdown prevents losing the last batch of spans.
+
+### Add a custom span
+
+Auto-instrumentation gives you one span per HTTP request and per database call. Add custom spans around the work you care about:
+
+```javascript
+// server.js
+const express = require("express");
+const { trace, SpanStatusCode } = require("@opentelemetry/api");
+
+const tracer = trace.getTracer("checkout");
+const app = express();
+const port = process.env.PORT || 3000;
+
+app.get("/checkout", async (req, res) => {
+  // Create a child span inside the auto-created HTTP span.
+  const total = await tracer.startActiveSpan(
+    "calculate-total",
+    async (span) => {
+      try {
+        span.setAttribute("cart.items", 3);
+        const total = await calculateTotal();
+        return total;
+      } catch (err) {
+        span.setStatus({ code: SpanStatusCode.ERROR });
+        throw err;
+      } finally {
+        span.end();
+      }
+    }
+  );
+
+  res.json({ total });
+});
+
+async function calculateTotal() {
+  // Stand-in for real work: a database query, an API call.
+  return 3 * 999;
+}
+
+app.listen(port, () => {
+  console.log(`Listening on port ${port}`);
+});
+```
+
+### Load the SDK before the app
+
+The SDK must load before any library it instruments. Set a custom [start command](/builds/build-and-start-commands) on the service in Railway:
+
+```plaintext
+node --require ./instrumentation.js server.js
+```
+
+The `--require` flag loads `instrumentation.js` before `server.js` and everything it imports.
+
+### Zero-code alternative
+
+If you do not need custom spans, skip the setup file entirely. Install two packages:
+
+```bash
+npm install @opentelemetry/api @opentelemetry/auto-instrumentations-node
+```
+
+Then use this start command:
+
+```plaintext
+node --require @opentelemetry/auto-instrumentations-node/register server.js
+```
+
+The register module builds the SDK from environment variables alone. The same `OTEL_EXPORTER_OTLP_ENDPOINT` and `OTEL_SERVICE_NAME` variables apply.
+
+## Instrument a Python app
+
+Install the distro, the OTLP exporter, and Flask for the example:
+
+```bash
+pip install opentelemetry-distro opentelemetry-exporter-otlp flask
+opentelemetry-bootstrap -a install
+```
+
+`opentelemetry-bootstrap` scans your installed packages and installs matching instrumentation libraries. Run it after adding dependencies, or add its output to `requirements.txt` so it runs during the Railway build.
+
+The Python OTLP exporter defaults to gRPC on port 4317. To use the HTTP endpoint on 4318 like the Node example, add one more variable to the service:
+
+```plaintext
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+```
+
+### Add a custom span
+
+```python
+import os
+
+from flask import Flask, jsonify
+from opentelemetry import trace
+
+tracer = trace.get_tracer("checkout")
+app = Flask(__name__)
+
+
+@app.route("/checkout")
+def checkout():
+    # Create a child span inside the auto-created request span.
+    with tracer.start_as_current_span("calculate-total") as span:
+        span.set_attribute("cart.items", 3)
+        total = 3 * 999
+    return jsonify(total=total)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=int(os.environ.get("PORT", 3000)))
+```
+
+### Wrap the start command
+
+Prefix the normal start command with `opentelemetry-instrument`:
+
+```plaintext
+opentelemetry-instrument python main.py
+```
+
+For a production server, wrap that instead:
+
+```plaintext
+opentelemetry-instrument gunicorn main:app --bind 0.0.0.0:$PORT
+```
+
+`opentelemetry-instrument` configures the SDK from the same `OTEL_*` environment variables and activates every instrumentation library that `opentelemetry-bootstrap` installed.
+
+## Verify telemetry is flowing
+
+1. Deploy the service and send it a few requests.
+2. Check the collector received the data. The collector from the [stack guide](/guides/deploy-an-otel-collector-stack) exposes a debugging UI (the zpages extension) where you can see incoming spans, or you can add the `debug` exporter to the collector config to print each received span to the service [logs](/observability/logs).
+3. Open your tracing backend (Jaeger in the [collector stack guide](/guides/deploy-an-otel-collector-stack)) and search for the service name you set in `OTEL_SERVICE_NAME`. You should see one trace per request, with your custom span nested inside the HTTP span.
+
+If nothing arrives, check three things: the reference variable resolves to the right collector service name, both services are in the same environment, and the endpoint uses `http://` with port 4318 (or 4317 for gRPC).
+
+## Where OpenTelemetry fits with Railway observability
+
+Railway already collects [logs](/observability/logs) and resource-level [metrics](/observability/metrics) (CPU, memory, network) for every service with no instrumentation. OpenTelemetry adds what Railway cannot see from outside the container: request-level traces, cross-service context propagation, and application-specific metrics. Use both: Railway metrics tell you a service is using 80% of its memory, and a trace tells you which endpoint and query is responsible.
+
+## Next steps
+
+- [Deploy an OpenTelemetry Collector and Backend on Railway](/guides/deploy-an-otel-collector-stack): the infrastructure this guide sends telemetry to.
+- [Private Networking](/networking/private-networking): how `<service>.railway.internal` hostnames work.
+- [Variables Reference](/variables/reference): every Railway-provided variable you can attach as a resource attribute.
+- [Third-Party Observability Tools](/guides/third-party-observability): send the same telemetry to hosted backends.

--- a/content/guides/isolate-staging-production.md
+++ b/content/guides/isolate-staging-production.md
@@ -1,0 +1,135 @@
+---
+title: Isolate Staging from Production for Compliance
+description: Separate staging and production on Railway with per-environment networks, per-environment bucket instances, and environment-scoped credentials.
+date: "2026-07-29"
+tags:
+  - environments
+  - compliance
+  - security
+  - architecture
+topic: architecture
+---
+
+Auditors for SOC 2, HIPAA, and similar frameworks expect a clear boundary between production and everything else: separate networks, separate data stores, separate credentials, and controlled access to production configuration. On Railway, that boundary is the environment.
+
+A Railway environment is an isolated instance of every service in a project. Each environment gets its own private network, its own variables, its own bucket instances, and its own deployments. Nothing in staging can reach production over the private network, and staging credentials never grant access to production data.
+
+That isolation is what this guide builds: a staging environment that mirrors production but stays separate from it, plus the access controls compliance reviews look for.
+
+## What isolation you get per environment
+
+| Layer | Isolation boundary |
+| --- | --- |
+| Private network | Per environment. Services in staging cannot reach production services at `<service>.railway.internal`. Each environment has its own isolated network. |
+| Variables | Per environment. Every variable value is scoped to one environment. |
+| Buckets | Per environment. Each environment gets its own bucket instance with its own S3 credentials. |
+| Databases and volumes | Per environment. Each environment is an isolated instance of every service, so a duplicated environment gets its own database services with their own volumes and data. |
+| Deployments | Per environment. Each environment deploys from its own configured branch. |
+
+Two things are shared across environments and need their own handling: project membership (addressed with [Environment RBAC](#restrict-who-can-touch-production)) and public networking (every service with a public domain is reachable from the internet regardless of environment, so staging endpoints should still require authentication).
+
+## Create a staging environment
+
+Every project starts with a `production` environment. To add staging:
+
+1. Open the environment dropdown in the top navigation and select **+ New Environment**, or go to **Settings → Environments**.
+2. Choose **Duplicate Environment** to copy production, including services, variables, and configuration. Choose **Empty Environment** if you want to add services one at a time.
+3. Review the staged changes banner and click **Deploy** to create the services.
+
+Duplicating is the common path. It gives you a copy of every service, so staging structurally matches production. One exception is deliberate: [sealed variables](/variables#sealed-variables) are not copied when duplicating an environment. Any secret you sealed in production must be set again in staging. That is what you want: staging should hold staging credentials, not production ones.
+
+## Point staging at its own branch
+
+Each service in each environment has its own deployment trigger. Configure them so code flows through staging before production:
+
+1. Switch to the `staging` environment in the environment dropdown.
+2. Open the service, go to **Settings**, and set the trigger branch to `staging`.
+3. Switch to `production` and confirm the same service triggers from `main`.
+
+Pushes to `staging` now deploy only the staging environment. Merges to `main` deploy production. See [GitHub autodeploys](/deployments/github-autodeploys) for details.
+
+## Per-environment private networks
+
+Railway's private networking is isolated at the project and environment level. Every service gets an internal DNS name at `<service>.railway.internal`, and that name resolves only within the same environment. So a misconfigured staging worker that tries to call `api.railway.internal` gets the staging API, never the production one; there is no route between the two networks.
+
+This means you do not need to build network segmentation yourself. The same connection string shape works in both environments and always resolves to the right instance:
+
+```
+http://api.railway.internal:3000
+postgresql://postgres:${{Postgres.PGPASSWORD}}@postgres.railway.internal:5432/railway
+```
+
+Because the DNS name is identical in both environments, your application code and reference variables stay the same. Only the environment they run in changes what they resolve to.
+
+## Per-environment bucket instances
+
+Railway [Storage Buckets](/storage-buckets) follow the same model. Each environment gets its own separate bucket instance with isolated credentials. When you duplicate an environment, staging gets its own bucket instance, separate from production's. Staging code cannot delete production objects, and test uploads never land next to customer data.
+
+Buckets are private only. Objects are reachable exclusively with the bucket's S3 credentials, through presigned URLs, or proxied through your backend; there is no public-bucket mode to accidentally enable in either environment.
+
+Wire the bucket credentials into your service with reference variables, so each environment's service receives that environment's credentials:
+
+```
+BUCKET=${{ bucket.BUCKET }}
+ACCESS_KEY_ID=${{ bucket.ACCESS_KEY_ID }}
+SECRET_ACCESS_KEY=${{ bucket.SECRET_ACCESS_KEY }}
+ENDPOINT=${{ bucket.ENDPOINT }}
+```
+
+In production, these resolve to the production bucket instance. In staging, the same references resolve to the staging instance, with no conditional logic or environment checks in your code.
+
+## Environment-scoped credentials
+
+Every variable in Railway is scoped to a single environment. Use that to keep external credentials separated too:
+
+- **Third-party API keys**: set the production key (for example, a live Stripe key) only in the production environment, and the test key in staging. Neither environment can read the other's values.
+- **Shared variables**: shared variables are also defined per environment under **Project Settings → Shared Variables**, so a project-wide `API_KEY` can hold different values in staging and production.
+- **Sealed variables**: seal production secrets so their values are never visible in the UI and cannot be retrieved via the API. Sealed values are excluded from environment duplication, PR environments, environment sync diffs, and external integrations.
+
+Your application should never branch on environment to pick credentials. If you find code like `if (env === "production") use LIVE_KEY`, move both keys into their respective environments under the same variable name. If you need the environment name at runtime for logging or guardrails, Railway provides `RAILWAY_ENVIRONMENT_NAME` automatically.
+
+## Restrict who can touch production
+
+Isolating the infrastructure is half the requirement. Compliance frameworks also ask who can access production secrets and data.
+
+[Environment RBAC](/enterprise/environment-rbac), available on Railway Enterprise, lets you mark the production environment as restricted:
+
+- Non-admin members and deployers can see the environment exists but cannot view its variables, logs, metrics, services, or configuration.
+- Deployments can still be triggered via git push, so developers keep deploying without ever reading production secrets.
+- Only admins can access restricted environments or toggle the restriction.
+
+Recommended setup for a compliance posture:
+
+1. Mark `production` as restricted.
+2. Keep `staging` unrestricted so the team can debug there freely.
+3. Limit admin membership to the people who operate production.
+4. Review admin access periodically.
+
+[Audit logs](/enterprise/audit-logs) give workspace admins a record of changes to projects, services, deployments, variables, and workspace settings, which covers the change-management evidence most audits ask for.
+
+## Keep staging and production in sync
+
+Isolation creates drift risk: staging stops matching production and tests stop being representative. Environment sync fixes this without breaking the boundary:
+
+1. Switch to the environment that should receive changes.
+2. Click **Sync** at the top of the canvas and select the source environment.
+3. Review the staged changes (services tagged "New", "Edited", "Removed") and click **Deploy**.
+
+Sync copies configuration, not data, so databases, volumes, and bucket contents stay separate. Sealed variables are also excluded from the sync diff, so production secrets never leak into staging through a sync.
+
+## Checklist
+
+- Staging environment duplicated from production, deploying from a `staging` branch
+- Production deploys only from `main`
+- All secrets set per environment; production secrets sealed
+- Bucket credentials wired via reference variables, not hardcoded
+- Live third-party keys present only in production
+- Production environment restricted via Environment RBAC (Enterprise)
+- Audit logs reviewed as part of your change-management process
+
+## Next steps
+
+- [Environments](/environments) covers PR environments, sync, and environment types in depth.
+- [Managing secrets on Railway](/guides/managing-secrets-on-railway) goes deeper on sealed variables and secret hygiene.
+- [Preview deployments with PR environments](/guides/preview-deployments-with-pr-environments) adds ephemeral per-PR environments on top of staging.
+- [Rotate credentials with zero downtime](/guides/rotate-credentials-zero-downtime) covers the credential lifecycle after isolation is in place.

--- a/content/guides/jupyter-server-team.md
+++ b/content/guides/jupyter-server-team.md
@@ -1,0 +1,162 @@
+---
+title: Deploy a Jupyter Server for Team Data Work
+description: Run a shared JupyterLab server on Railway with token authentication, a persistent volume for notebooks, and health checks for zero-downtime deploys.
+date: "2026-07-29"
+tags:
+  - jupyter
+  - python
+  - data-science
+  - volumes
+topic: integrations
+---
+
+A Jupyter server is a long-running web application that hosts notebooks, kernels, and files; your team connects from a browser, and all code executes on the server, not on anyone's laptop. This guide deploys one on Railway that your whole team shares: one Python environment, one set of data files, one pool of compute, instead of "works on my machine" differences across laptops.
+
+The setup includes:
+
+- Token authentication so only your team can open it.
+- A volume so notebooks survive redeploys.
+- A health check so dependency upgrades deploy with zero downtime.
+
+One constraint up front: Railway services run on CPU. There are no GPUs, so this setup fits data wrangling, analysis, reporting, and classical machine learning, not GPU model training.
+
+## Will long-running cells time out?
+
+No. Jupyter's browser UI talks to kernels over WebSockets, which Railway supports on every service. Those connections are exempt from the idle timeout that applies to plain HTTP requests, so a cell that runs for an hour keeps streaming output to your browser without being cut.
+
+Plain HTTP requests to a service are closed after 5 minutes of no data transfer, and run at most 15 minutes even while transferring. Jupyter's kernel protocol does not hit those limits because the long-lived channel is a WebSocket.
+
+## Create the project files
+
+You need two files. Railway's builder, [Railpack](/builds/railpack), detects `requirements.txt` and builds a Python environment automatically, so no Dockerfile is required.
+
+`requirements.txt`:
+
+```txt
+jupyterlab==4.4.5
+pandas==2.3.1
+matplotlib==3.10.3
+```
+
+Add whatever your team analyzes with: `polars`, `scikit-learn`, `duckdb`, database drivers. Pin versions. The server is shared, so an unpinned upgrade breaks everyone at once.
+
+`railway.json`:
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "startCommand": "jupyter lab --ip=0.0.0.0 --port=$PORT --no-browser --ServerApp.root_dir=/data --ServerApp.allow_remote_access=True",
+    "healthcheckPath": "/api",
+    "restartPolicyType": "ON_FAILURE"
+  }
+}
+```
+
+What each flag does:
+
+- `--ip=0.0.0.0` binds all interfaces so Railway's proxy can reach the server.
+- `--port=$PORT` listens on the port Railway injects.
+- `--ServerApp.root_dir=/data` serves notebooks from the volume mount path you will create below.
+- `--ServerApp.allow_remote_access=True` accepts requests whose `Host` header is your public domain. Without it, Jupyter blocks non-local hosts.
+- `healthcheckPath: /api` points the health check at Jupyter's version endpoint, which returns 200 without authentication. With a [health check](/deployments/healthchecks) configured, Railway keeps the old deployment serving until the new one is live.
+
+## Deploy the service
+
+From the directory containing both files, using the [Railway CLI](/cli):
+
+```bash
+railway init
+railway up
+```
+
+Or push the two files to a GitHub repository and create a service from it in the dashboard. See [deploying services](/services) for both flows.
+
+The first deploy will crash-loop until the volume and token exist. Set those up next.
+
+## Add a volume for notebooks
+
+Container filesystems on Railway are ephemeral. Every redeploy starts from a fresh image, so notebooks written to the container disk disappear. A [volume](/volumes) persists them.
+
+1. Right-click the service in your project canvas and choose **Attach Volume** (or use the Command Palette with `⌘K`).
+2. Set the mount path to `/data`.
+
+The start command above already points Jupyter's root directory at `/data`, so everything your team creates in the JupyterLab file browser lands on the volume.
+
+Two volume behaviors worth knowing:
+
+- Volumes are mounted when the container starts, not during build or pre-deploy. Do not write seed data to `/data` in a build step; it will not persist.
+- Volumes cost $0.15 per GB per month, metered per minute.
+
+That persistence has a limit, though: a volume is still a single disk. For datasets you cannot lose, enable [volume backups](/volumes/backups) or keep raw data in a [storage bucket](/storage-buckets) and treat the volume as a working directory.
+
+## Secure the server with a token
+
+A Jupyter server executes arbitrary code. Never expose one without authentication.
+
+Jupyter reads the `JUPYTER_TOKEN` environment variable at startup and requires it for every session. Set it as a [service variable](/variables):
+
+1. Open the service's **Variables** tab.
+2. Add `JUPYTER_TOKEN` with a long random value:
+
+```bash
+openssl rand -hex 32
+```
+
+Once you redeploy, team members open:
+
+```
+https://<your-domain>/?token=<value>
+```
+
+or paste the token into the login page. Everyone who has the token has full execution access, so treat it like a shared password: store it in your team's secret manager and rotate it when someone leaves. For per-user logins and an admin-managed user list, run [JupyterHub](https://jupyter.org/hub) instead of a single shared server; the volume and networking setup in this guide applies the same way.
+
+## Expose the server on a domain
+
+In the service's **Settings** tab, under **Networking**, generate a Railway-provided domain: a `*.up.railway.app` URL with TLS included. Railway detects the port your server listens on and sets it as that domain's target port. You can replace it with a [custom domain](/networking/domains) later.
+
+If other services in the same environment need to call the Jupyter REST API (for example, a scheduler that executes notebooks), they can use [private networking](/networking/private-networking) at `http://<service-name>.railway.internal:<port>` instead of going over the public internet. Private networking is scoped per environment.
+
+## Size the server for your team
+
+Railway bills for usage: $10 per GB of RAM per month and $20 per vCPU per month, metered by the minute. There is no per-seat charge, so one shared server for five analysts costs the same as for one.
+
+Memory is the number that matters. Every open kernel holds its DataFrames in RAM, and pandas typically needs several times the on-disk size of a dataset. Watch the service's memory graph during a normal working day, then set [replica limits](/pricing/cost-control) with headroom above the observed peak. When a kernel exhausts memory the whole server is at risk, so encourage the team to shut down idle kernels from the JupyterLab kernel sidebar.
+
+If the server sits idle outside working hours, consider [serverless](/deployments/serverless). Railway stops the container after 10 minutes with no outbound traffic and wakes it on the next request. Note that open JupyterLab tabs keep WebSocket traffic flowing, so the server only sleeps once everyone closes their tabs. Notebooks are on the volume, so nothing is lost across sleep and wake cycles.
+
+## Optional: real-time collaboration
+
+JupyterLab supports Google-Docs-style collaborative editing through the `jupyter-collaboration` extension. Add it to `requirements.txt`:
+
+```txt
+jupyter-collaboration==4.1.0
+```
+
+Redeploy, and multiple people editing the same notebook see each other's cursors and edits live. Without the extension, two people editing one notebook silently overwrite each other on save, so either install it or agree on one-notebook-per-person conventions.
+
+## Verify the deployment
+
+After the deploy goes live:
+
+```bash
+curl https://<your-domain>/api
+```
+
+should return a JSON version payload like `{"version": "2.16.0"}`. Then open the domain in a browser, authenticate with the token, create a notebook, and run:
+
+```python
+import pandas as pd
+
+df = pd.DataFrame({"x": range(5)})
+print(df.describe())
+```
+
+Redeploy the service and confirm the notebook is still there. That proves the volume mount is correct.
+
+## Next steps
+
+- [Volumes](/volumes) covers mount paths, sizing, and growth.
+- [Back up and restore volumes](/volumes/backups) protects the notebook data itself.
+- [Right-size CPU and memory](/guides/right-size-cpu-memory) helps you tune limits as the team grows.
+- [Managing secrets on Railway](/guides/managing-secrets-on-railway) covers safer handling of tokens like `JUPYTER_TOKEN`.

--- a/content/guides/keycloak-authentication.md
+++ b/content/guides/keycloak-authentication.md
@@ -1,0 +1,150 @@
+---
+title: Self-Host Keycloak for Authentication
+description: Deploy Keycloak on Railway with a Postgres database, an admin account, and a public domain. Configure a realm and an OIDC client for your applications.
+date: "2026-07-29"
+tags:
+  - keycloak
+  - authentication
+  - self-hosted
+  - postgres
+topic: integrations
+---
+
+[Keycloak](https://www.keycloak.org) is an open-source identity and access management server. It provides login pages, user management, single sign-on, and social login through standard protocols: OpenID Connect, OAuth 2.0, and SAML 2.0. Your applications delegate authentication to Keycloak instead of implementing it themselves.
+
+This guide deploys Keycloak on Railway from the official Docker image, backed by a Postgres database. Postgres holds all realms, users, clients, and sessions, so the Keycloak service itself is stateless and needs no volume.
+
+## What you will set up
+
+- A Keycloak instance from the official Docker image, running in production mode
+- A Postgres database for all Keycloak state
+- A public domain with TLS for the admin console and login pages
+- A realm and an OIDC client your applications can authenticate against
+
+## One-click deploy from a template
+
+Railway has a Keycloak template that provisions Keycloak and Postgres together:
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/keycloak)
+
+After deploying, open the service domain, log in with the bootstrap admin credentials from the service variables, and skip to [Create a realm and client](#create-a-realm-and-client).
+
+If you prefer manual setup, continue below.
+
+## Deploy manually
+
+### 1. Create the project and database
+
+1. Create a new [project](/projects) on Railway.
+2. Add a Postgres database: click **+ New**, then **Database**, then **PostgreSQL**.
+
+Keycloak supports Postgres directly, so do not run it against the embedded dev database in production; that database is not durable across deploys.
+
+### 2. Deploy the Keycloak Docker image
+
+1. Click **+ New**, then **Docker Image**.
+2. Enter `quay.io/keycloak/keycloak:26.3` as the image name.
+3. In the service **Settings**, set the custom start command to:
+
+```
+/opt/keycloak/bin/kc.sh start
+```
+
+`start` runs Keycloak in production mode. The default `start-dev` command is for local development only.
+
+### 3. Configure environment variables
+
+Add the following variables to the Keycloak service. The `${{Postgres.*}}` entries are [reference variables](/variables) that resolve to your database's credentials. The database connection uses [private networking](/networking/private-networking), so traffic between Keycloak and Postgres never leaves your project.
+
+| Variable | Value |
+| --- | --- |
+| `KC_DB` | `postgres` |
+| `KC_DB_URL` | `jdbc:postgresql://${{Postgres.RAILWAY_PRIVATE_DOMAIN}}:5432/${{Postgres.PGDATABASE}}` |
+| `KC_DB_USERNAME` | `${{Postgres.PGUSER}}` |
+| `KC_DB_PASSWORD` | `${{Postgres.PGPASSWORD}}` |
+| `KC_BOOTSTRAP_ADMIN_USERNAME` | `admin` |
+| `KC_BOOTSTRAP_ADMIN_PASSWORD` | A strong random password |
+| `KC_HTTP_ENABLED` | `true` |
+| `KC_PROXY_HEADERS` | `xforwarded` |
+| `KC_HEALTH_ENABLED` | `true` |
+
+Two of these need explanation:
+
+- `KC_HTTP_ENABLED=true` and `KC_PROXY_HEADERS=xforwarded` tell Keycloak it is running behind a TLS-terminating proxy. Railway terminates TLS at the edge and forwards plain HTTP to your container with `X-Forwarded-*` headers. Without these settings, production mode refuses HTTP connections.
+- `KC_BOOTSTRAP_ADMIN_*` creates a temporary admin account on first startup. After first login, create a permanent admin user in the master realm and remove these variables.
+
+### 4. Generate a domain and set the hostname
+
+1. In the Keycloak service **Settings**, under **Networking**, click **Generate Domain**. Keycloak listens on port 8080; select it as the [target port](/networking/domains/working-with-domains) if prompted.
+2. Add one more variable, using the domain you just generated:
+
+| Variable | Value |
+| --- | --- |
+| `KC_HOSTNAME` | `https://your-keycloak.up.railway.app` |
+
+Keycloak uses `KC_HOSTNAME` to build issuer URLs, redirect URLs, and admin console links. It must match the public domain exactly, including the `https://` scheme. If you later [add a custom domain](/networking/domains/working-with-domains), update `KC_HOSTNAME` to match.
+
+After the deploy completes, open the domain and log in to the admin console with your bootstrap credentials.
+
+### 5. Configure a healthcheck for zero-downtime deploys
+
+Keycloak serves its health endpoints on a separate management port, 9000, not on the main HTTP port. Railway healthchecks probe the port in the `PORT` variable, so point it at the management port:
+
+1. Add a service variable `PORT` with the value `9000`. Keycloak ignores `PORT` (it configures its listener with `KC_HTTP_PORT`), so this only affects the healthcheck. Public traffic still reaches port 8080 through the domain's target port.
+2. In the service **Settings**, set the [healthcheck path](/deployments/healthchecks) to `/health/ready`.
+
+With the healthcheck configured, Railway keeps the old deployment serving traffic until the new one reports ready.
+
+## Create a realm and client
+
+A realm is an isolated set of users, credentials, and clients. Keep the built-in `master` realm for Keycloak administration and create a separate realm for your applications.
+
+1. In the admin console, open the realm dropdown in the top left and click **Create realm**. Name it, for example, `myapp`.
+2. Go to **Clients**, then **Create client**. Set the client ID (for example `web-app`), keep the type **OpenID Connect**, and click **Next**.
+3. Enable **Standard flow** for browser-based login. Click **Next**, then set **Valid redirect URIs** to your application's callback URL (for example `https://myapp.up.railway.app/auth/callback`) and **Web origins** to your application's origin.
+4. Go to **Users**, then **Create new user**, and set a password under the **Credentials** tab.
+
+Your realm now exposes a standard OIDC discovery document:
+
+```
+https://your-keycloak.up.railway.app/realms/myapp/.well-known/openid-configuration
+```
+
+Any OIDC library can configure itself from this URL. It lists the authorization, token, userinfo, and JWKS endpoints.
+
+## Test the token endpoint
+
+To verify the deployment end to end, create a client with **Client authentication** enabled and **Service accounts roles** checked (a confidential client), copy its secret from the **Credentials** tab, then request a token:
+
+```bash
+curl -s -X POST \
+  "https://your-keycloak.up.railway.app/realms/myapp/protocol/openid-connect/token" \
+  -H "Content-Type: application/x-www-form-urlencoded" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=my-service" \
+  -d "client_secret=YOUR_CLIENT_SECRET"
+```
+
+A JSON response containing `access_token` confirms Keycloak, Postgres, and the public domain are wired correctly.
+
+## Connect applications inside the same project
+
+Services in the same Railway environment can reach Keycloak over private networking at `keycloak.railway.internal:8080` (the name matches your service name). This is useful for backend token validation because the traffic stays inside the project.
+
+Keep the issuer consistent: tokens are issued with the public `KC_HOSTNAME` URL in the `iss` claim. If a backend fetches the discovery document over the internal hostname, most OIDC libraries will reject tokens because the issuer does not match. So the simplest reliable setup uses the public domain everywhere and reserves the internal hostname for non-OIDC calls such as the admin REST API.
+
+## Sizing and production notes
+
+A few points matter once real users depend on this deployment:
+
+- Keycloak runs on the JVM. Expect a baseline of several hundred MB of memory; 1 GB is a reasonable starting allocation for small deployments. Railway bills that memory by actual usage (per MB per minute), so an idle instance costs less than its limit.
+- All state lives in Postgres, so redeploys, image upgrades, and restarts do not lose users or sessions Keycloak persists there.
+- Pin the image to a specific version (as this guide does with `26.3`) and upgrade deliberately. Keycloak upgrades run database migrations on startup.
+- Remove the `KC_BOOTSTRAP_ADMIN_*` variables after creating a permanent admin account.
+
+## Next steps
+
+- [Handle frontend authentication patterns](/guides/frontend-authentication): Where tokens live and how SPAs, SSR apps, and static sites differ.
+- [Private networking](/networking/private-networking): How service-to-service traffic works inside a project.
+- [Configure healthchecks](/deployments/healthchecks): Zero-downtime deploy behavior in detail.
+- [Manage secrets on Railway](/guides/managing-secrets-on-railway): Keep the admin password and client secrets out of your code.

--- a/content/guides/langfuse-llm-observability.md
+++ b/content/guides/langfuse-llm-observability.md
@@ -1,0 +1,190 @@
+---
+title: Self-Host Langfuse for LLM Observability
+description: Deploy Langfuse v3 on Railway with Postgres, ClickHouse, Redis, and object storage. Trace, debug, and evaluate your LLM applications on infrastructure you control.
+date: "2026-07-29"
+tags:
+  - langfuse
+  - observability
+  - ai
+  - self-hosted
+topic: integrations
+---
+
+[Langfuse](https://langfuse.com) is an open-source LLM engineering platform: it captures traces of your LLM calls (prompts, completions, latency, token usage, cost) and layers evaluation, prompt management, and analytics on top. This guide deploys Langfuse v3 on Railway and sends it a first trace. Self-hosting it keeps all trace data, including prompts that may contain user data, inside infrastructure you control.
+
+Langfuse v3 is a multi-service application: a web server, a background worker, Postgres for transactional data, ClickHouse for trace analytics, Redis for queues and caching, and S3-compatible object storage for raw event uploads. Railway runs each component as a separate service with shared private networking, so the whole stack fits in one project.
+
+Langfuse only observes LLM calls; it does not run models, so it is a standard CPU workload. Railway has no GPU instances, and this stack does not need one.
+
+## What we will set up
+
+- Langfuse web and worker as separate Railway services
+- PostgreSQL, ClickHouse, and Redis databases
+- A Railway storage bucket for event uploads
+- A public domain for the Langfuse UI
+
+## One-click deploy from a template
+
+Railway has a Langfuse v3 template that provisions all six services (web, worker, Postgres, ClickHouse, Redis, and MinIO for object storage) in one step.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/langfuse)
+
+After deploying, open the web service's domain, create your admin account, and skip to [Send traces from your application](#send-traces-from-your-application).
+
+If you prefer to set things up manually, or want to use Railway's native storage buckets instead of MinIO, continue below.
+
+## Manual deployment
+
+### 1. Create the project and databases
+
+1. Create a new [project](/projects) on Railway.
+2. Add [PostgreSQL](/databases/postgresql): click **+ New > Database > PostgreSQL**.
+3. Add [Redis](/databases/redis): click **+ New > Database > Redis**.
+
+### 2. Deploy ClickHouse
+
+Langfuse stores traces and observations in ClickHouse.
+
+1. Click **+ New > Docker Image** and enter `clickhouse/clickhouse-server:24`.
+2. Set these variables on the service:
+
+| Variable | Value |
+| --- | --- |
+| `CLICKHOUSE_DB` | `default` |
+| `CLICKHOUSE_USER` | `clickhouse` |
+| `CLICKHOUSE_PASSWORD` | A random string (use `openssl rand -hex 32`) |
+
+3. Attach a [volume](/volumes) mounted at `/var/lib/clickhouse`. Without a volume, all trace data is lost on every redeploy.
+
+ClickHouse needs no public domain. Langfuse reaches it over [private networking](/networking/private-networking) on port 8123 (HTTP) and 9000 (native TCP, used for migrations).
+
+### 3. Create a storage bucket
+
+Langfuse writes every incoming trace event to object storage before the worker ingests it into ClickHouse. Railway [storage buckets](/storage-buckets) are private and S3-compatible, which is what Langfuse expects.
+
+1. Click **+ New > Bucket** and pick a region.
+2. Note the bucket's **Credentials** tab. It exposes `BUCKET`, `ACCESS_KEY_ID`, `SECRET_ACCESS_KEY`, `REGION`, and `ENDPOINT` as referenceable variables, and tells you whether the bucket uses virtual-hosted or path-style URLs.
+
+The region is locked after creation, so create the bucket in the same region as your services.
+
+### 4. Generate secrets
+
+Langfuse requires three secrets. Generate them locally:
+
+```bash
+openssl rand -hex 32   # NEXTAUTH_SECRET
+openssl rand -hex 32   # SALT
+openssl rand -hex 32   # ENCRYPTION_KEY (must be exactly 64 hex characters)
+```
+
+### 5. Deploy the Langfuse web service
+
+1. Click **+ New > Docker Image** and enter `langfuse/langfuse:3`.
+2. Add the following variables, using [reference variables](/variables#referencing-another-services-variable) for the databases and bucket. The examples assume services named `Postgres`, `Redis`, `ClickHouse`, and `Bucket`; adjust to your service names.
+
+| Variable | Value |
+| --- | --- |
+| `DATABASE_URL` | `${{Postgres.DATABASE_URL}}` |
+| `CLICKHOUSE_URL` | `http://clickhouse.railway.internal:8123` |
+| `CLICKHOUSE_MIGRATION_URL` | `clickhouse://clickhouse.railway.internal:9000` |
+| `CLICKHOUSE_USER` | `${{ClickHouse.CLICKHOUSE_USER}}` |
+| `CLICKHOUSE_PASSWORD` | `${{ClickHouse.CLICKHOUSE_PASSWORD}}` |
+| `CLICKHOUSE_CLUSTER_ENABLED` | `false` |
+| `REDIS_CONNECTION_STRING` | `${{Redis.REDIS_URL}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_BUCKET` | `${{Bucket.BUCKET}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_REGION` | `${{Bucket.REGION}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_ENDPOINT` | `${{Bucket.ENDPOINT}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_ACCESS_KEY_ID` | `${{Bucket.ACCESS_KEY_ID}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_SECRET_ACCESS_KEY` | `${{Bucket.SECRET_ACCESS_KEY}}` |
+| `LANGFUSE_S3_EVENT_UPLOAD_FORCE_PATH_STYLE` | `false` (or `true` if your bucket's Credentials tab says path-style) |
+| `NEXTAUTH_URL` | The public URL of this service, e.g. `https://langfuse-production-xxxx.up.railway.app` |
+| `NEXTAUTH_SECRET` | The first secret from step 4 |
+| `SALT` | The second secret from step 4 |
+| `ENCRYPTION_KEY` | The third secret from step 4 |
+
+The private hostnames (`clickhouse.railway.internal`) come from the service names in your project. Private networking is scoped per environment, so the web service, worker, and databases must live in the same environment.
+
+3. Langfuse listens on port 3000. Generate a public domain for the service in **Settings > Networking** and set `NEXTAUTH_URL` to this domain once it exists.
+
+The web service runs Postgres and ClickHouse migrations on startup, so the first deploy takes a few minutes.
+
+### 6. Deploy the Langfuse worker
+
+The worker ingests events from the bucket into ClickHouse and runs evaluations.
+
+1. Click **+ New > Docker Image** and enter `langfuse/langfuse-worker:3`.
+2. Copy the same variables from the web service. `NEXTAUTH_URL` is not needed on the worker, but `SALT` and `ENCRYPTION_KEY` must match the web service exactly.
+3. Do not generate a public domain. The worker listens on port 3030 for internal health checks only and talks to everything else over private networking.
+
+### 7. Create your account
+
+Open the web service's public domain, sign up (the first user becomes the instance admin), create an organization and a project, and copy the project's public and secret API keys from **Settings > API Keys**.
+
+## Send traces from your application
+
+Install the Langfuse SDK in the application you want to observe:
+
+```bash
+npm install langfuse
+```
+
+Point it at your self-hosted instance and record a trace:
+
+```typescript
+import { Langfuse } from "langfuse";
+
+const langfuse = new Langfuse({
+  baseUrl: process.env.LANGFUSE_HOST, // https://your-langfuse.up.railway.app
+  publicKey: process.env.LANGFUSE_PUBLIC_KEY,
+  secretKey: process.env.LANGFUSE_SECRET_KEY,
+});
+
+async function main(): Promise<void> {
+  const trace = langfuse.trace({
+    name: "support-answer",
+    userId: "user_123",
+    input: { question: "How do I reset my password?" },
+  });
+
+  const generation = trace.generation({
+    name: "draft-answer",
+    model: "claude-sonnet-4-5",
+    input: [{ role: "user", content: "How do I reset my password?" }],
+  });
+
+  // ... call your LLM provider here ...
+  const answer = "Go to Settings > Security and click Reset Password.";
+
+  generation.end({
+    output: answer,
+    usage: { input: 12, output: 14 },
+  });
+
+  trace.update({ output: { answer } });
+
+  await langfuse.flushAsync();
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+If the application also runs on Railway in the same project and environment, set `LANGFUSE_HOST` to the web service's private address (`http://langfuse.railway.internal:3000`, adjusting for your service name). Trace ingestion then never leaves the private network and incurs no egress charges.
+
+Langfuse also ships framework integrations (OpenAI SDK wrapper, LangChain callbacks, OpenTelemetry) that use the same three environment variables.
+
+## Operational notes
+
+- **Memory**: ClickHouse and the Langfuse web container use the most memory. Railway bills RAM by usage at $10 per GB per month; watch the metrics tab and set limits with headroom rather than guessing. The bucket is cheaper by comparison, holding raw events at $0.015 per GB per month with free egress.
+- **Backups**: enable scheduled [backups](/volumes/backups) on the ClickHouse volume, and rely on the Postgres database's backups for transactional data.
+- **Upgrades**: the `langfuse/langfuse:3` and `langfuse/langfuse-worker:3` tags track the v3 line. Redeploy both services together; the web service applies migrations on startup.
+- **Single node**: run one ClickHouse replica with `CLICKHOUSE_CLUSTER_ENABLED=false`. A single node handles large trace volumes before clustering is worth the complexity.
+
+## Next steps
+
+- [Route LLM traffic through a gateway](/guides/llm-gateway) and trace it in one place
+- [Run ClickHouse for product analytics](/guides/clickhouse-analytics) for volume sizing and query patterns that apply to trace data too
+- [Private networking](/networking/private-networking) for how internal DNS and environment scoping work
+- [Storage buckets](/storage-buckets) for presigned URLs, credentials, and S3 client configuration

--- a/content/guides/langgraph-agent-backend.md
+++ b/content/guides/langgraph-agent-backend.md
@@ -1,0 +1,225 @@
+---
+title: Deploy a LangGraph Agent Backend
+description: Run a LangGraph agent as a FastAPI service on Railway with Postgres checkpointing for durable conversation state and Claude as the LLM.
+date: "2026-07-29"
+tags:
+  - langgraph
+  - agents
+  - python
+  - postgres
+topic: ai
+---
+
+In this guide we deploy a Python LangGraph agent on Railway as an HTTP service:
+
+- **FastAPI service** exposes the agent over HTTP.
+- **Postgres** stores checkpoints, so threads are durable and multi-turn.
+- **Claude** (or any hosted LLM API) does the reasoning over HTTP.
+
+The agent itself is a LangGraph graph: a framework for building stateful agents where each node is a step (call the model, run a tool), edges define control flow, and a checkpointer persists the full graph state after every step. That last part is what makes LangGraph a good fit for a hosted backend: with a Postgres checkpointer, every conversation thread survives restarts and redeploys.
+
+Running the model locally isn't an option here, though: Railway runs CPU workloads only, with no GPU instances, so the agent calls an external LLM API instead. That's the standard LangGraph deployment shape.
+
+## Prerequisites
+
+- A Railway account and project.
+- An Anthropic API key (or another LLM provider key).
+- Python 3.11+.
+
+## Provision Postgres
+
+Add a Postgres database to your project via the `ctrl / cmd + k` menu or the `+ New` button on the Project Canvas. See the [PostgreSQL guide](/databases/postgresql) for details.
+
+The database exposes a `DATABASE_URL` variable. Your agent service will read it through a [reference variable](/variables#referencing-another-services-variable).
+
+## Project structure
+
+```
+langgraph-agent/
+├── main.py
+├── requirements.txt
+```
+
+Create `requirements.txt`:
+
+```txt
+fastapi==0.115.6
+uvicorn==0.34.0
+langgraph==0.3.34
+langgraph-checkpoint-postgres==2.0.21
+langchain-anthropic==0.3.13
+langchain-core==0.3.63
+psycopg[binary,pool]==3.2.6
+```
+
+Install locally with:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Build the agent
+
+Create `main.py`. It defines a two-node graph (agent and tools), wires it to a Postgres checkpointer backed by a connection pool, and serves it with FastAPI:
+
+```python
+import os
+from typing import Annotated
+
+from fastapi import FastAPI
+from langchain_anthropic import ChatAnthropic
+from langchain_core.messages import HumanMessage
+from langchain_core.tools import tool
+from langgraph.checkpoint.postgres import PostgresSaver
+from langgraph.graph import END, START, StateGraph
+from langgraph.graph.message import add_messages
+from langgraph.prebuilt import ToolNode
+from psycopg_pool import ConnectionPool
+from pydantic import BaseModel
+from typing_extensions import TypedDict
+
+
+# --- Tools ---------------------------------------------------------------
+
+@tool
+def word_count(text: str) -> int:
+    """Count the number of words in a piece of text."""
+    return len(text.split())
+
+
+tools = [word_count]
+
+# --- Model ---------------------------------------------------------------
+
+llm = ChatAnthropic(model="claude-opus-5", max_tokens=4096)
+llm_with_tools = llm.bind_tools(tools)
+
+
+# --- Graph ---------------------------------------------------------------
+
+class State(TypedDict):
+    messages: Annotated[list, add_messages]
+
+
+def agent_node(state: State) -> State:
+    response = llm_with_tools.invoke(state["messages"])
+    return {"messages": [response]}
+
+
+def route_after_agent(state: State) -> str:
+    last_message = state["messages"][-1]
+    if getattr(last_message, "tool_calls", None):
+        return "tools"
+    return END
+
+
+builder = StateGraph(State)
+builder.add_node("agent", agent_node)
+builder.add_node("tools", ToolNode(tools))
+builder.add_edge(START, "agent")
+builder.add_conditional_edges("agent", route_after_agent, {"tools": "tools", END: END})
+builder.add_edge("tools", "agent")
+
+# --- Checkpointer --------------------------------------------------------
+
+pool = ConnectionPool(
+    conninfo=os.environ["DATABASE_URL"],
+    max_size=20,
+    kwargs={"autocommit": True, "prepare_threshold": 0},
+)
+checkpointer = PostgresSaver(pool)
+checkpointer.setup()  # creates checkpoint tables on first run
+
+graph = builder.compile(checkpointer=checkpointer)
+
+# --- API -----------------------------------------------------------------
+
+api = FastAPI()
+
+
+class ChatRequest(BaseModel):
+    thread_id: str
+    message: str
+
+
+@api.get("/health")
+def health() -> dict:
+    return {"status": "ok"}
+
+
+@api.post("/chat")
+def chat(req: ChatRequest) -> dict:
+    config = {"configurable": {"thread_id": req.thread_id}}
+    result = graph.invoke(
+        {"messages": [HumanMessage(content=req.message)]},
+        config,
+    )
+    return {
+        "thread_id": req.thread_id,
+        "reply": result["messages"][-1].content,
+    }
+```
+
+Two details matter for a hosted deployment:
+
+- **The checkpointer is the memory.** Every call with the same `thread_id` resumes the same conversation. State lives in Postgres, not in process memory, so redeploys and restarts lose nothing.
+- **`prepare_threshold: 0` and `autocommit: True`** are required by the Postgres checkpointer when used with a psycopg connection pool.
+
+## Deploy to Railway
+
+1. Push the code to a GitHub repository and create a new service from it in your project, or deploy with the [CLI](/cli) using `railway up`.
+2. Railway detects Python and builds the service with [Railpack](/builds).
+3. Set the start command in service settings:
+
+```bash
+uvicorn main:api --host 0.0.0.0 --port $PORT
+```
+
+4. Add variables on the agent service:
+
+```
+ANTHROPIC_API_KEY=sk-ant-...
+DATABASE_URL=${{Postgres.DATABASE_URL}}
+```
+
+The `${{Postgres.DATABASE_URL}}` syntax is a [reference variable](/variables#referencing-another-services-variable) that resolves to the Postgres service's connection string.
+
+5. Generate a public domain under the service's Settings tab. Railway provides a `*.up.railway.app` domain; you can attach a [custom domain](/networking/domains) later.
+
+## Configure a health check
+
+Set the healthcheck path to `/health` in the service settings. That path is what enables zero-downtime deploys: Railway checks it over HTTP, and the new deployment must respond before traffic switches over. See [healthchecks](/deployments/healthchecks).
+
+## Test it
+
+```bash
+curl -X POST https://your-service.up.railway.app/chat \
+  -H "Content-Type: application/json" \
+  -d '{"thread_id": "demo-1", "message": "How many words are in: the quick brown fox?"}'
+```
+
+Send a second request with the same `thread_id` and a follow-up question. The agent answers with full context from the earlier turn, loaded from the Postgres checkpoint.
+
+## Long-running agent turns
+
+Agent turns that chain several tool calls and model calls can take a while, and that runs up against Railway's request limits: HTTP requests can run up to 15 minutes as long as data keeps transferring, but connections close after 5 minutes of inactivity. Two ways to stay inside those limits:
+
+- **Stream the response.** LangGraph's `graph.stream()` yields events per step; forward them as server-sent events so bytes keep flowing during long turns.
+- **Move to async workers.** For turns that run longer than a request should, enqueue the job and poll for results. The [AI agent workers guide](/guides/ai-agent-workers) covers that architecture with Redis as the queue and Postgres for state, and it composes with LangGraph directly: the worker runs `graph.invoke()` instead of a hand-rolled agent loop.
+
+## Scaling and cost notes
+
+- Railway pricing is usage-based: RAM at $10/GB-month, CPU at $20/vCPU-month, egress at $0.05/GB. A LangGraph service is mostly I/O-bound (waiting on the LLM API), so small resource limits are enough.
+- If traffic is intermittent, enable [serverless](/deployments/serverless). The service sleeps after 10 minutes without outbound traffic and wakes on the next request. Note that an open database connection pool counts as outbound traffic and prevents sleep; if you want sleep behavior, connect per-request instead of holding a pool.
+- Postgres and the agent service talk over the connection string from the reference variable. For traffic between services in the same environment, [private networking](/networking/private-networking) at `<service>.railway.internal` avoids egress fees.
+
+## Redis as an alternative state store
+
+LangGraph also has a Redis checkpointer (`langgraph-checkpoint-redis`), and Railway's [Redis template](/databases/redis) deploys with zero configuration and exposes `REDIS_URL` if you want to swap it in. Postgres stays the better default for conversation state you want to keep and query; Redis fits short-lived threads, or cases where you already run Redis as a queue for workers.
+
+## Next steps
+
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers) - Move long agent turns off the request path with Redis-backed workers.
+- [Deploy a Multi-Agent System on Railway](/guides/multi-agent-system) - Split specialized agents into separate services.
+- [Estimate AI Agent Costs](/guides/estimate-ai-agent-costs) - Model compute and egress costs for agent workloads.
+- [Running Agents on Railway](/guides/running-agents-on-railway) - The broader picture of hosting autonomous agents.

--- a/content/guides/llm-gateway.md
+++ b/content/guides/llm-gateway.md
@@ -1,0 +1,188 @@
+---
+title: Build an LLM Gateway in TypeScript
+description: Build and deploy an LLM gateway on Railway that issues its own API keys, enforces per-key token budgets, and tracks spend across teams. One place to hold provider keys instead of scattering them across services.
+date: "2026-07-29"
+tags:
+  - llm
+  - gateway
+  - typescript
+  - ai
+topic: ai
+---
+
+An LLM gateway is a service that sits between your applications and LLM providers. Applications call the gateway with keys you issue; the gateway holds the real provider keys, enforces limits, records usage, and forwards the request. One service knows the provider credentials instead of every service knowing them.
+
+In this guide we build a small gateway in TypeScript and deploy it on Railway. It does three things: authenticates callers with gateway-issued keys, enforces a daily token budget per key, and tracks what each key spends.
+
+If you want an off-the-shelf gateway with model routing and failover across 100+ providers, deploy LiteLLM instead: see [Deploy an AI API Gateway](/guides/ai-api-proxy). Build your own when the logic you need is small and specific, and you would rather own 100 lines than operate someone else's admin UI.
+
+## Why a gateway
+
+Three problems show up as soon as more than one service calls an LLM:
+
+- **Key sprawl.** Every service holds a copy of the provider key. Rotating it means touching every service.
+- **No per-consumer limits.** The provider enforces one org-level rate limit. A runaway script in one team exhausts it for everyone.
+- **Unattributed spend.** The provider bill is one number. Which service, team, or feature spent it is invisible.
+
+A gateway solves all three with one move: callers get their own keys, and the provider key lives in exactly one place.
+
+## 1. Create the gateway
+
+```bash
+mkdir llm-gateway && cd llm-gateway
+npm init -y
+npm install express @anthropic-ai/sdk
+npm install -D typescript @types/node @types/express
+npx tsc --init
+```
+
+Update `tsconfig.json`:
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}
+```
+
+The gateway reads its key table from a `GATEWAY_KEYS` variable in the form `key:daily-token-limit`, comma-separated. That keeps the example self-contained; the upgrade path is a database table.
+
+```typescript
+// src/index.ts
+import Anthropic from "@anthropic-ai/sdk";
+import express from "express";
+
+const anthropic = new Anthropic(); // reads ANTHROPIC_API_KEY
+
+// GATEWAY_KEYS="team-a-key:200000,team-b-key:50000"
+const limits = new Map<string, number>(
+  (process.env.GATEWAY_KEYS ?? "").split(",").map((entry) => {
+    const [key, limit] = entry.split(":");
+    return [key, Number(limit)] as const;
+  })
+);
+
+type Usage = { tokens: number; requests: number; resetAt: number };
+const usage = new Map<string, Usage>();
+
+function nextUtcMidnight(): number {
+  const now = new Date();
+  return Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() + 1);
+}
+
+function usageFor(key: string): Usage {
+  const current = usage.get(key);
+  if (current && current.resetAt > Date.now()) return current;
+  const fresh = { tokens: 0, requests: 0, resetAt: nextUtcMidnight() };
+  usage.set(key, fresh);
+  return fresh;
+}
+
+const app = express();
+app.use(express.json());
+
+app.post("/v1/messages", async (req, res) => {
+  const key = req.headers.authorization?.replace("Bearer ", "") ?? "";
+  const limit = limits.get(key);
+  if (limit === undefined) {
+    res.status(401).json({ error: "unknown gateway key" });
+    return;
+  }
+
+  const spent = usageFor(key);
+  if (spent.tokens >= limit) {
+    res.status(429).json({
+      error: "daily token budget exhausted",
+      resets_at: new Date(spent.resetAt).toISOString(),
+    });
+    return;
+  }
+
+  const { model, max_tokens, messages, system } = req.body;
+  const response = await anthropic.messages.create({
+    model,
+    max_tokens,
+    messages,
+    ...(system ? { system } : {}),
+  });
+
+  spent.tokens += response.usage.input_tokens + response.usage.output_tokens;
+  spent.requests += 1;
+
+  res.json(response);
+});
+
+// Per-key spend, for dashboards and finger-pointing
+app.get("/v1/usage", (req, res) => {
+  const key = req.headers.authorization?.replace("Bearer ", "") ?? "";
+  const limit = limits.get(key);
+  if (limit === undefined) {
+    res.status(401).json({ error: "unknown gateway key" });
+    return;
+  }
+  const spent = usageFor(key);
+  res.json({ tokens_used: spent.tokens, limit, requests: spent.requests });
+});
+
+const port = Number(process.env.PORT) || 3000;
+app.listen(port, "0.0.0.0", () => {
+  console.log(`LLM gateway listening on port ${port}`);
+});
+```
+
+Add the scripts to `package.json`:
+
+```json
+{
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  }
+}
+```
+
+## 2. Deploy on Railway
+
+1. Push the repository to GitHub, create a new [project](/projects) on Railway, and deploy the repo. Railway detects Node and builds via [Railpack](/builds/railpack). Or skip the repository: `railway init` and `railway up` from the [CLI](/cli) deploy the directory directly.
+2. Set two [variables](/variables) on the service: `ANTHROPIC_API_KEY` (the one real provider key) and `GATEWAY_KEYS` (your issued keys and their daily budgets).
+3. If only your own services call the gateway, skip the public domain. Services in the same project environment reach it over [private networking](/networking/private-networking) at `http://llm-gateway.railway.internal:3000`. Generate a [public domain](/networking/domains) only if callers live outside the project.
+
+Callers switch from the provider to the gateway by changing the URL and the key:
+
+```bash
+curl http://llm-gateway.railway.internal:3000/v1/messages \
+  -H "Authorization: Bearer team-a-key" \
+  -H "Content-Type: application/json" \
+  -d '{"model": "claude-opus-4-8", "max_tokens": 256, "messages": [{"role": "user", "content": "Hello"}]}'
+```
+
+## What the in-memory version does not survive
+
+The `Map` resets on every deploy and is per-replica, which means budgets reset when you ship and split when you scale. That is acceptable while you evaluate the pattern and wrong after that. The upgrade is mechanical:
+
+- Move `usage` to [Postgres](/databases/postgresql) (one row per key per day, `UPDATE ... SET tokens = tokens + $1` on each request) or [Redis](/databases/redis) (`INCRBY` with a key that expires at midnight UTC).
+- Move `limits` to a table so issuing a key does not require a redeploy.
+
+The handlers do not change shape. Only the two lookups do.
+
+## What to add next
+
+- **Streaming passthrough.** Agents want tokens as they generate. Forward `anthropic.messages.stream` events through [Server-Sent Events](/guides/streaming-ai-responses); count tokens from the final message usage.
+- **A second provider.** Add an OpenAI branch keyed on the model prefix. The gateway's callers never change.
+- **Dollar budgets.** Multiply token usage by your per-model rates at write time and cap on spend instead of tokens.
+
+## Next steps
+
+- [Deploy an AI API Gateway](/guides/ai-api-proxy): the LiteLLM route, when you want routing and failover without writing code.
+- [Stream AI Responses with Server-Sent Events](/guides/streaming-ai-responses): the streaming layer for the gateway.
+- [Estimate the Cost of Running AI Agents](/guides/estimate-ai-agent-costs): what the workloads behind the gateway cost to run.
+- [Private Networking](/networking/private-networking): keeping the gateway off the public internet.

--- a/content/guides/load-test-k6.md
+++ b/content/guides/load-test-k6.md
@@ -1,0 +1,171 @@
+---
+title: Load Test an App Before Launch with k6
+description: Write a k6 load test, run it locally or as a Railway service, set realistic performance targets, and read Railway metrics while the test runs.
+date: "2026-07-29"
+tags:
+  - load-testing
+  - k6
+  - performance
+  - metrics
+topic: infrastructure
+---
+
+Before launch you want three numbers: the request rate your current resources can handle, the load where latency starts to degrade, and whether errors appear under pressure. A load test gets you all three by sending controlled, realistic traffic at your application and measuring how it responds.
+
+k6 does exactly that: it's an open source load testing tool from Grafana Labs. You write test scenarios in JavaScript, and k6 executes them with a configurable number of virtual users (VUs). It reports latency percentiles, throughput, and error rates, and it can fail the run automatically when results miss your thresholds.
+
+This guide puts k6 to work: write a script, choose realistic targets, run the test locally and then as a Railway service, and watch the target's metrics while it runs.
+
+## What you need
+
+- An application deployed on Railway with a public domain, for example `myapp.up.railway.app`. See [public networking](/networking/public-networking) if you have not exposed your service yet.
+- k6 installed locally, or a Railway project where you can add a second service to act as the test runner.
+
+One caveat before you start: if your target service has [serverless](/deployments/serverless) enabled, it sleeps after 10 minutes without outbound traffic and wakes on the next request. The first requests of your test will measure cold start time, not steady-state performance. Disable serverless on the target for the duration of the test, or accept that the opening seconds of the run are noise.
+
+## Install k6
+
+On macOS:
+
+```bash
+brew install k6
+```
+
+On Debian or Ubuntu:
+
+```bash
+sudo gpg -k
+sudo gpg --no-default-keyring --keyring /usr/share/keyrings/k6-archive-keyring.gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys C5AD17C747E3415A3642D57D77C6C491D6AC1D69
+echo "deb [signed-by=/usr/share/keyrings/k6-archive-keyring.gpg] https://dl.k6.io/deb stable main" | sudo tee /etc/apt/sources.list.d/k6.list
+sudo apt-get update && sudo apt-get install k6
+```
+
+With Docker, no install is needed:
+
+```bash
+docker run --rm -i grafana/k6 run - <script.js
+```
+
+## Write the test script
+
+Create a file named `script.js`. This script ramps traffic up in stages, checks every response, and defines pass/fail thresholds:
+
+```javascript
+import http from "k6/http";
+import { check, sleep } from "k6";
+
+const BASE_URL = __ENV.TARGET_URL || "https://myapp.up.railway.app";
+
+export const options = {
+  stages: [
+    { duration: "1m", target: 20 },  // ramp up to 20 VUs
+    { duration: "3m", target: 20 },  // hold steady
+    { duration: "1m", target: 50 },  // push past expected peak
+    { duration: "2m", target: 50 },  // hold at peak
+    { duration: "1m", target: 0 },   // ramp down
+  ],
+  thresholds: {
+    http_req_duration: ["p(95)<500"], // 95% of requests under 500ms
+    http_req_failed: ["rate<0.01"],   // less than 1% errors
+  },
+};
+
+export default function () {
+  const res = http.get(`${BASE_URL}/`);
+
+  check(res, {
+    "status is 200": (r) => r.status === 200,
+    "body is not empty": (r) => r.body && r.body.length > 0,
+  });
+
+  sleep(1); // each VU pauses 1s between requests, like a real user
+}
+```
+
+The `stages` array shapes the traffic. The `thresholds` block makes the run self-grading: if the p95 latency exceeds 500ms or more than 1% of requests fail, k6 exits with a non-zero code. That makes the same script usable as a CI gate later.
+
+Test the endpoints your users actually hit. A test that only requests `/` while your real traffic hammers `/api/search` tells you very little. Add more `http.get` or `http.post` calls to the default function to model a realistic session.
+
+## Set realistic targets
+
+Base your numbers on expected traffic:
+
+- **Virtual users.** Estimate peak concurrent users, not total signups. If you expect 10,000 daily visitors with sessions averaging 3 minutes, your steady concurrency is far lower than 10,000. A common starting point is peak hourly visitors multiplied by average session length in hours. Then test at that level and at 2 to 3 times it, so you know your headroom.
+- **Latency threshold.** 500ms at p95 is a reasonable default for API endpoints. Pages that render HTML or call downstream services may warrant more. Set the threshold at the point where the experience degrades for your users, not at the best number your app can achieve.
+- **Error rate.** Under 1% is a sane launch bar. Anything above that under expected load is a bug to fix, not a threshold to relax.
+- **Duration.** Run at least 5 to 10 minutes at steady load. Memory leaks and connection pool exhaustion often take minutes to surface. A 30-second burst hides them.
+
+Two Railway edge limits matter when you interpret results. Requests through Railway's edge can run up to 15 minutes as long as data keeps transferring, and are closed after 5 minutes of idle time. If your test includes long-running requests, keep them under those limits or the closures will show up as errors in k6 that are not application failures.
+
+## Run the test locally
+
+Point the script at your Railway domain and run it:
+
+```bash
+TARGET_URL=https://myapp.up.railway.app k6 run script.js
+```
+
+k6 prints a live progress bar and finishes with a summary:
+
+```
+http_req_duration..........: avg=182ms min=95ms med=160ms max=1.2s p(90)=290ms p(95)=340ms
+http_req_failed............: 0.12% ✓ 14 ✗ 11986
+http_reqs..................: 12000  33.2/s
+```
+
+Running locally is the simplest option and is fine for most pre-launch tests. Your local machine and home connection can usually generate a few hundred VUs before they become the bottleneck. If the k6 process pegs your CPU or your upload bandwidth saturates, the numbers stop being trustworthy, and it is time to run the test from a server instead.
+
+## Run k6 as a Railway service
+
+Running the test runner on Railway gives it a datacenter network connection and removes your laptop's CPU and upload bandwidth from the measurement. k6 is a Go binary, so deploy it from a Dockerfile based on the official image.
+
+Create a repository (or a directory to deploy with `railway up`) with two files, the `script.js` from above and this `Dockerfile`:
+
+```dockerfile
+FROM grafana/k6:latest
+COPY script.js /script.js
+ENTRYPOINT ["k6", "run", "/script.js"]
+```
+
+Then:
+
+1. Create a new service in your project and point it at the repository or directory. See [services](/services) for the creation flow.
+2. Set a `TARGET_URL` [variable](/variables) on the service, for example `https://myapp.up.railway.app`.
+3. Set the service's [restart policy](/deployments/restart-policy) to `Never`. k6 exits when the test completes; the default `On Failure` policy would rerun the test up to 10 times whenever thresholds fail, which is exactly when you do not want more load.
+4. Deploy. The test runs once, streams its output to the [deploy logs](/observability/logs), and exits.
+
+To run the test again, redeploy the service. Remove the service when you are done so it does not sit in the project.
+
+Two notes on this setup:
+
+- **Egress cost.** Traffic between the k6 service and your target's public domain leaves Railway's network and returns through the edge. Those responses count as outbound traffic at $0.05/GB. A typical API load test moves little data at that rate, but factor this in before load testing endpoints that return large payloads.
+- **Private networking option.** If the k6 service runs in the same project and environment as the target, it can hit the target over [private networking](/networking/private-networking) at `http://myapp.railway.internal:PORT`. This skips the public edge, so it measures your application alone rather than the full path your users take, and it avoids egress charges. Use the public URL for launch-readiness numbers and the private one for isolating application performance. Private networking is scoped per environment, so both services must be in the same environment.
+
+## Watch metrics during the test
+
+Open your target service in the Railway dashboard and go to the **Metrics** tab while the test runs. Railway charts four resource metrics, with deploy markers on the timeline:
+
+- **CPU.** If CPU pins at your limit while latency climbs, you are compute-bound. Raise the service's resource limits or add [replicas](/deployments/scaling).
+- **Memory.** Healthy services plateau. A line that climbs for the whole run and never flattens suggests a leak or an unbounded cache. In production, that service would eventually be killed for exceeding its memory limit.
+- **Network.** Confirms the test traffic is arriving, and shows whether response payloads are larger than you assumed.
+- **Disk.** Relevant if your app writes logs or temp files per request.
+
+If the service runs multiple replicas, switch the metrics view from **Sum** to **Replica** to confirm load is spreading evenly rather than hammering one instance. See [metrics](/observability/metrics) for details on both views.
+
+Railway does not collect application-level metrics such as request latency or error rates; those come from the k6 summary. For per-endpoint latency and error tracking inside your app, wire up an observability vendor as described in [Connect a Third-Party Observability Tool](/guides/third-party-observability).
+
+Also tail the target's [logs](/observability/logs) during the run. Timeouts, connection pool errors, and unhandled exceptions often appear in logs before they move the error-rate needle.
+
+## Act on the results
+
+- **Latency rises with load, CPU is high.** Scale vertically by raising resource limits, or horizontally with replicas. Railway distributes public traffic randomly across replicas in a region, so stateless services scale this way with no code changes.
+- **Errors spike at a specific VU count.** Look for a fixed-size bottleneck: database connection pool, worker count, or a downstream rate limit. The k6 output tells you the request rate where it broke; size the pool for it.
+- **Memory grows without bound.** Fix the leak before launch. Adding RAM only delays the crash.
+- **Everything passes with 3x headroom.** You are done. Configure a [healthcheck](/deployments/healthchecks) so future deploys are zero-downtime, and keep the k6 script in your repository to rerun before major releases.
+
+## Next steps
+
+- [Scaling Your Application](/guides/scaling-your-application)
+- [Connect a Third-Party Observability Tool](/guides/third-party-observability)
+- [Healthchecks](/deployments/healthchecks)
+- [Metrics](/observability/metrics)

--- a/content/guides/local-vs-remote-mcp-servers.md
+++ b/content/guides/local-vs-remote-mcp-servers.md
@@ -1,0 +1,72 @@
+---
+title: Choose Between Local and Remote MCP Servers
+description: When an MCP server should run locally over stdio and when it should be a remote Streamable HTTP service. Decision factors, what the 2026 spec changed, and how to deploy the remote kind on Railway.
+date: "2026-07-29"
+tags:
+  - mcp
+  - agents
+  - architecture
+  - ai
+topic: ai
+---
+
+An MCP server runs in one of two places. A local server is a subprocess the AI client launches on your machine and talks to over standard input/output. A remote server is an HTTP service the client calls over the network. Same protocol, same tools; different transport, and a different set of things that can go wrong.
+
+The decision is less about preference than about three questions: who uses the tools, what the tools touch, and who keeps the server running.
+
+## The short answer
+
+Run the server **locally** when the tools are for you: they touch your filesystem, your local git checkout, your machine's credentials, and nobody else needs them.
+
+Run the server **remotely** when the tools are for a team or a product: they wrap a shared database, an internal API, or your application's data, and more than one person (or agent) should reach them without installing anything.
+
+## How the two differ
+
+| | Local (stdio) | Remote (Streamable HTTP) |
+|---|---|---|
+| Runs | As a subprocess of the client | As a hosted HTTP service |
+| Reach | One machine, one user | Anyone with the URL and credentials |
+| Access to | Local files, local processes | Whatever the server is deployed next to |
+| Setup per user | Install the server and configure the command | Paste a URL |
+| Updates | Every user updates their copy | Deploy once, every client gets it |
+| Auth | Inherits your local permissions | Must be built: bearer tokens or OAuth |
+| Uptime | Alive while the client is | Your job, like any service |
+
+Two of those rows decide most cases. **Access**: a tool that reads local files has to run locally; a tool that queries your production database should not have production credentials distributed to every laptop. **Updates**: a team of ten running local copies of a shared tool is ten slightly different versions; a remote server is one.
+
+## What the 2026 spec changed
+
+The [2026-07-28 spec revision](https://blog.modelcontextprotocol.io/posts/2026-07-28/) simplified the remote side. Streamable HTTP is the single remote transport (the older HTTP+SSE transport is officially deprecated, with a year-long offramp), and the protocol is now stateless: no initialize handshake, no session header, so any replica of a remote server can serve any request. Remote servers scale like ordinary HTTP services now, which removed the main operational argument against them.
+
+stdio is unchanged. It remains the right transport for local tools and is not deprecated.
+
+## Running the local kind
+
+A local server is a command in your client's configuration. In Claude Code:
+
+```bash
+claude mcp add my-tools -- node /path/to/server/dist/index.js
+```
+
+The client launches the process, pipes JSON-RPC over stdio, and kills it when the session ends. There is nothing to host and nothing to secure beyond your own machine.
+
+## Running the remote kind
+
+A remote server is a deployment. Build it with the MCP SDK's Streamable HTTP transport, deploy it, and give clients the URL:
+
+```bash
+claude mcp add --transport http my-tools https://my-tools-production.up.railway.app/mcp
+```
+
+[Build and Deploy Your Own MCP Server](/guides/mcp-server) walks through the whole thing on Railway: the stateless transport setup, bearer-token auth, and the deploy. A remote server on Railway can also stay off the public internet entirely: agents and services in the same project environment reach it over [private networking](/networking/private-networking), which is the right shape when the "team" consuming the tools is other services, not people.
+
+## The migration path
+
+Most servers that matter end up remote, and the path is unexciting by design: the tool definitions do not change between transports. A server built with the MCP SDK swaps its stdio transport for the Streamable HTTP transport, gains an auth check, and everything a client saw before, it sees after. Starting local is not a decision you get locked into.
+
+## Next steps
+
+- [Build and Deploy Your Own MCP Server](/guides/mcp-server): the remote path, end to end.
+- [Railway MCP Server](/ai/mcp-server): Railway's own remote MCP server for managing infrastructure.
+- [Agent Skills](/ai/agent-skills): the other way to extend coding agents with Railway knowledge.
+- [Private Networking](/networking/private-networking): remote servers without public exposure.

--- a/content/guides/lock-down-production-project.md
+++ b/content/guides/lock-down-production-project.md
@@ -1,0 +1,140 @@
+---
+title: Lock Down a Production Railway Project
+description: Harden a production Railway project with Under Attack Mode, private networking, scoped API tokens, sealed variables, and workspace-level access controls.
+date: 2026-07-29
+tags:
+  - security
+  - networking
+  - variables
+  - tokens
+topic: infrastructure
+---
+
+Locking down a production project means reducing what an attacker can reach and what a leaked credential can do. On Railway that comes down to five controls: keep internal services off the public internet, turn on Under Attack Mode when traffic floods hit, scope every API token to the smallest surface that works, seal production secrets so they cannot be read back, and restrict who in your workspace can change production.
+
+None of these require new infrastructure. They are settings on the project you already have. This guide walks through each one in the order you should apply them.
+
+## Remove public exposure from internal services
+
+Every service with a public domain is attack surface. Databases, workers, queues, and internal APIs rarely need one.
+
+Services in the same project and environment can reach each other over [private networking](/networking/private-networking) without public exposure, over encrypted WireGuard tunnels that never leave Railway's network. Each one gets an internal DNS name:
+
+```
+<service-name>.railway.internal
+```
+
+So a service named `api` is reachable from its siblings at `http://api.railway.internal:PORT`, where `PORT` is the port your app listens on. Private networking is isolated per environment: services in `production` cannot reach services in `staging`, and services in other projects cannot reach yours at all.
+
+To lock down an internal service:
+
+1. Open the service and go to **Settings**.
+2. Under **Networking**, delete any public domain the service does not need.
+3. Update callers to use the `<service-name>.railway.internal` hostname instead of the public URL.
+
+Use [reference variables](/variables#reference-variables) so the internal URL never gets hardcoded:
+
+```
+BACKEND_URL=http://${{api.RAILWAY_PRIVATE_DOMAIN}}:8080
+```
+
+After this step, the only services with public domains should be the ones end users hit: typically a frontend and a public API.
+
+## Turn on Under Attack Mode during a DDoS
+
+Railway's [web application firewall (WAF)](/networking/waf) runs at the edge, in front of your service. Its main control is Under Attack Mode, an on-demand defense against DDoS attacks and bot floods.
+
+While Under Attack Mode is on, every new visitor sees a browser check before any request reaches your service. Real browsers pass it once and continue normally. Non-browser traffic, including the bots and scripts driving the attack, is blocked at the edge. That's why it fits active incidents, not always-on protection.
+
+Enable it from the dashboard:
+
+1. Open the service under attack and go to its **Settings**.
+2. In the **Edge** section, find **Under Attack Mode**.
+3. Pick a duration (1, 3, 12, or 24 hours, or until you turn it off), then click **Activate**.
+
+It takes effect across Railway's global network within about 20 seconds. Or use the CLI:
+
+```bash
+railway waf under-attack enable --service web --duration 1h
+railway waf under-attack status --service web
+railway waf under-attack disable --service web
+```
+
+Two details matter for real deployments:
+
+- **Protecting a site and its API together.** Clearance from the browser check is scoped to your whole domain. Enable Under Attack Mode on the site first, then on the API. Once a visitor passes the check on `example.com`, requests to `api.example.com` also pass without a second check. This only works within one root domain; `*.up.railway.app` subdomains are isolated from each other.
+- **API-only domains.** The check is only shown to browser navigations. A domain that serves only an API will have all of its traffic blocked while Under Attack Mode is on, so do not enable it on a standalone API that non-browser clients call directly.
+
+## Scope API tokens to the smallest surface
+
+A leaked token is only as dangerous as its scope. Railway has three [token types](/integrations/api#creating-a-token), and production automation should almost never use the broadest one.
+
+| Token type | Scope | Use for |
+| ---------- | ----- | ------- |
+| Account token | Everything you can access, across all workspaces | Personal scripts on your own machine only |
+| Workspace token | One workspace | Team CI/CD, shared automation |
+| Project token | One environment in one project | Deployments, service-specific automation |
+
+For a production deploy pipeline, use a project token. It is scoped to a single environment within a single project, so a compromise of your CI system exposes one environment, not your whole account. Create it from the tokens page in your project settings, then authenticate with the `Project-Access-Token` header:
+
+```bash
+curl --request POST \
+  --url https://backboard.railway.com/graphql/v2 \
+  --header 'Project-Access-Token: <PROJECT_TOKEN>' \
+  --header 'Content-Type: application/json' \
+  --data '{"query":"query { projectToken { projectId environmentId } }"}'
+```
+
+Workspace tokens are created from the [tokens page](https://railway.com/account/tokens) in your account settings by selecting a workspace. They can access all of that workspace's resources but nothing personal and nothing in other workspaces. The third option, an account token (created with "No workspace" selected), suits local, personal use only. Never put one in shared CI.
+
+Store whichever token you use as a [sealed variable](#seal-production-secrets) or in your CI provider's secret store, never in the repository.
+
+## Seal production secrets
+
+[Sealed variables](/variables#sealed-variables) make a secret write-only. Railway still provides the value to builds and deployments, but it is never visible in the UI and cannot be retrieved through the API. If a dashboard session or an API token leaks, sealed values stay unreadable.
+
+To seal an existing variable, open the 3-dot menu next to it in the service's **Variables** tab and choose **Seal**.
+
+Sealing is permanent and has constraints to plan around:
+
+- Sealed variables cannot be un-sealed. You can edit the value from the 3-dot menu, but you can never read the current value back.
+- The values are not provided by `railway variables` or `railway run` in the CLI.
+- They are not copied into PR environments, duplicated environments, or duplicated services, and they are not synced to external integrations.
+
+That last point is a feature for production: a preview environment spun up from a pull request never receives your sealed production credentials. Give preview environments their own non-sealed test credentials for anything they need to boot.
+
+When rotating, verify the new credential works before revoking the old one, because you cannot read a sealed value back. See [rotate credentials without downtime](/guides/rotate-credentials-zero-downtime) for the full rotation flow.
+
+## Restrict who can change production
+
+Infrastructure settings only help if account access is locked down too.
+
+**Enforce 2FA for the workspace.** Workspace admins on the Pro plan and above can require every member to have two-factor authentication enabled before accessing the workspace. Toggle **Require 2FA** in your workspace's People settings. Members without 2FA are prompted to set it up before they can touch any workspace resource. See [2FA enforcement](/access/two-factor-enforcement).
+
+**Use the least-privileged project role.** [Project members](/projects/project-members) have three roles: Owner (full administration of the project), Editor (can deploy, change project settings, and add Editor or Viewer members, but cannot do destructive actions like deleting services or the project), and Viewer (read only, cannot deploy and cannot see environment variables). Default teammates to Viewer, move them to Editor when they need to deploy, and reserve Owner for the people who administer the project.
+
+**Gate deploys from unlinked GitHub users.** If someone pushes to a connected branch without a linked Railway account, Railway does not deploy the push automatically. It creates a [deployment approval](/services#approving-a-deployment) on the service, and a project member must click **Approve** before the commit deploys.
+
+**Wait for CI before deploying.** Enable [Wait for CI](/deployments/github-autodeploys#wait-for-ci) so Railway waits for your GitHub workflows to pass before starting a deployment. A failing test suite then blocks the deploy instead of racing it.
+
+## Lockdown checklist
+
+Run through this list on any project serving production traffic:
+
+- Public domains removed from every service except user-facing ones
+- Internal traffic moved to `<service-name>.railway.internal` over [private networking](/networking/private-networking)
+- Under Attack Mode tested once so you know the flow before an incident
+- CI uses a project token, not an account token
+- Production credentials sealed, with separate test credentials for preview environments
+- 2FA enforcement on for the workspace
+- Members hold the least-privileged role that lets them do their job
+- Wait for CI enabled on the production service
+
+For hardening beyond security, including health checks, restart policies, and observability, work through the [production readiness checklist](/overview/production-readiness-checklist).
+
+## Next steps
+
+- [Manage secrets on Railway](/guides/managing-secrets-on-railway)
+- [Rotate credentials without downtime](/guides/rotate-credentials-zero-downtime)
+- [Private networking](/networking/private-networking)
+- [WAF and Under Attack Mode](/networking/waf)

--- a/content/guides/mcp-server.md
+++ b/content/guides/mcp-server.md
@@ -1,7 +1,7 @@
 ---
 title: Build and Deploy Your Own MCP Server
-description: Build a Model Context Protocol server in TypeScript and deploy it on Railway. Expose custom tools and resources that AI assistants like Claude and Cursor can call over the network.
-date: "2026-04-14"
+description: Build a remote MCP server in TypeScript with Streamable HTTP transport and deploy it on Railway. Expose your app's data as tools that AI assistants like Claude and Cursor can call over the network.
+date: "2026-07-29"
 tags:
   - mcp
   - typescript
@@ -9,38 +9,44 @@ tags:
 topic: ai
 ---
 
-The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI assistants to external tools and data sources. An MCP server exposes tools (functions the AI can call) and resources (data the AI can read) over a standardized protocol.
+The [Model Context Protocol](https://modelcontextprotocol.io) (MCP) is an open standard for connecting AI assistants to external tools and data. An MCP server exposes tools the assistant can call and resources it can read.
 
-This guide covers building an MCP server in TypeScript and deploying it on Railway so AI assistants like Claude Desktop and Cursor can connect to it over the network.
+In this guide we build a remote MCP server in TypeScript and deploy it on Railway, so assistants like Claude and Cursor can call it over the network.
 
-Railway already has an [MCP server for managing Railway infrastructure](/ai/mcp-server). This guide is different: it covers building and hosting your own MCP server for your own tools and data.
+Railway already has an [MCP server for managing Railway infrastructure](/ai/mcp-server). This guide is not about that one. It is about building and hosting your own, for your own tools and data.
 
 ## How MCP transport works
 
-MCP supports two transport protocols:
+MCP has two transport protocols:
 
-- **stdio**: The client launches the server as a local subprocess. Communication happens over standard input/output. This only works when the server runs on the same machine as the client.
-- **SSE (Server-Sent Events)**: The server runs as an HTTP service. The client connects over the network. This is the transport you need for a hosted MCP server.
+- **stdio**: The client launches the server as a local subprocess and talks to it over standard input/output. This only works when the server runs on the same machine as the client.
+- **Streamable HTTP**: The server runs as an HTTP service with a single `/mcp` endpoint. The client connects over the network. This is the transport for a hosted server.
 
-Since Railway hosts the server remotely, you must use SSE transport.
+Streamable HTTP replaced the older HTTP+SSE transport. The [2026-07-28 spec revision](https://blog.modelcontextprotocol.io/posts/2026-07-28/) made the deprecation official, with a year-long offramp. Guides and client configs built around an `/sse` endpoint target the legacy transport. New servers should use Streamable HTTP.
+
+The same revision made MCP a stateless request/response protocol. The `initialize` handshake and `Mcp-Session-Id` header are retired; each request carries the protocol version and client identity in its own metadata. This matters for hosting. Any replica can serve any request, so the service scales horizontally without sticky sessions. Session tracking still exists in the SDK, but only as a compatibility mode for clients on older spec revisions.
 
 ## Prerequisites
 
-- A Railway account
-- Node.js 18+ for local development
-- An AI client that supports remote MCP servers (Claude Desktop, Cursor, etc.)
+- Node.js 20 or later
+- A [Railway account](https://railway.com)
+- An AI assistant that supports remote MCP servers (Claude Code, Cursor, or Claude via Connectors)
 
 ## 1. Create the MCP server
 
-Initialize a project and install the MCP SDK:
+Most MCP servers exist to expose an application's data and actions: query the database, search the docs, create a record. We will build the smallest version of that: a to-do list with tools to create, list, and complete tasks. The shape extends to whatever your application stores.
+
+Initialize a project and install the MCP SDK packages:
 
 ```bash
-mkdir my-mcp-server && cd my-mcp-server
+mkdir todo-mcp-server && cd todo-mcp-server
 npm init -y
-npm install @modelcontextprotocol/sdk express
+npm install @modelcontextprotocol/server @modelcontextprotocol/express @modelcontextprotocol/node express zod
 npm install -D typescript @types/node @types/express
 npx tsc --init
 ```
+
+The SDK splits into a core server package plus thin adapters: `@modelcontextprotocol/express` wires MCP into an Express app, and `@modelcontextprotocol/node` provides the Streamable HTTP transport for Node's request and response types.
 
 Update `tsconfig.json` with the following settings:
 
@@ -60,67 +66,96 @@ Update `tsconfig.json` with the following settings:
 }
 ```
 
-Create the server with a sample tool:
+Create the server with the to-do tools:
 
 ```typescript
 // src/index.ts
-import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import express from "express";
+import { createMcpExpressApp } from "@modelcontextprotocol/express";
+import { NodeStreamableHTTPServerTransport } from "@modelcontextprotocol/node";
+import { McpServer } from "@modelcontextprotocol/server";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
 
-const app = express();
+type Todo = { id: string; title: string; done: boolean };
+const todos = new Map<string, Todo>();
 
-// Store transports by session ID so the POST handler can route messages
-const transports = new Map<string, SSEServerTransport>();
+const server = new McpServer({
+  name: "todo-mcp-server",
+  version: "1.0.0",
+});
 
-function createServer() {
-  const server = new McpServer({
-    name: "my-mcp-server",
-    version: "1.0.0",
-  });
-
-  // Define a tool
-  server.tool("get_weather", "Get the current weather for a city", {
-    city: { type: "string", description: "City name" },
-  }, async ({ city }) => {
-    // Replace with a real API call
+server.registerTool(
+  "create_todo",
+  {
+    description: "Add a task to the to-do list",
+    inputSchema: z.object({
+      title: z.string().describe("What needs doing"),
+    }),
+  },
+  async ({ title }) => {
+    const todo: Todo = { id: randomUUID(), title, done: false };
+    todos.set(todo.id, todo);
     return {
-      content: [
-        { type: "text", text: `Weather in ${city}: 72°F, sunny` },
-      ],
+      content: [{ type: "text", text: `Created ${todo.id}: ${title}` }],
     };
-  });
-
-  return server;
-}
-
-app.get("/sse", async (req, res) => {
-  const transport = new SSEServerTransport("/messages", res);
-  transports.set(transport.sessionId, transport);
-
-  res.on("close", () => {
-    transports.delete(transport.sessionId);
-  });
-
-  const server = createServer();
-  await server.connect(transport);
-});
-
-app.post("/messages", express.json(), async (req, res) => {
-  const sessionId = req.query.sessionId as string;
-  const transport = transports.get(sessionId);
-
-  if (!transport) {
-    res.status(400).send("Unknown session");
-    return;
   }
+);
 
-  await transport.handlePostMessage(req, res);
+server.registerTool(
+  "list_todos",
+  {
+    description: "List every task and its status",
+    inputSchema: z.object({}),
+  },
+  async () => ({
+    content: [
+      { type: "text", text: JSON.stringify([...todos.values()], null, 2) },
+    ],
+  })
+);
+
+server.registerTool(
+  "complete_todo",
+  {
+    description: "Mark a task as done",
+    inputSchema: z.object({
+      id: z.string().describe("The id returned by create_todo"),
+    }),
+  },
+  async ({ id }) => {
+    const todo = todos.get(id);
+    if (!todo) {
+      return {
+        content: [{ type: "text", text: `No task with id ${id}` }],
+        isError: true,
+      };
+    }
+    todo.done = true;
+    return {
+      content: [{ type: "text", text: `Done: ${todo.title}` }],
+    };
+  }
+);
+
+// host: "0.0.0.0" binds for deployment. The default binds 127.0.0.1 and
+// enables localhost-only DNS rebinding protection, which rejects requests
+// arriving through a public domain.
+const app = createMcpExpressApp({ host: "0.0.0.0" });
+
+app.post("/mcp", async (req, res) => {
+  // A fresh transport per request: stateless, per the 2026-07-28 spec.
+  // sessionIdGenerator: undefined opts out of the legacy session mode
+  // kept for clients on older spec revisions.
+  const transport = new NodeStreamableHTTPServerTransport({
+    sessionIdGenerator: undefined,
+  });
+  await server.connect(transport);
+  await transport.handleRequest(req, res, req.body);
 });
 
-const port = process.env.PORT || 3000;
+const port = Number(process.env.PORT) || 3000;
 app.listen(port, "0.0.0.0", () => {
-  console.log(`MCP server running on port ${port}`);
+  console.log(`MCP server listening on port ${port}`);
 });
 ```
 
@@ -141,7 +176,13 @@ Add a build script to `package.json`:
 npm run build && npm start
 ```
 
-The server starts on port 3000. You can test the SSE endpoint at `http://localhost:3000/sse`.
+The server starts on port 3000 with its endpoint at `http://localhost:3000/mcp`. Test it with the MCP Inspector, an interactive client for calling tools:
+
+```bash
+npx @modelcontextprotocol/inspector
+```
+
+Enter `http://localhost:3000/mcp` as the URL with Streamable HTTP transport and connect. Call `create_todo` with a title, then `list_todos` to see the task, then `complete_todo` with its id.
 
 ## 3. Deploy to Railway
 
@@ -149,68 +190,72 @@ The server starts on port 3000. You can test the SSE endpoint at `http://localho
 2. Create a new [project](/projects) on Railway.
 3. Click **+ New > GitHub Repo** and select your repository.
 4. Railway detects the Node.js project and builds it via [Railpack](/builds/railpack).
-5. Generate a [public domain](/networking/public-networking#railway-provided-domain) under **Settings > Networking**.
+5. Generate a [public domain](/networking/domains) under **Settings > Networking**.
 
-Your MCP server is now reachable at `https://your-server-production-xxxx.up.railway.app/sse`.
+The [Railway CLI](/cli) skips the repository entirely: `railway init` creates the project, and `railway up` deploys the directory you are standing in.
+
+Your MCP server is now reachable at `https://your-server-production-xxxx.up.railway.app/mcp`.
+
+Railway injects the `PORT` [environment variable](/variables) at runtime, which the server code above already reads.
 
 ## 4. Connect from an AI assistant
 
-### Claude Desktop
+### Claude Code
 
-Add to your Claude Desktop configuration (`claude_desktop_config.json`):
-
-```json
-{
-  "mcpServers": {
-    "my-server": {
-      "url": "https://your-server-production-xxxx.up.railway.app/sse"
-    }
-  }
-}
+```bash
+claude mcp add --transport http my-server https://your-server-production-xxxx.up.railway.app/mcp
 ```
 
 ### Cursor
 
-Add to your Cursor MCP settings:
+Add to `.cursor/mcp.json`:
 
 ```json
 {
   "mcpServers": {
     "my-server": {
-      "url": "https://your-server-production-xxxx.up.railway.app/sse"
+      "url": "https://your-server-production-xxxx.up.railway.app/mcp"
     }
   }
 }
 ```
 
-Restart the client after updating the configuration. Your tools will appear in the AI assistant's tool list.
+### Claude (web and desktop)
+
+Add the server URL as a custom connector under **Settings > Connectors**.
+
+Restart the client after updating the configuration. The three tools appear in the assistant's tool list. Ask it to add a task and list what's open; it will call the tools itself.
 
 ## Adding authentication
 
-A public MCP server is accessible to anyone with the URL. To restrict access, add a simple bearer token check:
+A public MCP server is accessible to anyone with the URL. To restrict access, check a bearer token before the MCP handler runs. Express runs middleware in registration order, so this `app.use` must come before the `app.post("/mcp", ...)` route:
 
 ```typescript
-app.get("/sse", async (req, res) => {
+app.use("/mcp", (req, res, next) => {
   const token = req.headers.authorization?.replace("Bearer ", "");
   if (token !== process.env.MCP_AUTH_TOKEN) {
-    return res.status(401).send("Unauthorized");
+    res.status(401).send("Unauthorized");
+    return;
   }
-  const transport = new SSEServerTransport("/messages", res);
-  transports.set(transport.sessionId, transport);
-  res.on("close", () => transports.delete(transport.sessionId));
-  const server = createServer();
-  await server.connect(transport);
+  next();
 });
 ```
 
-Set `MCP_AUTH_TOKEN` as an [environment variable](/variables) in your Railway service.
+Set `MCP_AUTH_TOKEN` as an [environment variable](/variables) in your Railway service, and configure the same token in clients that support custom headers.
+
+For full OAuth, MCP defines an [authorization spec](https://modelcontextprotocol.io/specification/draft/basic/authorization) that treats your server as an OAuth resource server. The `@modelcontextprotocol/express` package ships `requireBearerAuth` and `mcpAuthMetadataRouter` helpers for validating tokens and serving the protected resource metadata that spec-compliant clients discover.
+
+## Keeping the server private
+
+If the only consumers of your MCP server are agents and services in the same project environment, skip the public domain entirely. Services in an environment reach each other over [private networking](/networking/private-networking) at `http://<service-name>.railway.internal:<port>/mcp`, so the server never accepts traffic from the public internet.
 
 ## Adding a database
 
-If your tools need persistent state, add [Postgres](/databases/postgresql) to your project and access it via the `DATABASE_URL` [reference variable](/variables#referencing-another-services-variable). For example, a tool that queries a knowledge base or stores user preferences.
+The in-memory `Map` keeps the example self-contained, but it is per-replica and wiped on every redeploy. The protocol will not carry state for you either; requests are stateless. State lives behind the server, in a database. Add [Postgres](/databases/postgresql) to your project, connect via the `DATABASE_URL` [reference variable](/variables#referencing-another-services-variable), and swap the `Map` operations for queries against a `todos` table. The tool definitions do not change. Only the handler bodies do.
 
 ## Next steps
 
+- [Choose Between Local and Remote MCP Servers](/guides/local-vs-remote-mcp-servers): when a server should be remote at all.
 - [Railway MCP Server](/ai/mcp-server): Railway's own MCP server for managing infrastructure.
 - [Agent Skills](/ai/agent-skills): Open format for extending AI coding assistants with Railway knowledge.
 - [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): For tools that trigger long-running tasks.

--- a/content/guides/migrate-database-minimal-downtime.md
+++ b/content/guides/migrate-database-minimal-downtime.md
@@ -1,0 +1,217 @@
+---
+title: Migrate a Production Database into Railway with Minimal Downtime
+description: Move a production PostgreSQL database into Railway using dump and restore or logical replication, with a cutover checklist that keeps downtime to seconds.
+date: "2026-07-29"
+tags:
+  - postgresql
+  - migration
+  - databases
+  - infrastructure
+topic: infrastructure
+---
+
+Moving a production PostgreSQL database into Railway and pointing the application at it comes down to one choice: how much downtime you can tolerate. A dump and restore takes the database offline for as long as the copy runs, while logical replication streams changes continuously and reduces the cutover to seconds.
+
+This guide covers both strategies, when to use each, and how to cut over safely. The same decision framework applies to MySQL and MongoDB, though the tooling differs.
+
+## Choose a migration strategy
+
+| | Dump and restore | Logical replication |
+|---|---|---|
+| Downtime | Full duration of dump + restore | Seconds at cutover |
+| Complexity | Low | Moderate |
+| Source requirements | Network access only | `wal_level = logical`, replication privileges |
+| Best for | Databases up to a few GB, or apps that tolerate a maintenance window | Large databases, apps that cannot afford a window |
+
+Rule of thumb: time a dump and restore against a staging copy first. If the total is inside an acceptable maintenance window, use it. It is simpler and has fewer failure modes. Reach for logical replication only when the window is not acceptable.
+
+## Provision the target database on Railway
+
+Add a PostgreSQL service to your project from the Project Canvas with the `+ New` button, or deploy the [PostgreSQL template](https://railway.com/deploy/postgres). Railway provisions the database with credentials exposed as service variables: `PGHOST`, `PGPORT`, `PGUSER`, `PGPASSWORD`, `PGDATABASE`, and a combined `DATABASE_URL`.
+
+Match or exceed the source's PostgreSQL major version. Logical replication works across major versions, but restoring a dump into an older major version does not.
+
+## Get an external connection string
+
+Your source database lives outside Railway, so the migration traffic needs a public route into the new database. That route comes from a [TCP proxy](/networking/tcp-proxy), which Railway's PostgreSQL template ships with enabled by default. It gives you a public endpoint like `shuttle.proxy.rlwy.net:15140` that forwards raw TCP to the database's internal port.
+
+Find the proxy domain and port in the database service's Settings under Networking, or read the public `DATABASE_PUBLIC_URL` variable on the service. Your external connection string looks like:
+
+```txt
+postgresql://postgres:<PGPASSWORD>@shuttle.proxy.rlwy.net:15140/railway
+```
+
+Two things about the proxy:
+
+- Traffic through it counts as network egress when data leaves Railway, billed at [$0.05 per GB](/pricing/plans).
+- It is for external access only. Once your application also runs on Railway, connect over [private networking](/networking/private-networking) at `<service>.railway.internal` instead. Private traffic stays inside Railway's network and is not billed as egress.
+
+Verify connectivity from the machine that will run the migration:
+
+```bash
+psql "postgresql://postgres:<PGPASSWORD>@shuttle.proxy.rlwy.net:15140/railway" -c "SELECT version();"
+```
+
+You can also open a shell directly with the Railway CLI using [`railway connect`](/cli/connect), which is useful for the verification queries later in this guide.
+
+## Strategy 1: dump and restore
+
+This strategy takes a consistent snapshot of the source and loads it into Railway. Writes to the source during the copy are lost, so stop the application (or put it in read-only mode) before dumping.
+
+### 1. Dump the source
+
+```bash
+pg_dump -Fc --no-acl --no-owner \
+  -h <source-host> -p <source-port> \
+  -U <source-user> -d <source-db> \
+  -f backup.dump
+```
+
+The `-Fc` flag writes PostgreSQL's compressed custom format, which restores faster than plain SQL and lets `pg_restore` parallelize. `--no-acl --no-owner` strips role-specific grants that will not exist on the target.
+
+### 2. Restore into Railway
+
+```bash
+pg_restore --no-acl --no-owner --clean --if-exists \
+  -h shuttle.proxy.rlwy.net -p 15140 \
+  -U postgres -d railway \
+  -j 4 \
+  backup.dump
+```
+
+`-j 4` restores four tables in parallel. `--clean --if-exists` drops existing objects first, which makes the command safe to re-run.
+
+### 3. Verify and cut over
+
+Run the checks in the [verification section](#verify-the-migration) below, update your application's `DATABASE_URL`, and bring the application back up. Total downtime is the dump plus the restore plus the deploy.
+
+## Strategy 2: logical replication
+
+Logical replication keeps the source live while PostgreSQL streams every committed change to the Railway database, which acts as the subscriber and opens an outbound connection to the source. The initial table sync happens in the background; once the subscriber catches up, cutover is a config change.
+
+That connection means the source must be reachable from Railway and configured to publish changes, though the Railway side needs no replication-specific configuration.
+
+### 1. Prepare the source
+
+On the source database, enable logical WAL and confirm slot capacity:
+
+```sql
+ALTER SYSTEM SET wal_level = 'logical';
+-- Restart the source PostgreSQL server for this to take effect.
+
+SHOW max_replication_slots;   -- needs at least 1 free
+SHOW max_wal_senders;         -- needs at least 1 free
+```
+
+Create a replication user and a publication covering the tables you want to move:
+
+```sql
+CREATE ROLE railway_migration WITH LOGIN REPLICATION PASSWORD 'a-strong-password';
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO railway_migration;
+
+CREATE PUBLICATION railway_migration_pub FOR ALL TABLES;
+```
+
+If the source is itself a Railway PostgreSQL service (for example, migrating between projects or regions), you can set `wal_level` the same way. Railway's Postgres supports `ALTER SYSTEM`; run the statement, then restart the deployment from the service's 3-dot menu.
+
+### 2. Copy the schema
+
+Logical replication moves rows, not DDL. Copy the schema first:
+
+```bash
+pg_dump --schema-only --no-acl --no-owner \
+  -h <source-host> -p <source-port> \
+  -U <source-user> -d <source-db> \
+  | psql "postgresql://postgres:<PGPASSWORD>@shuttle.proxy.rlwy.net:15140/railway"
+```
+
+### 3. Create the subscription on Railway
+
+Connect to the Railway database and subscribe to the source:
+
+```sql
+CREATE SUBSCRIPTION railway_migration_sub
+  CONNECTION 'host=<source-host> port=<source-port> dbname=<source-db> user=railway_migration password=a-strong-password'
+  PUBLICATION railway_migration_pub;
+```
+
+PostgreSQL now copies every table's existing rows, then switches to streaming live changes.
+
+### 4. Monitor until caught up
+
+On the Railway database, watch the sync state:
+
+```sql
+-- 'r' means a table is fully synced and streaming
+SELECT srrelid::regclass AS table, srsubstate FROM pg_subscription_rel;
+```
+
+On the source, check replication lag:
+
+```sql
+SELECT slot_name,
+       pg_size_pretty(pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn)) AS lag
+FROM pg_replication_slots;
+```
+
+Wait until every table reports state `r` and lag stays near zero under normal traffic.
+
+### 5. Cut over
+
+1. Stop writes to the source: put the application in maintenance mode or scale writers to zero.
+2. Wait for lag to reach zero. This usually takes seconds.
+3. Resync sequences. Logical replication does not carry sequence values, so serial and identity columns would collide on the first insert. Run this on the Railway database:
+
+```sql
+SELECT setval(
+  pg_get_serial_sequence(quote_ident(schemaname) || '.' || quote_ident(tablename), columnname),
+  (SELECT COALESCE(MAX(id), 1) FROM your_table)
+) FROM (VALUES ('public', 'your_table', 'id')) AS t(schemaname, tablename, columnname);
+```
+
+Repeat for each table with a sequence, or generate the statements from `information_schema.columns`.
+
+4. Point the application at Railway by updating `DATABASE_URL`, then bring it back up.
+5. Drop the subscription once traffic is confirmed healthy:
+
+```sql
+DROP SUBSCRIPTION railway_migration_sub;
+```
+
+Dropping the subscription also removes the replication slot on the source. Do not leave the slot behind: an orphaned slot forces the source to retain WAL and will eventually fill its disk.
+
+## Verify the migration
+
+Run these checks on both databases before and after cutover:
+
+```sql
+-- Row counts per table
+SELECT relname, n_live_tup
+FROM pg_stat_user_tables
+ORDER BY relname;
+
+-- Database size
+SELECT pg_size_pretty(pg_database_size(current_database()));
+```
+
+For stronger guarantees, checksum a few critical tables:
+
+```sql
+SELECT md5(string_agg(t::text, '' ORDER BY id)) FROM your_table t;
+```
+
+Then confirm the application works end to end against the new database before you decommission the source.
+
+## After the migration
+
+- **Switch to private networking.** If your application runs in the same Railway environment, connect via `postgres.railway.internal` (the `DATABASE_URL` reference variable does this for you). Keep the TCP proxy only if external clients still need access.
+- **Enable backups.** Configure scheduled [volume backups](/volumes/backups) on the database service.
+- **Consider PITR.** [Point-in-Time Recovery](/volumes/point-in-time-recovery) archives every WAL segment to a storage bucket, letting you restore to any timestamp in the retention window.
+- **Keep the source for a rollback window.** Retain the old database in read-only mode for a few days. If something surfaces, you can replicate in the reverse direction rather than restoring from backup.
+
+## Next steps
+
+- [PostgreSQL on Railway](/databases/postgresql)
+- [TCP Proxy](/networking/tcp-proxy)
+- [Volume backups](/volumes/backups)
+- [Private networking](/networking/private-networking)

--- a/content/guides/multi-region-api-failover.md
+++ b/content/guides/multi-region-api-failover.md
@@ -1,0 +1,209 @@
+---
+title: Serve a Multi-Region API with Failover
+description: Run one API service across multiple Railway regions with replicas, nearest-region routing, and automatic replica restarts. Covers routing behavior, health checks, and what failover Railway gives you.
+date: "2026-07-29"
+tags:
+  - multi-region
+  - replicas
+  - scaling
+  - architecture
+topic: architecture
+---
+
+A multi-region API is a single service that runs identical copies (replicas) in more than one geographic region behind one domain. Users are routed to the nearest region, which cuts latency. If a replica crashes, the remaining replicas absorb the load while Railway restarts the failed one, so the service keeps serving traffic.
+
+On Railway you do not run separate services per region or manage a load balancer; you assign replica counts to regions on one service, and Railway handles routing. This guide deploys a small Node.js API to three Railway regions, configures replicas as code, sets up health-checked zero-downtime deploys, and verifies which region served a request.
+
+## How Railway routes multi-region traffic
+
+Railway's edge network uses anycast routing. Every request enters at the edge point of presence (POP) nearest to the user, regardless of where your service is deployed. From there:
+
+- If your service runs in multiple regions, the request is forwarded to the nearest region where it is deployed.
+- Within a region, requests are distributed randomly across the replicas in that region.
+- Sticky sessions are not supported. Any replica can receive any request.
+
+Railway offers four deployment regions:
+
+| Name | Location | Region identifier |
+| --- | --- | --- |
+| US West Metal | California, USA | `us-west2` |
+| US East Metal | Virginia, USA | `us-east4-eqdc4a` |
+| EU West Metal | Amsterdam, Netherlands | `europe-west4-drams3a` |
+| Southeast Asia Metal | Singapore | `asia-southeast1-eqsg3a` |
+
+All regions sit behind the same domain. Adding or removing regions requires no DNS changes.
+
+## What failover you get
+
+"Failover" covers several layers. Railway provides some automatically, and your architecture must provide the rest.
+
+**Replica-level failover: automatic.** The default restart policy is `On Failure`. If a replica exits with a non-zero code, Railway restarts only that replica while the other replicas continue handling the workload. With two or more replicas per region, a single crash does not drop traffic.
+
+**Deploy-time failover: automatic with a health check.** When a healthcheck path is configured, Railway routes traffic to a new deployment only after the endpoint returns HTTP 200, so a broken build does not replace a working one. Health checks are HTTP only, and Railway calls the endpoint at deploy time, not continuously after the deployment is live. For continuous uptime monitoring, run an external monitor such as the Uptime Kuma template.
+
+**Database failover: your database's job.** A multi-region API is only as available as its data layer. Railway can convert a PostgreSQL service into a high-availability cluster (Patroni, etcd, HAProxy) that promotes a replica automatically if the primary goes down. See [PostgreSQL HA](/databases/postgresql-ha).
+
+## Step 1: Build a stateless API
+
+Replicas cannot be used with volumes, and any replica can receive any request. Keep all state in a database or in [storage buckets](/storage-buckets), never on local disk or in process memory.
+
+Railway injects two variables into every replica that are useful for logging and debugging:
+
+- `RAILWAY_REPLICA_ID`: a unique ID per replica
+- `RAILWAY_REPLICA_REGION`: the region the replica runs in
+
+Create a project:
+
+```bash
+mkdir multi-region-api && cd multi-region-api
+npm init -y
+npm install express@5.1.0
+```
+
+Create `server.js`:
+
+```javascript
+const express = require("express");
+
+const app = express();
+const port = process.env.PORT || 3000;
+
+const region = process.env.RAILWAY_REPLICA_REGION || "local";
+const replicaId = process.env.RAILWAY_REPLICA_ID || "local";
+
+// Health endpoint used by Railway's deploy-time healthcheck.
+app.get("/health", (req, res) => {
+  res.status(200).json({ status: "ok", region, replicaId });
+});
+
+// Example API endpoint. Echoes which replica and region served it.
+app.get("/api/whoami", (req, res) => {
+  res.json({
+    region,
+    replicaId,
+    edge: req.get("x-railway-edge") || null,
+    servedAt: new Date().toISOString(),
+  });
+});
+
+app.listen(port, () => {
+  console.log(`[${region}/${replicaId}] listening on ${port}`);
+});
+```
+
+Two details matter for multi-region operation:
+
+- Listen on `process.env.PORT`. Railway injects it and uses the same port for health checks.
+- Log the region and replica ID. Metrics for a service are aggregated across all replicas, so structured logs are how you tell regions apart.
+
+## Step 2: Configure regions as code
+
+Create a `railway.json` in the repo root:
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "healthcheckPath": "/health",
+    "multiRegionConfig": {
+      "us-east4-eqdc4a": {
+        "numReplicas": 2
+      },
+      "europe-west4-drams3a": {
+        "numReplicas": 2
+      },
+      "asia-southeast1-eqsg3a": {
+        "numReplicas": 2
+      }
+    },
+    "restartPolicyType": "ON_FAILURE"
+  }
+}
+```
+
+This declares six replicas: two each in US East, EU West, and Southeast Asia. Two per region means a crashed replica in any region leaves a healthy one serving local traffic while the restart happens.
+
+You can configure the same thing in the dashboard: open the service settings and use the Regions field in the Scale section. Creating, deleting, or reassigning replicas triggers a staged change. Applying it scales the service without a full redeploy: new replicas start from the existing deployment image, and removed replicas are drained gracefully.
+
+## Step 3: Deploy
+
+Push the repo to GitHub and create a new Railway project from it, or deploy directly with the [CLI](/cli):
+
+```bash
+npm install -g @railway/cli
+railway login
+railway init
+railway up
+```
+
+That triggers Railpack, which detects the Node.js app and builds it without a Dockerfile. Generate a public domain under the service's Settings, Networking section, or run:
+
+```bash
+railway domain
+```
+
+The service gets a single `*.up.railway.app` domain that fronts every region.
+
+## Step 4: Verify routing and failover
+
+### Check which region served a request
+
+Send the `X-Railway-Debug` header. Railway adds an `X-Railway-Upstream-Zone` response header identifying the region that served the request:
+
+```bash
+curl -sI -H "X-Railway-Debug: 1" https://your-app.up.railway.app/api/whoami | grep -i x-railway
+```
+
+You will see something like:
+
+```
+x-railway-edge: ams1
+x-railway-upstream-zone: railway/europe-west4-drams3a
+```
+
+`x-railway-edge` is the POP where the request entered Railway's network. `x-railway-upstream-zone` is the deployment region that served it. The response body from `/api/whoami` also reports the region and replica ID from the replica's own environment.
+
+Test from multiple locations with a tool like globalping.io. Requests from Europe should report the EU West zone, requests from Asia the Southeast Asia zone.
+
+### Watch a replica failover
+
+Add a deliberate crash endpoint while testing (remove it before production):
+
+```javascript
+app.get("/api/crash", (req, res) => {
+  res.json({ crashing: replicaId });
+  setTimeout(() => process.exit(1), 100);
+});
+```
+
+Hit `/api/crash`, then keep requesting `/api/whoami`. Responses continue from the surviving replica in that region while Railway restarts the crashed one under the `On Failure` policy. The restarted replica rejoins the pool a few moments later.
+
+## Where to put the database
+
+Replicas in every region connect to the same database. Run the database in the region closest to your write-heavy traffic, and reference it over [private networking](/networking/private-networking) at `<service>.railway.internal`, which keeps traffic off the public internet. Any service with a volume attached, including the database, is locked to that one region, and changing it later requires a volume migration with downtime, so plan the database region up front.
+
+That distance still costs you: expect higher latency on database calls from replicas in regions far from the database. Patterns that keep this manageable:
+
+- Cache read-heavy data in each region (an in-memory cache per replica, or a Redis service).
+- Keep request handlers to one or two database round trips instead of many sequential queries.
+- For database-level failover, convert Postgres to an [HA cluster](/databases/postgresql-ha) so a primary failure promotes a replica automatically.
+
+## Cost of multi-region replicas
+
+Railway bills usage per replica: memory at $10 per GB per month and CPU at $20 per vCPU per month, metered by actual consumption. That means six mostly idle replicas cost little more than one, since billing follows real usage rather than provisioned capacity. Each can also scale up to your plan's full vCPU and memory limits, so total available capacity is the per-replica limit multiplied by the replica count.
+
+The metrics tab shows usage summed across all replicas. Per-replica breakdowns come from your logs via `RAILWAY_REPLICA_ID` and `RAILWAY_REPLICA_REGION`.
+
+## Limitations to design around
+
+- No sticky sessions. Store sessions in a shared database or Redis, or use stateless tokens such as JWTs.
+- No volumes on replicated services. Use a database or storage buckets for persistent data. Buckets are locked to the region chosen at creation.
+- Health checks run at deploy time only. Add external monitoring for continuous checks.
+- Metrics are aggregated across replicas. Use structured logging for per-region visibility.
+
+## Next steps
+
+- [Scaling](/deployments/scaling) covers replica behavior and load balancing in detail.
+- [Regions](/deployments/regions) lists region options and what happens when a service changes region.
+- [Edge networking](/networking/edge-networking) explains anycast routing and the debug headers used above.
+- [Health checks](/deployments/healthchecks) shows how to guarantee zero-downtime deploys.

--- a/content/guides/object-storage-for-ai-agents.md
+++ b/content/guides/object-storage-for-ai-agents.md
@@ -1,0 +1,110 @@
+---
+title: Use Object Storage for AI Agent Outputs
+description: Store AI agent artifacts in S3-compatible object storage on Railway. Where generated files, transcripts, and reports should live, how to write them from a worker, and how to share them with presigned URLs.
+date: "2026-07-29"
+tags:
+  - object-storage
+  - agents
+  - buckets
+  - ai
+topic: ai
+---
+
+Object storage for AI workloads means putting what agents produce, generated files, run transcripts, reports, datasets, into an S3-compatible store instead of a database or a filesystem. Objects are written once, read many times, addressed by key, and shared by URL.
+
+In this guide we store agent outputs in a Railway [storage bucket](/storage-buckets) and serve them back with presigned URLs.
+
+## Where agent outputs should live
+
+An agent run produces two kinds of data, and they want different homes:
+
+- **State** (task status, steps, tool calls, token counts) is small, structured, and queried. It belongs in [Postgres](/databases/postgresql).
+- **Artifacts** (the generated PDF, the CSV export, the full transcript, the rendered image) are large, immutable, and fetched whole. They belong in object storage.
+
+Putting artifacts in Postgres bloats the database and its backups. Putting them on a [volume](/volumes) ties them to one service and gives you no URL to hand out. Object storage is built for exactly this shape: a Railway bucket is private, S3-compatible, and billed at $0.015 per GB-month with free egress and unlimited free API operations.
+
+## 1. Add a bucket
+
+Click **Create** on your project canvas and select **Bucket**. Pick the region where your workers run; it cannot be changed after creation.
+
+Each Railway environment gets its own bucket instance with isolated credentials, so agent runs in a PR environment cannot touch production artifacts.
+
+## 2. Connect from the worker
+
+The bucket exposes its credentials as [variable references](/variables#referencing-a-shared-variable). Add them to the worker service that produces artifacts:
+
+| Variable | Reference |
+| --- | --- |
+| `BUCKET` | `${{Bucket.BUCKET}}` |
+| `ACCESS_KEY_ID` | `${{Bucket.ACCESS_KEY_ID}}` |
+| `SECRET_ACCESS_KEY` | `${{Bucket.SECRET_ACCESS_KEY}}` |
+| `ENDPOINT` | `${{Bucket.ENDPOINT}}` |
+| `REGION` | `${{Bucket.REGION}}` |
+
+The bucket's credential presets can also inject these under the default names your S3 library expects (the AWS SDKs, Bun's S3 driver, and others), so the client picks them up with no explicit configuration.
+
+## 3. Write artifacts, hand out URLs
+
+Install the S3 client:
+
+```bash
+npm install @aws-sdk/client-s3 @aws-sdk/s3-request-presigner
+```
+
+The worker writes each artifact under a key that encodes the run, and the API hands the client a presigned URL instead of the bytes:
+
+```typescript
+import { GetObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import { getSignedUrl } from "@aws-sdk/s3-request-presigner";
+
+const s3 = new S3Client({
+  region: process.env.REGION,
+  endpoint: process.env.ENDPOINT,
+  credentials: {
+    accessKeyId: process.env.ACCESS_KEY_ID!,
+    secretAccessKey: process.env.SECRET_ACCESS_KEY!,
+  },
+});
+
+// Worker: store the artifact when the run completes
+export async function storeArtifact(runId: string, name: string, body: string) {
+  const key = `runs/${runId}/${name}`;
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: process.env.BUCKET,
+      Key: key,
+      Body: body,
+      ContentType: "text/markdown",
+    })
+  );
+  return key;
+}
+
+// API: return a time-limited download URL, not the bytes
+export async function artifactUrl(key: string) {
+  return getSignedUrl(
+    s3,
+    new GetObjectCommand({ Bucket: process.env.BUCKET, Key: key }),
+    { expiresIn: 3600 }
+  );
+}
+```
+
+The key scheme is the schema. `runs/{runId}/{name}` means listing a run's artifacts is a prefix query, and deleting a run's artifacts is a prefix delete. Store the key in the run's Postgres row and the two systems stay joined.
+
+## Why presigned URLs matter here
+
+Buckets are private; there are no public bucket URLs. A presigned URL is a time-limited grant to one object, which fits agent artifacts well: the user who requested the run gets the report, and the link expires.
+
+It also routes the bytes around your services. Files served through presigned URLs come directly from the bucket and incur no egress cost, and your API never holds a 50 MB PDF in memory. The same pattern works for uploads: a client can [upload directly to the bucket](/storage-buckets/uploading-serving) with a presigned POST, so input files for agent runs skip your API too.
+
+## Retention
+
+Agents produce artifacts on every run, forever. Decide early what expires: keep final reports, expire intermediate outputs. A [cron service](/cron-jobs) that prefix-deletes `runs/` older than N days keeps the bucket from becoming an unbounded ledger of every draft your agents ever wrote.
+
+## Next steps
+
+- [Storage Buckets](/storage-buckets): credentials, URL styles, and S3 compatibility.
+- [Uploading & Serving Files](/storage-buckets/uploading-serving): presigned upload and download patterns in full.
+- [Deploy an AI Agent with Async Workers](/guides/ai-agent-workers): the worker architecture these artifacts come from.
+- [Use Storage Buckets for Uploads, Exports, and Assets](/guides/storage-buckets-guide): the general-purpose bucket patterns.

--- a/content/guides/postgres-backups-restores.md
+++ b/content/guides/postgres-backups-restores.md
@@ -1,0 +1,199 @@
+---
+title: Back Up and Restore Postgres
+description: Set up volume backups and point-in-time recovery for Postgres on Railway, take logical dumps with pg_dump, and run a restore drill so you know recovery works before you need it.
+date: "2026-07-29"
+tags:
+  - postgres
+  - backups
+  - disaster-recovery
+  - point-in-time-recovery
+topic: infrastructure
+---
+
+A backup you have never restored is unverified. This guide enables the three backup layers available for Postgres on Railway, then runs a restore drill with `pg_dump` and `pg_restore` so you test the whole loop before an incident forces you to.
+
+Railway Postgres stores its data on a [volume](/volumes). That gives you three ways to protect it:
+
+| Layer | What it is | Restores to | Best for |
+|---|---|---|---|
+| [Volume backups](/volumes/backups) | Scheduled or manual snapshots of the volume | The same service, same project and environment | Routine recovery from bad deploys or data mistakes |
+| [Point-in-time recovery](/volumes/point-in-time-recovery) | Continuous WAL archiving to a storage bucket via pgBackRest | A new sibling Postgres service, at any timestamp in the window | Recovering to the moment just before a `DROP TABLE` or bad migration |
+| Logical dumps (`pg_dump`) | A portable SQL-level export you create yourself | Anywhere: another Railway service, another provider, your laptop | Offsite copies, migrations, and restore drills |
+
+Use all three for production. Volume backups and PITR are Railway features you enable once. Logical dumps are the layer you control end to end, and the one you can test cheaply.
+
+## Enable scheduled volume backups
+
+Volume backups snapshot everything on the volume attached to your Postgres service. They are incremental and copy-on-write, so you are only billed for data unique to each snapshot, at the same per-GB rate as [volumes](/volumes).
+
+To enable them:
+
+1. Open your Postgres service and go to the **Backups** tab.
+2. Choose one or more schedules. Each schedule has its own retention:
+   - **Daily**: every 24 hours, kept for 6 days
+   - **Weekly**: every 7 days, kept for 1 month
+   - **Monthly**: every 30 days, kept for 3 months
+3. You can also trigger a manual backup from the same tab at any time.
+
+Two limits to know about:
+
+- Manual backups are limited to 50% of the volume's total size. If your data is above that threshold, grow the volume first.
+- Wiping a volume deletes all of its backups. Backups protect against data mistakes, not against deleting the volume itself. That is what logical dumps are for.
+
+### Restore a volume backup
+
+In the **Backups** tab, find the backup by its date stamp and click **Restore**. Railway stages the change instead of applying it immediately: a new volume named after the backup's date stamp is mounted at the original mount path, and the previous volume is unmounted but retained. Review the [staged change](/deployments/staged-changes) and click **Deploy** to apply it. The service redeploys on the restored data.
+
+Restoring a backup removes any newer backups created after it, and backups can only be restored into the same project and environment.
+
+## Enable point-in-time recovery
+
+Volume backups restore to fixed snapshot times. [Point-in-time recovery](/volumes/point-in-time-recovery) (PITR) restores to any timestamp in the archive window, which is what you want when the incident happened between snapshots.
+
+When PITR is enabled, the Postgres image archives every WAL segment to a private Railway [storage bucket](/storage-buckets) using pgBackRest, and takes rolling base backups (weekly full, daily incremental). The last 4 full backups are retained, giving a restore window of roughly 4 weeks.
+
+To enable it:
+
+1. Open the **Backups** tab on your Postgres service.
+2. Click **Enable PITR** and confirm.
+
+Railway creates a bucket named **Postgres-PITR**, sets `WAL_ARCHIVE_*` variables on the service, and redeploys it. Once archiving is healthy and the first base backup completes, a datetime picker appears on the Backups tab. PITR works for single-node Postgres and [Postgres HA](/databases/postgresql-ha) clusters; on HA clusters, enabling rolls through the cluster with about 5 seconds of unavailability during the switchover.
+
+The restore window starts from the first post-enable base backup. Enabling PITR today does not let you restore to yesterday, so enable it before you need it.
+
+PITR has no separate fee. You pay bucket storage at the standard rate for the compressed WAL and base backups, plus network egress for the uploads, though idle databases archive almost nothing.
+
+### Restore to a point in time
+
+On the **Backups** tab, pick a timestamp in the datetime picker and click **Restore to this moment**. Railway creates a new Postgres service next to the original, named `<source>-restored-YYYYMMDD-HHMM`, and replays the base backup plus archived WAL forward until it reaches your target.
+
+The source service is untouched and keeps serving traffic the whole time. After the restore, you have two services side by side: verify the fork's data, then cut over by swapping connection strings or copying the rows you need back into the source. The fork runs as plain non-archiving Postgres; enable PITR on it separately if you want continued coverage.
+
+## Take a logical backup with pg_dump
+
+Logical dumps are portable and provider-independent. They are also the only layer that survives deleting the project itself.
+
+You need the Postgres client tools installed locally (`pg_dump`, `pg_restore`, `psql`). On macOS: `brew install libpq`. On Debian/Ubuntu: `apt-get install postgresql-client`.
+
+To reach the database from your machine, open a tunnel with the [Railway CLI](/cli/connect). In a project directory linked with `railway link`:
+
+```bash
+railway connect postgres --tunnel-only
+```
+
+This opens a local tunnel to the database and prints connection details (host, port, user, password, database) without launching a client. Leave it running and, in a second terminal, take a dump in custom format:
+
+```bash
+pg_dump "postgresql://postgres:<password>@localhost:<port>/railway" \
+  --format=custom \
+  --no-owner \
+  --file=backup-$(date +%Y%m%d-%H%M%S).dump
+```
+
+Custom format (`--format=custom`) is compressed and lets `pg_restore` do selective and parallel restores, which plain SQL dumps cannot.
+
+Alternatively, connect through the public [TCP proxy](/networking/tcp-proxy) using the `DATABASE_PUBLIC_URL` variable from the Postgres service:
+
+```bash
+pg_dump "$DATABASE_PUBLIC_URL" --format=custom --no-owner --file=backup.dump
+```
+
+Traffic over the TCP proxy is billed as network egress, so the tunnel is preferable for large databases you dump often.
+
+## Run a restore drill
+
+Do this once now, and on a schedule after. The goal is to prove the dump actually restores, and to time how long it takes.
+
+Restore into a scratch database rather than the production one. With the tunnel from the previous section still open:
+
+```bash
+# Create a scratch database on the same server
+psql "postgresql://postgres:<password>@localhost:<port>/railway" \
+  -c 'CREATE DATABASE restore_drill;'
+
+# Restore the dump into it
+pg_restore \
+  --dbname="postgresql://postgres:<password>@localhost:<port>/restore_drill" \
+  --no-owner \
+  --exit-on-error \
+  backup-20260729-090000.dump
+```
+
+Then verify the restored data looks right:
+
+```bash
+psql "postgresql://postgres:<password>@localhost:<port>/restore_drill" <<'SQL'
+-- Row counts per table, compare against production
+SELECT relname, n_live_tup
+FROM pg_stat_user_tables
+ORDER BY n_live_tup DESC;
+SQL
+```
+
+Spot-check a few recent rows in your most important tables. When you are satisfied, drop the scratch database:
+
+```bash
+psql "postgresql://postgres:<password>@localhost:<port>/railway" \
+  -c 'DROP DATABASE restore_drill;'
+```
+
+Record two numbers from the drill: how long the restore took, and how old the dump was. Those are your real recovery time and recovery point.
+
+## Automate offsite dumps with a cron service
+
+For an offsite copy that survives anything happening to the project, run `pg_dump` on a schedule from a [cron job](/cron-jobs) service and upload the result to a separate Railway [storage bucket](/storage-buckets) (or any S3-compatible store outside Railway).
+
+Create a bucket in your project, then create an empty service with this Dockerfile:
+
+```dockerfile
+FROM postgres:16-alpine
+
+RUN apk add --no-cache aws-cli
+
+COPY backup.sh /backup.sh
+RUN chmod +x /backup.sh
+
+CMD ["/backup.sh"]
+```
+
+And this `backup.sh`:
+
+```bash
+#!/bin/sh
+set -eu
+
+STAMP=$(date -u +%Y%m%d-%H%M%S)
+FILE="backup-${STAMP}.dump"
+
+echo "Dumping database..."
+pg_dump "$DATABASE_URL" --format=custom --no-owner --file="/tmp/${FILE}"
+
+echo "Uploading ${FILE} to bucket..."
+aws s3 cp "/tmp/${FILE}" "s3://${BUCKET}/${FILE}" \
+  --endpoint-url "$ENDPOINT"
+
+echo "Done."
+```
+
+Wire up the variables on the cron service:
+
+- `DATABASE_URL`: a [reference](/variables) to the Postgres service's `DATABASE_URL`, so the dump travels over private networking with no egress cost for the database read. The upload to the bucket does count as service egress, since buckets live on the public network.
+- `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_DEFAULT_REGION`, `ENDPOINT`, `BUCKET`: use the bucket's variable-reference presets from its Credentials tab. The AWS CLI picks up the `AWS_*` names automatically.
+
+Finally, set a cron schedule in the service settings, for example `0 3 * * *` for a daily dump at 03:00 UTC. Cron schedules on Railway run in UTC, the minimum granularity is 5 minutes, and if a run is still going when the next trigger fires, the new run is skipped rather than stacked. That's why the service must exit when the dump finishes, which the script above does.
+
+Bucket storage is billed at $0.015 per GB-month with free API operations, so retaining a few weeks of compressed dumps is cheap. Add a cleanup step to the script (`aws s3 rm` on objects older than your retention window) once the bucket starts accumulating.
+
+## Which layer to use when
+
+- **Bad deploy corrupted some rows an hour ago**: PITR, restore to the minute before the deploy, copy the rows back.
+- **Need yesterday's state of the whole database**: volume backup restore, or PITR if you need a specific time.
+- **Migrating to another provider or region**: logical dump. A bucket's region is fixed at creation, but a dump file goes anywhere.
+- **Project or volume was deleted**: only the offsite logical dumps survive this. That is why the cron service exists.
+
+## Next steps
+
+- [Volume backups reference](/volumes/backups)
+- [Point-in-time recovery](/volumes/point-in-time-recovery)
+- [Deploy PostgreSQL on Railway](/databases/postgresql)
+- [Cron jobs](/cron-jobs)

--- a/content/guides/private-container-registry.md
+++ b/content/guides/private-container-registry.md
@@ -1,0 +1,198 @@
+---
+title: Deploy from a Private Container Registry
+description: Deploy Docker images from private registries (GHCR, Docker Hub, GitLab, ECR, Google Artifact Registry) on Railway, from credential setup to CI-driven redeploys.
+date: "2026-07-29"
+tags:
+  - docker
+  - registries
+  - deployments
+  - ci-cd
+topic: infrastructure
+---
+
+Railway can deploy a service directly from a private container registry, one whose images require authentication to pull. You provide the image path and registry credentials; Railway authenticates with the registry, pulls the image, and runs it. There is no build step on Railway's side, so what you push to the registry is exactly what runs.
+
+## Requirements
+
+Private registry credentials are available on the [Pro plan](/pricing/plans). Public images work on any plan.
+
+Railway works with any registry that supports standard Docker authentication, including:
+
+| Registry | Domain |
+| -------- | ------ |
+| Docker Hub | `docker.io` (default) |
+| GitHub Container Registry | `ghcr.io` |
+| GitLab Container Registry | `registry.gitlab.com` |
+| Quay.io | `quay.io` |
+| AWS ECR | account-specific domain |
+| Google Artifact Registry | `us-west1-docker.pkg.dev` (region-specific) |
+
+## Build and push an image
+
+The example below uses GitHub Container Registry (GHCR), but the flow is the same for any registry: build, tag with the full registry path, push.
+
+A minimal app to containerize:
+
+```javascript
+// server.js
+const http = require("http");
+
+const port = process.env.PORT || 3000;
+
+const server = http.createServer((req, res) => {
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ status: "ok", version: process.env.APP_VERSION || "dev" }));
+});
+
+server.listen(port, () => {
+  console.log(`Listening on ${port}`);
+});
+```
+
+```dockerfile
+# Dockerfile
+FROM node:22-slim
+
+WORKDIR /app
+COPY server.js .
+
+CMD ["node", "server.js"]
+```
+
+Build and push:
+
+```bash
+# Authenticate to GHCR with a personal access token that has write:packages scope
+echo $GITHUB_TOKEN | docker login ghcr.io -u your-github-username --password-stdin
+
+# Build for linux/amd64. Docker on Apple Silicon defaults to arm64,
+# so pass --platform explicitly when building on an ARM machine.
+docker build --platform linux/amd64 -t ghcr.io/your-org/my-app:1.0.0 .
+
+docker push ghcr.io/your-org/my-app:1.0.0
+```
+
+Images pushed to GHCR are private by default when the repository is private.
+
+## Create the service on Railway
+
+1. In your project canvas, create a new service and choose **Docker Image** as the source.
+2. Enter the full image path, including the registry domain: `ghcr.io/your-org/my-app:1.0.0`. For Docker Hub you can omit the domain: `your-username/private-image:1.0.0`.
+3. Deploy. The first deploy fails to pull until credentials are configured, which is the next step.
+
+## Configure registry credentials
+
+1. Open the service's **Settings** page.
+2. Under **Source**, find **Registry Credentials**.
+3. Enter your credentials and save, then redeploy.
+
+Credentials are encrypted at rest with envelope encryption and only decrypted at deployment time when Railway pulls the image.
+
+### GHCR
+
+For `ghcr.io` you need only a token: create a [GitHub personal access token](https://github.com/settings/tokens) with the `read:packages` scope and paste it into the **GitHub Access Token** field. Railway handles the username for you.
+
+Use a token scoped to read only. The `write:packages` token from your CI pipeline should not be reused here.
+
+### Other registries
+
+For all other registries, provide a username and password:
+
+| Registry | Username | Password |
+| -------- | -------- | -------- |
+| Docker Hub | Docker ID | [Personal access token](https://docs.docker.com/security/access-tokens/) |
+| GitLab | GitLab username | Personal access token with `read_registry` scope |
+| Quay.io | Robot account, `namespace+robotname` | Generated robot token |
+| AWS ECR | `AWS` | Token from `aws ecr get-login-password` |
+| Google Artifact Registry | `_json_key` | Full service account JSON key contents |
+
+### The ECR token problem
+
+ECR authentication tokens expire after 12 hours. A token saved in Railway's registry credentials stops working half a day later, and the next redeploy or restart that needs to pull the image will fail.
+
+If you control where images live, prefer a registry with long-lived credentials (GHCR, Docker Hub, GitLab, Quay) for services deployed to Railway. If your images must stay in ECR, your CI pipeline needs to refresh the stored credential before each deploy, or mirror the image to a registry with static credentials as a final CI step.
+
+## Deploy new versions from CI
+
+Pushing a new image does not redeploy your service on its own. There are three ways to get a new version live.
+
+### Option 1: a mutable tag plus a CI redeploy
+
+Push a mutable tag like `:latest` or `:production`, then trigger a redeploy with the [Railway CLI](/cli/redeploy). The redeploy pulls the tag again and picks up the new digest.
+
+```yaml
+# .github/workflows/deploy.yml
+name: Build and deploy
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64
+          push: true
+          tags: ghcr.io/${{ github.repository }}:production
+
+      - name: Redeploy on Railway
+        run: npx -y @railway/cli@latest redeploy --service my-app --yes
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+```
+
+Create a project token under your project settings and store it as `RAILWAY_TOKEN` in your repository secrets. A project token is scoped to one environment, so the redeploy targets that environment's service.
+
+### Option 2: image auto updates
+
+For images on Docker Hub or GHCR, Railway can [check for new versions automatically](/deployments/image-auto-updates) and redeploy during a maintenance window you choose. Within that window, semantic version tags update according to a policy you set (patches only, or minor plus patches), and mutable tags like `:latest` redeploy whenever the digest behind the tag changes.
+
+Auto updates fit dependencies you consume (databases, reverse proxies, third-party tools) better than your own application, because detection results are cached for up to a few hours and updates wait for the maintenance window. For your own app, a CI-triggered redeploy is immediate and deterministic.
+
+### Option 3: unique tags plus a staged update
+
+Tag every build uniquely (`:1.4.2`, or the git SHA) and update the service's image reference for each release. This gives you exact rollbacks: [deployment rollbacks](/deployments/deployment-actions) restore both the image reference and the variables from a previous deploy. You can update the image in the service settings, or automate it against Railway's API.
+
+## Runtime configuration
+
+Railway runs your image as-is, so configuration happens through the service, not the build:
+
+- **Port.** Railway injects a `PORT` variable and expects your process to listen on it when serving HTTP behind a [Railway-provided domain](/networking/domains). The example server above reads `process.env.PORT`.
+- **Variables.** Set them under the service's **Variables** tab. They are injected at runtime, so the same image can run with different configuration in each environment.
+- **Start command.** The image's `CMD` runs by default. Override it in service settings if the image ships multiple entrypoints.
+- **Health checks.** Configure an HTTP [health check path](/deployments/healthchecks) so Railway only shifts traffic to a new container after it reports healthy. This is required for zero-downtime deploys.
+
+## Private images in templates
+
+If you publish a [template](/templates/create) that uses a private image, you can attach your registry credentials to the template service without exposing them. Users who deploy the template see that the service uses hidden registry credentials but cannot read them, and SSH access is disabled on those services to protect the credentials. See [private Docker images in templates](/templates/private-docker-images).
+
+## Troubleshooting
+
+- **Pull fails with an authentication error.** Verify the image path includes the registry domain and that the token has read scope for that specific package or repository. GHCR packages have their own access settings separate from the repository.
+- **Pull worked yesterday, fails today.** Check for expired credentials. ECR tokens last 12 hours; some registries expire personal access tokens on a schedule you set at creation.
+- **Image runs locally but crashes immediately on Railway.** Check the image's CPU architecture. Docker on Apple Silicon builds arm64 images by default; rebuild with `--platform linux/amd64` and push again.
+- **New push is not live.** Redeploys are not automatic. Trigger `railway redeploy`, wait for the maintenance window if you use auto updates, or update the tag reference.
+
+## Next steps
+
+- [Private registries](/builds/private-registries) is the reference for supported registries and credential formats.
+- [Image auto updates](/deployments/image-auto-updates) covers maintenance windows, version policies, and volume backups before updates.
+- [Health checks](/deployments/healthchecks) explains how to get zero-downtime deploys for image-based services.
+- [Deploy a Node Express API with zero downtime](/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime) shows the full production setup around a deployed service.

--- a/content/guides/rabbitmq-producers-consumers.md
+++ b/content/guides/rabbitmq-producers-consumers.md
@@ -1,0 +1,221 @@
+---
+title: Deploy RabbitMQ and Wire Up Producers and Consumers
+description: Run RabbitMQ on Railway, expose the management UI, and connect producer and consumer services over private networking with Node.js and amqplib.
+date: "2026-07-29"
+tags:
+  - rabbitmq
+  - message-queues
+  - private-networking
+  - workers
+topic: integrations
+---
+
+RabbitMQ is a message broker that sits between the services that create work (producers) and the services that process it (consumers). Producers publish messages to the broker and move on. Consumers pull messages at their own pace and acknowledge each one after processing; a failed message can be retried or dead-lettered instead of lost. This decouples request handling from slow work like sending email, processing uploads, or calling external APIs. This guide deploys RabbitMQ on Railway and connects a producer and a consumer to it over private networking.
+
+On Railway, a typical setup is three services in one project:
+
+1. **RabbitMQ**: the broker, deployed from a template or Docker image, with a volume for message persistence.
+2. **Producer**: your API service. It accepts requests and publishes messages.
+3. **Consumer**: a worker service with no public domain. It consumes messages and does the work.
+
+The services talk to each other over [private networking](/networking/private-networking), so broker traffic never leaves your project and generates no egress charges.
+
+## Deploy RabbitMQ
+
+### Option 1: use a template
+
+Search the <a href="https://railway.com/templates" target="_blank">template marketplace</a> for RabbitMQ and click **Deploy Now**. Templates come preconfigured with credentials and a volume. You can also add a template to an existing project: click **+ New** on your project canvas and select **Template**. See [deploy a template](/templates/deploy) for the full flow.
+
+### Option 2: deploy the Docker image
+
+If you prefer to configure it yourself:
+
+1. In your project, click **+ New**, choose **Docker Image**, and enter `rabbitmq:4-management`. The `-management` tag includes the web management UI.
+2. In the service's **Variables** tab, set the default credentials:
+
+```
+RABBITMQ_DEFAULT_USER=admin
+RABBITMQ_DEFAULT_PASS=<generate a strong password>
+```
+
+3. Attach a [volume](/volumes) so messages survive restarts. Create a volume from the command palette (`⌘K`) or by right-clicking the project canvas, connect it to the RabbitMQ service, and set the mount path to `/var/lib/rabbitmq`. Without a volume, queues and messages are lost whenever the container restarts. Volumes cost $0.15 per GB per month and are only mounted at runtime, not during builds.
+4. Deploy. RabbitMQ listens for AMQP connections on port `5672` and serves the management UI on port `15672`.
+
+## Expose the management UI
+
+The management UI is a regular HTTP app, so you can put it behind a Railway domain:
+
+1. Open the RabbitMQ service's **Settings** tab.
+2. In the **Networking** section, generate a domain and set the target port to `15672`.
+3. Open the generated `*.up.railway.app` URL and log in with `RABBITMQ_DEFAULT_USER` and `RABBITMQ_DEFAULT_PASS`.
+
+From the UI you can watch queue depth, message rates, consumer counts, and unacknowledged messages. Anyone with the URL can reach the login page, so use a strong password.
+
+## Connect over private networking
+
+Every service in an environment gets an internal DNS name at `<service-name>.railway.internal`. If your broker service is named `rabbitmq`, producers and consumers in the same environment reach it at `rabbitmq.railway.internal:5672`. That reachability stops at the environment boundary, so your staging services cannot reach your production broker.
+
+Instead of hardcoding credentials in each service, define one `RABBITMQ_URL` variable on the producer and consumer using [reference variables](/variables):
+
+```
+RABBITMQ_URL=amqp://${{rabbitmq.RABBITMQ_DEFAULT_USER}}:${{rabbitmq.RABBITMQ_DEFAULT_PASS}}@${{rabbitmq.RAILWAY_PRIVATE_DOMAIN}}:5672
+```
+
+Railway resolves the references at deploy time. Rotate the password on the broker and both services pick it up on their next deploy.
+
+Private networking has two limits:
+
+- It is available at runtime only. Do not try to connect to RabbitMQ from a build step.
+- Use plain `amqp://`, not `amqps://`. Traffic between services is already encrypted with WireGuard.
+
+If an external system outside Railway must publish or consume directly, enable [TCP Proxy](/networking/tcp-proxy) on the RabbitMQ service with internal port `5672`. Railway generates a public `domain:port` pair that proxies raw TCP to the broker. Keep this off unless you need it; internal services should use the private address.
+
+## Write the producer
+
+The producer is an HTTP API that publishes a message for each incoming request. We use Express and amqplib.
+
+Install the dependencies:
+
+```bash
+npm install express amqplib
+```
+
+```javascript
+// producer.js
+const express = require("express");
+const amqp = require("amqplib");
+
+const QUEUE = "tasks";
+let channel = null;
+
+async function connect() {
+  const connection = await amqp.connect(process.env.RABBITMQ_URL);
+  connection.on("close", () => {
+    console.error("RabbitMQ connection closed, exiting");
+    process.exit(1); // Railway restarts the service
+  });
+  channel = await connection.createChannel();
+  await channel.assertQueue(QUEUE, { durable: true });
+}
+
+const app = express();
+app.use(express.json());
+
+app.post("/jobs", (req, res) => {
+  if (!channel) {
+    return res.status(503).json({ error: "broker not connected" });
+  }
+  const payload = Buffer.from(JSON.stringify(req.body));
+  channel.sendToQueue(QUEUE, payload, { persistent: true });
+  res.status(202).json({ queued: true });
+});
+
+app.get("/health", (req, res) => {
+  if (!channel) {
+    return res.status(503).json({ ok: false });
+  }
+  res.json({ ok: true });
+});
+
+const port = process.env.PORT || 3000;
+
+connect()
+  .then(() => {
+    app.listen(port, () => console.log(`Producer listening on ${port}`));
+  })
+  .catch((err) => {
+    console.error("Failed to connect to RabbitMQ:", err.message);
+    process.exit(1);
+  });
+```
+
+Two details matter for durability. The queue is declared with `durable: true`, so the queue definition survives a broker restart. Each message is published with `persistent: true`, so the message itself is written to disk on the volume. You need both, plus the volume on the broker, for messages to survive a restart.
+
+The `/health` endpoint returns 503 until the broker connection is up. Set it as the service's [healthcheck](/deployments/healthchecks) path in the deploy settings so a deploy is only marked live once the producer can publish. Healthchecks also guarantee zero-downtime deploys: the old version keeps serving until the new one passes.
+
+## Write the consumer
+
+The consumer is a plain worker with no HTTP server and no public domain. Deploy it as its own service in the same project.
+
+```bash
+npm install amqplib
+```
+
+```javascript
+// consumer.js
+const amqp = require("amqplib");
+
+const QUEUE = "tasks";
+
+async function handleJob(job) {
+  // Replace with real work: send an email, resize an image, call an API.
+  console.log("Processing job:", job);
+}
+
+async function main() {
+  const connection = await amqp.connect(process.env.RABBITMQ_URL);
+  connection.on("close", () => {
+    console.error("RabbitMQ connection closed, exiting");
+    process.exit(1); // Railway restarts the service
+  });
+
+  const channel = await connection.createChannel();
+  await channel.assertQueue(QUEUE, { durable: true });
+  channel.prefetch(5);
+
+  await channel.consume(QUEUE, async (msg) => {
+    if (!msg) return;
+    try {
+      const job = JSON.parse(msg.content.toString());
+      await handleJob(job);
+      channel.ack(msg);
+    } catch (err) {
+      console.error("Job failed:", err.message);
+      // Requeue once; drop on redelivery to avoid poison-message loops.
+      channel.nack(msg, false, !msg.fields.redelivered);
+    }
+  });
+
+  console.log(`Consuming from "${QUEUE}"`);
+}
+
+main().catch((err) => {
+  console.error("Failed to start consumer:", err.message);
+  process.exit(1);
+});
+```
+
+Key decisions in this code:
+
+- **Manual acknowledgment.** The consumer calls `channel.ack(msg)` only after the job succeeds. If the consumer crashes mid-job, RabbitMQ redelivers the message to another consumer.
+- **Prefetch.** `channel.prefetch(5)` caps unacknowledged messages per consumer at 5. Without it, RabbitMQ pushes the entire queue to the first consumer that connects.
+- **Poison messages.** On failure, the message is requeued once (`!msg.fields.redelivered`). If it fails again it is dropped. For production, configure a dead-letter exchange instead of dropping.
+- **Exit on disconnect.** When the broker connection closes, the process exits with a non-zero code and Railway restarts the service, which reconnects cleanly.
+
+To process more messages in parallel, scale the consumer service to multiple replicas or increase the prefetch count. Those extra replicas help because RabbitMQ distributes messages across all consumers on the same queue.
+
+Do not enable serverless (app sleeping) on the consumer or the broker. An idle consumer still needs its open AMQP connection, and the heartbeat traffic on that connection counts as outbound activity, so the service would never sleep anyway.
+
+## Test the pipeline
+
+Publish a job through the producer's public domain:
+
+```bash
+curl -X POST https://your-producer.up.railway.app/jobs \
+  -H "Content-Type: application/json" \
+  -d '{"type": "welcome-email", "userId": 42}'
+```
+
+Then check two places:
+
+1. The consumer service's logs should show `Processing job: { type: 'welcome-email', userId: 42 }`.
+2. The management UI's **Queues** tab should show the `tasks` queue with a brief spike in message rate and zero messages ready.
+
+If messages pile up as "Ready" with no consumers listed, the consumer is not connected: check its logs for a bad `RABBITMQ_URL` or a service name mismatch in the reference variable.
+
+## Next steps
+
+- [Choose between cron jobs, background workers, and queues](/guides/cron-workers-queues) for when RabbitMQ is the right tool.
+- [Private networking](/networking/private-networking) for how internal DNS and environment isolation work.
+- [Variables](/variables) for reference variables and shared variables across services.
+- [Scaling your application](/guides/scaling-your-application) for adding replicas to consumers.

--- a/content/guides/redis-cache-vs-store.md
+++ b/content/guides/redis-cache-vs-store.md
@@ -1,0 +1,156 @@
+---
+title: Run Redis as a Cache vs a Persistent Store
+description: Configure Redis as a cache or as a durable store on Railway. Covers the persistence settings, eviction policies, and start commands for each mode.
+date: "2026-07-29"
+tags:
+  - redis
+  - caching
+  - persistence
+  - architecture
+topic: architecture
+---
+
+Redis can play two different roles. As a cache, it holds disposable copies of data that lives elsewhere, and losing everything in it costs you nothing but a few slow requests. As a persistent store, it is the system of record for data like sessions, queues, or counters, and losing it means losing real state. The same server binary handles both roles, but getting each one right means configuring it separately: a cache with bounded memory and eviction, or a durable store with AOF persistence and a volume.
+
+## Three settings decide the mode
+
+These are the settings that separate the two configurations:
+
+| Setting | Cache | Persistent store |
+|---|---|---|
+| `maxmemory` | Set to a hard limit | Unset or generous headroom |
+| `maxmemory-policy` | `allkeys-lru` (or `allkeys-lfu`) | `noeviction` (default) |
+| Persistence (RDB/AOF) | Disabled | AOF enabled, plus RDB snapshots |
+
+The dividing line is whether Redis is allowed to throw data away: a cache is, a store is not. Everything else follows from that.
+
+## Configure Redis as a cache
+
+For a cache you want bounded memory, automatic eviction of cold keys, and no disk writes.
+
+Deploy the [Redis template](/databases/redis), then set a custom [start command](/deployments/start-command) on the service:
+
+```bash
+redis-server --save "" --appendonly no --maxmemory 400mb --maxmemory-policy allkeys-lru
+```
+
+What each flag does:
+
+- `--save ""` disables RDB snapshots. Without this, the Redis Docker image uses its built-in snapshot schedule and writes dump files to disk. A cache does not need them.
+- `--appendonly no` keeps the append-only file off. This is already the default; the flag makes the intent explicit.
+- `--maxmemory 400mb` caps the dataset. When the cap is reached, Redis evicts keys instead of growing.
+- `--maxmemory-policy allkeys-lru` evicts the least recently used key, across all keys, whenever memory is needed. Use `allkeys-lfu` instead if your access pattern favors frequently used keys over recently used ones.
+
+A cache configured this way does not need a volume. If the service restarts, it comes back empty and refills from your source of truth.
+
+### Pick a maxmemory value
+
+Railway bills memory at usage-based rates (see [pricing](/pricing/plans)), so `maxmemory` is also your cost ceiling for the dataset. Leave headroom between `maxmemory` and the service's memory limit: Redis needs extra memory beyond the dataset for client buffers and copy-on-write during forks. That headroom follows a common rule: set `maxmemory` to roughly half of the memory you expect the container to use at peak.
+
+### Eviction policies compared
+
+| Policy | Behavior | Use when |
+|---|---|---|
+| `noeviction` | Writes fail with an error when memory is full | Redis is a store, never a cache |
+| `allkeys-lru` | Evict least recently used key, any key | General-purpose cache |
+| `allkeys-lfu` | Evict least frequently used key, any key | Cache with stable hot set |
+| `volatile-lru` | Evict LRU among keys with a TTL | Mixed cache and store in one instance (avoid this, see below) |
+| `volatile-ttl` | Evict the key closest to expiry | TTL-driven caches |
+| `allkeys-random` / `volatile-random` | Evict random keys | Rarely the right choice |
+
+## Configure Redis as a persistent store
+
+For sessions, job queues (BullMQ, Sidekiq, Celery), rate-limit counters, or any data your application cannot rebuild, you need durability.
+
+1. **Attach a volume.** The Railway Redis template runs the [official Redis Docker image](https://hub.docker.com/_/redis), which uses `/data` as its working directory. Make sure the service has a [volume](/volumes) mounted at `/data` so RDB and AOF files survive restarts and redeploys. That mount happens when the container starts, not during build, which works fine for Redis since it only reads its data directory at runtime.
+
+2. **Enable AOF.** Set the start command:
+
+```bash
+redis-server --appendonly yes --appendfsync everysec
+```
+
+The append-only file logs every write. With `appendfsync everysec`, Redis syncs the log to disk once per second, so a crash loses at most about one second of writes. Alongside that AOF log, RDB snapshots stay on their default schedule and act as compact restore points.
+
+3. **Keep `noeviction`.** It is the default policy. When memory fills up, writes fail loudly instead of Redis silently deleting your queue jobs or sessions. A failed write is a signal to resize; a silently evicted job is data loss.
+
+4. **Turn on backups.** Volume-backed services support scheduled [backups](/volumes/backups). Persistence protects you from restarts; backups protect you from bad deploys and operator error.
+
+If the dataset grows, you can resize the volume live from the volume settings without downtime on paid plans.
+
+## Do not mix both roles in one instance
+
+You could run one Redis with TTLs on cache keys, no TTLs on durable keys, and `volatile-lru` as the policy. That setup has three problems:
+
+- Cache traffic and store traffic compete for the same memory budget, so a burst of cache fills can pressure the durable dataset.
+- Persistence settings apply to the whole instance. You either pay AOF write overhead for cache traffic or run your durable data without it.
+- One `FLUSHALL` or one memory incident takes out both.
+
+Run two Redis services in the same project instead: `redis-cache` with the cache configuration and `redis-store` with the persistent configuration. Both are reachable from your other services over [private networking](/networking/private-networking) at `redis-cache.railway.internal` and `redis-store.railway.internal`, and internal traffic does not count toward egress billing.
+
+## Connect from your application
+
+Each Redis service exposes a `REDIS_URL` [variable](/variables) you can reference from other services in the project. With two instances, reference each service's variable separately.
+
+Install the client:
+
+```bash
+npm install ioredis
+```
+
+Then connect to both, using the cache with a cache-aside pattern and the store for durable state:
+
+```typescript
+import Redis from "ioredis";
+
+// family: 0 enables dual-stack lookup, required for
+// private networking hostnames like redis-cache.railway.internal
+const cache = new Redis(process.env.CACHE_REDIS_URL!, { family: 0 });
+const store = new Redis(process.env.STORE_REDIS_URL!, { family: 0 });
+
+// Cache-aside: try the cache, fall back to the real source, then fill.
+async function getProduct(id: string): Promise<Product> {
+  const cached = await cache.get(`product:${id}`);
+  if (cached) return JSON.parse(cached) as Product;
+
+  const product = await fetchProductFromDatabase(id);
+  // Always set a TTL on cache keys. Eviction is the safety net, not the plan.
+  await cache.set(`product:${id}`, JSON.stringify(product), "EX", 300);
+  return product;
+}
+
+// Durable state: no TTL, lives in the persistent instance.
+async function recordLogin(userId: string): Promise<void> {
+  await store.hset(`session:${userId}`, {
+    lastLogin: Date.now().toString(),
+  });
+}
+
+interface Product {
+  id: string;
+  name: string;
+  priceCents: number;
+}
+
+async function fetchProductFromDatabase(id: string): Promise<Product> {
+  // Replace with your real database query.
+  return { id, name: "example", priceCents: 1000 };
+}
+```
+
+The `family: 0` option matters when connecting over the internal network. Without it, some clients fail DNS resolution for `.railway.internal` hostnames. See the [ENOTFOUND troubleshooting guide](/databases/troubleshooting/enotfound-redis-railway-internal) for details.
+
+## Which configuration fits your workload
+
+- **Page and API response caching, computed results, HTML fragments:** cache mode. Rebuildable by definition.
+- **Sessions:** persistent store. Users notice when every session drops on a redeploy.
+- **Job queues:** persistent store with AOF. An evicted or lost job is silent data loss.
+- **Rate limiting:** depends. If a reset window on restart is acceptable, cache mode is fine. If limits enforce billing or abuse rules, use the store.
+- **Pub/sub:** neither setting matters. Pub/sub messages are never persisted in Redis regardless of configuration; use a queue if you need delivery guarantees.
+
+## Next steps
+
+- [Redis on Railway](/databases/redis) - Deploy and connect the Redis template.
+- [Using Volumes](/volumes) - Attach persistent storage to a service.
+- [Backups](/volumes/backups) - Schedule automated volume backups.
+- [Choose Between Cron Jobs, Background Workers, and Queues](/guides/cron-workers-queues) - Background processing patterns that pair with Redis.

--- a/content/guides/right-size-cpu-memory.md
+++ b/content/guides/right-size-cpu-memory.md
@@ -1,0 +1,120 @@
+---
+title: Right-Size CPU and Memory from Real Metrics
+description: How to read the Metrics tab on Railway, translate real CPU and memory usage into a monthly cost, and set replica and usage limits that cap spend without crashing your service.
+date: "2026-07-29"
+tags:
+  - metrics
+  - cost
+  - infrastructure
+  - scaling
+topic: infrastructure
+---
+
+Right-sizing means matching the resources a service is allowed to use to the resources it actually needs. That takes three steps: read the Metrics tab, turn real usage into a monthly cost, and set limits that cap spend without crashing your service.
+
+On most platforms you right-size by picking an instance size. On Railway there is no instance size to pick: services scale vertically up to your plan's limits automatically, and you are billed per minute for what the service actually consumes. That consumption is priced per resource: RAM costs $10 per GB per month, CPU $20 per vCPU per month.
+
+That billing model changes what right-sizing means: your baseline bill is set by real usage, not by an allocation you chose. The work is to read the metrics, understand what your service really uses, and set limits so a memory leak, a runaway loop, or a traffic spike cannot turn into a surprise invoice.
+
+## How resource billing works on Railway
+
+Railway meters four resources for a running service:
+
+| Resource | Price | Per-minute rate |
+| --- | --- | --- |
+| RAM | $10 / GB / month | $0.000231 / GB / minute |
+| CPU | $20 / vCPU / month | $0.000463 / vCPU / minute |
+| Network egress | $0.05 / GB | metered per KB |
+| Volume storage | $0.15 / GB / month | metered per minute |
+
+Two consequences follow:
+
+1. **Idle services still cost money.** A service that holds 512 MB of RAM at zero traffic is billed for 512 MB every minute it runs. You pay for consumption, not requests.
+2. **Headroom is free until your process uses it.** Because there is no instance size to buy, generous limits cost nothing on their own. Look instead for memory your process holds but does not need, and CPU it burns without doing useful work.
+
+Your plan sets the ceiling per replica. On the Pro plan, for example, each replica can use up to 24 GB RAM and 24 vCPU. See [plans](/pricing/plans) for the limits on each plan.
+
+## Read the Metrics tab
+
+Open your project, click the service, and select the **Metrics** tab. Railway shows four graphs per service:
+
+- **CPU**: processor usage in vCPU
+- **Memory**: RAM consumption
+- **Disk Usage**: storage utilization
+- **Network**: inbound and outbound traffic
+
+Up to 30 days of data is available, and the time series is continuous across deployments, not per deployment. Dotted vertical lines mark when each deployment began, so you can attribute a jump in memory or CPU to a specific commit.
+
+What to look for:
+
+- **Memory baseline.** The flat line your memory graph settles at after startup. This is what your service costs at idle. For a typical Node or Python web service this is 100 to 400 MB.
+- **Memory slope.** A line that climbs steadily across days and only resets at the deployment markers is a leak. Fix the leak before touching limits; a limit will turn the leak into a crash instead of a bill.
+- **CPU shape.** Web services should sit near zero and spike with traffic. A CPU line that is pinned high with no matching traffic in the Network graph means busy-waiting, a hot polling loop, or a misbehaving dependency.
+- **Deployment deltas.** Compare the baseline before and after a dotted line. A dependency upgrade that adds 200 MB of resident memory is easy to spot here and adds $2 per month per replica until you fix it.
+
+### Sum and Replica views
+
+If the service runs multiple [replicas](/deployments/scaling), the Metrics tab offers two views. **Sum** combines all replicas: two replicas at 100 MB each show as 200 MB. **Replica** shows each instance separately, which is the view to use for right-sizing, because limits apply per replica and one hot replica can hide behind a calm average. Public network traffic is only shown in the Sum view.
+
+## Do the cost math
+
+Take the numbers off the graphs and turn them into dollars. The formula for a service that runs continuously:
+
+```
+monthly cost ≈ (avg RAM in GB × $10) + (avg vCPU × $20) + (egress GB × $0.05)
+```
+
+Use the average, not the peak, because billing is per minute of actual usage. A service that spikes to 2 GB for five minutes a day but idles at 300 MB is billed almost entirely at 300 MB.
+
+Worked example, a typical API service:
+
+- Memory baseline 350 MB, brief spikes to 700 MB: call it 0.36 GB average → 0.36 × $10 = **$3.60/month**
+- CPU averaging 0.05 vCPU with request spikes to 0.5 vCPU → 0.05 × $20 = **$1.00/month**
+- 20 GB egress → 20 × $0.05 = **$1.00/month**
+
+Total: about $5.60 per month. Multiply the RAM and CPU terms by the replica count if you run more than one.
+
+This math also tells you where optimization pays. In the example above, halving memory saves $1.80 per month; cutting CPU is worth twice as much per unit, so a busy-looping process at 1 vCPU flat is a $20 per month bug. And because a vCPU-minute costs twice a GB-minute, trading memory for CPU (caching computed results, for instance) is usually the right direction on Railway.
+
+For a breakdown of what you have already spent by project and by resource (CPU, memory, network), see the Usage page in your workspace settings. See [understanding your bill](/pricing/understanding-your-bill) for how the subscription fee and usage overage combine.
+
+## Set replica limits
+
+By default a service can scale up to your plan's per-replica maximum. If you want a hard ceiling below that, set replica limits: **service settings → Deploy → Replica Limits**. This caps the CPU and memory available to each replica.
+
+Set limits from the metrics, not from guesses:
+
+- **Memory limit**: at least 1.5 to 2 times the observed peak, not the baseline. A Node service idling at 300 MB that peaks at 700 MB during garbage collection or bursts should get a limit of about 1.5 GB, not 512 MB.
+- **CPU limit**: set it above the spikes you see under normal traffic. Its main job is to bound the worst-case CPU bill from a runaway process.
+
+Railway warns that limits set too low will crash your service. See [cost control](/pricing/cost-control). Replica limits are the right tool when you would rather have the service crash and restart than absorb unbounded cost, which is the correct trade for a leaky worker but the wrong one for your production API during a launch.
+
+Replica limits do not lower your baseline bill: usage below the limit is billed identically with or without one, so they only bound the tail.
+
+## Cap total spend with usage limits
+
+Replica limits bound one service. To bound the whole bill, set usage limits on the [Workspace Usage page](https://railway.com/workspace/usage):
+
+- **Custom email alert**: a soft threshold. Railway emails you when usage crosses it and nothing is shut down. Set this at your expected monthly spend so drift gets noticed in days, not at invoice time.
+- **Hard limit**: when billing-cycle usage hits this amount, Railway takes all workloads offline. Emails go out at 75%, 90%, and 100%. The minimum hard limit is $10.
+
+A sane default: email alert at your normal monthly spend, hard limit at 3 to 5 times that. The hard limit is destructive by design, so leave real headroom above legitimate growth.
+
+## Cut the waste the metrics reveal
+
+Once the graphs show where the money goes, three changes reduce it:
+
+- **[Serverless](/deployments/serverless)** stops a service after 10 minutes without outbound traffic and restarts it on the next request. For staging environments, preview deploys, and low-traffic internal tools, this converts the idle baseline to near zero. Note that persistent database connections or outbound polling count as activity and will keep the service awake.
+- **[Private networking](/networking/private-networking)** eliminates egress charges between services in the same environment. If your app talks to its database over the public URL, switch to the `.railway.internal` hostname (use `DATABASE_URL` instead of `DATABASE_PUBLIC_URL`); the Network graph plus the $0.05/GB rate tells you what that has been costing.
+- **Delete or scale down replicas you cannot justify.** The Replica view makes it obvious when a second replica carries no meaningful load. Fewer replicas means one less multiple on the RAM and CPU terms.
+
+## Recheck after every meaningful deploy
+
+Right-sizing is not a one-time exercise. The deployment markers on the metrics graphs make the loop cheap: after a dependency bump, a framework upgrade, or a feature that adds caching, glance at the before and after baselines. Catching a 300 MB regression the week it deploys costs one look; catching it at invoice time costs a month of $3.
+
+## Next steps
+
+- [Metrics](/observability/metrics): full reference for the Metrics tab, including replica views
+- [Cost control](/pricing/cost-control): usage limits, replica limits, and serverless in detail
+- [Scaling](/deployments/scaling): horizontal scaling with replicas and multi-region deployment
+- [Understanding your bill](/pricing/understanding-your-bill): how subscription fees and usage combine on your invoice

--- a/content/guides/roll-back-bad-deploy.md
+++ b/content/guides/roll-back-bad-deploy.md
@@ -1,0 +1,120 @@
+---
+title: Roll Back a Bad Deploy Fast
+description: How to revert a broken deployment on Railway in under a minute. Covers rollback vs redeploy vs restart, image retention limits, and healthcheck-gated deploys that stop bad code before it goes live.
+date: "2026-07-29"
+tags:
+  - deployments
+  - rollback
+  - incident-response
+  - healthchecks
+topic: infrastructure
+---
+
+A rollback on Railway restores a previous deployment's Docker image and its custom variables as a new active deployment. There is no rebuild, so it completes in seconds. When a deploy breaks production, rolling back is almost always faster than pushing a fix.
+
+Rollback is one of three recovery actions Railway gives you, alongside redeploy and restart. This guide covers when each one applies, plus how to configure healthcheck-gated deploys so a broken release never receives traffic.
+
+## Roll back from the dashboard
+
+1. Open your project and click the affected service.
+2. Go to the **Deployments** tab.
+3. Find the last known-good deployment in the list.
+4. Click the three dots at the end of that deployment and select **Rollback**.
+5. Confirm the rollback.
+
+Railway restores both the Docker image and the custom variables from that deployment, so if the outage was caused by a bad environment variable change rather than bad code, the rollback reverts that too.
+
+That stored image is what makes rollback fast: there's no build step, and the rollback is live as soon as the container starts.
+
+## Which deployments can you roll back to?
+
+Rollback depends on Railway still having the old image. Railway retains images for a period after a deployment is removed, based on your plan:
+
+| Plan | Image retention |
+| --- | --- |
+| Free / Trial | 24 hours |
+| Hobby | 72 hours |
+| Pro | 120 hours |
+| Enterprise | 360 hours |
+
+Deployments older than your plan's retention window cannot be restored, and the **Rollback** option will not appear on them. For those, use **Redeploy** instead: it rebuilds the image from the deployment's original source code with its original variables. The result is the same version of your app, but you wait for a build.
+
+See the [image retention policy](/pricing/plans#image-retention-policy) for details.
+
+## Rollback vs redeploy vs restart
+
+Railway has three recovery actions. Picking the right one saves time.
+
+| Action | What it does | Build? | Use when |
+| --- | --- | --- | --- |
+| **Rollback** | Restores a previous deployment's image and variables | No | The latest deploy broke something and an older version worked |
+| **Redeploy** | Creates a new deployment from the same source and configuration | Yes | The image expired from retention, or you want a fresh build of the same commit |
+| **Restart** | Restarts the current deployment's existing container | No | The app wedged at runtime (memory leak, stuck connection) but the code is fine |
+
+Redeploy and restart are available from the same three-dots menu on the Deployments tab, and restart also appears inline on a `Crashed` deployment. Before reaching that state, Railway automatically restarts crashed deployments up to 10 times, depending on your [restart policy](/deployments/restart-policy), then marks them `Crashed` and notifies project members by email and [webhook](/observability/webhooks).
+
+One more distinction: **Redeploy** on a deployment reuses that deployment's exact code and configuration. To deploy the latest commit from your default branch instead, open the Command Palette (`CMD + K`) and choose "Deploy Latest Commit".
+
+## Roll back or redeploy from the CLI
+
+The dashboard is the only place to roll back to an arbitrary older deployment. The CLI covers the redeploy and restart cases:
+
+```bash
+# Redeploy the most recent deployment (triggers a rebuild)
+railway redeploy --service backend --yes
+
+# Restart the current deployment without rebuilding
+railway restart --service backend --yes
+```
+
+`railway restart` reuses the existing image and waits for the deployment to become healthy before the command completes. `railway redeploy` creates a new deployment from the same source, which includes a build.
+
+To inspect deployment history and grab IDs for log correlation:
+
+```bash
+# List recent deployments with IDs, statuses, and timestamps
+railway deployment list
+
+# View logs for a specific deployment
+railway logs <deployment-id>
+```
+
+`railway deployment list --json` is useful in scripts, for example to fetch the latest deployment ID with `jq`.
+
+## Prevent bad deploys with a healthcheck
+
+A rollback fixes the incident after users saw it. A healthcheck-gated deploy prevents the incident.
+
+When a service has a healthcheck path configured, Railway queries that endpoint on every new deployment and only switches traffic once it returns HTTP `200`. If the endpoint does not return `200` within the timeout, the deploy is marked failed and the previous deployment keeps serving traffic.
+
+To set it up:
+
+1. Add an endpoint to your app (for example `/health`) that returns status `200` when the app is ready. Your app must listen on the `PORT` variable Railway injects, since the healthcheck targets that port.
+2. In the service settings, set the healthcheck path to `/health`.
+3. Optionally adjust the timeout. The default is 300 seconds; change it in settings or with the `RAILWAY_HEALTHCHECK_TIMEOUT_SEC` variable.
+
+Two caveats:
+
+- The healthcheck runs only at deploy time. Railway does not monitor the endpoint continuously after the deployment goes live.
+- Services with an attached [volume](/volumes) cannot run two deployments at once, so a volume-backed service has a brief window of downtime on every deploy even with a healthcheck configured.
+
+Healthcheck requests come from the hostname `healthcheck.railway.app`. If your framework restricts allowed hosts, add it to the allowlist or the check will fail with errors like "failed with service unavailable".
+
+See [healthchecks](/deployments/healthchecks) for full configuration details.
+
+## What to do when a deploy goes bad
+
+This order minimizes downtime:
+
+1. **Confirm the deploy is the cause.** Check whether errors started right after the latest deployment went live. Deployment timestamps are on the Deployments tab.
+2. **Roll back first, debug second.** Click the three dots on the last good deployment and confirm the rollback. Users stop seeing errors in seconds.
+3. **Diagnose from the failed deployment's logs.** The failed deployment and its build and runtime logs remain available after the rollback.
+4. **Fix forward.** Push the corrected commit. The new deploy replaces the rolled-back one through your normal flow.
+5. **Add a healthcheck if you did not have one.** If the bad deploy would have failed a `/health` probe, a healthcheck would have blocked it automatically.
+
+## Next steps
+
+- [Debug a production incident with logs, metrics, and traces](/guides/debug-production-incident)
+- [Deployment actions](/deployments/deployment-actions)
+- [Healthchecks](/deployments/healthchecks)
+- [Set up alerts for crashes and failed deploys](/guides/alerts-crashes-failed-deploys)

--- a/content/guides/rotate-credentials-zero-downtime.md
+++ b/content/guides/rotate-credentials-zero-downtime.md
@@ -1,0 +1,161 @@
+---
+title: Rotate API Keys and Database Credentials Without Downtime
+description: Use the dual-key overlap pattern, staged redeploys, and reference variables to rotate secrets on Railway with zero downtime.
+date: "2026-07-29"
+tags:
+  - secrets
+  - variables
+  - security
+  - deployments
+topic: infrastructure
+---
+
+Credential rotation means replacing a secret with a new one and revoking the old one. The zero-downtime version has one rule: at no point may a running service hold a credential that has already been revoked. You get that with an overlap window: a period where the old and new credentials are both valid. Issue the new credential, move your services onto it, verify, then revoke the old one. Never the other way around.
+
+Building that overlap on Railway comes down to three mechanics: how variable changes propagate through staged changes, how to make the redeploy itself zero-downtime, and how to rotate third-party API keys and database passwords with the dual-key overlap pattern. For how to store secrets in the first place, see [Managing Secrets on Railway](/guides/managing-secrets-on-railway).
+
+## How variable changes apply on Railway
+
+Rotation on Railway is a variable update plus a redeploy, so it helps to know exactly when each happens.
+
+Adding, updating, or removing a variable creates a set of [staged changes](/deployments/staged-changes). Nothing hits your running services until you click **Deploy** on the changeset. When you do, every affected service is redeployed with the new values. This is what makes batch rotation safe: you can update five variables across three services, review the diff in one place, and apply everything in a single deploy.
+
+Two useful variations:
+
+- **Commit without redeploying.** Hold `Alt` while clicking **Deploy** to commit the staged changes without triggering a redeploy. The new values apply on the next deploy of each service.
+- **From the CLI**, `railway variable set` sets the variable and triggers a redeploy. Pass `--skip-deploys` to skip the redeploy:
+
+```bash
+railway variable set API_KEY=new-value --service backend --skip-deploys
+```
+
+Containers read environment variables only at startup, so a variable change never restarts a running container by itself; the new value only exists inside the new deployment. That is the property the rest of this guide builds on.
+
+## Make the redeploy itself zero-downtime
+
+A rotation forces a redeploy, so the redeploy must not drop traffic. Two settings control this.
+
+**Configure a healthcheck.** Set a healthcheck path in your service settings. When a healthcheck is configured, Railway queries the endpoint until it returns HTTP `200`, and only then makes the new deployment active and the old one inactive. Without a healthcheck, there is no guarantee the new container is ready before it starts receiving traffic. See [Healthchecks](/deployments/healthchecks).
+
+Your healthcheck should verify the new credential works. If the endpoint checks a database connection, a deploy with a bad `DATABASE_URL` fails its healthcheck and the old deployment keeps serving, so the rotation fails safe.
+
+**Configure overlap and draining.** By default Railway keeps one deployment per service and stops the old one once the new one is live. Two settings on the service let the versions overlap:
+
+- `RAILWAY_DEPLOYMENT_OVERLAP_SECONDS` keeps the previous deployment active for a window after the new one goes live (default `0`).
+- `RAILWAY_DEPLOYMENT_DRAINING_SECONDS` controls how long the old deployment gets between SIGTERM and SIGKILL, so in-flight requests finish (default `0`).
+
+Both can also be set in [config as code](/config-as-code/reference#overlap-seconds). Details in [Deployment Teardown](/deployments/deployment-teardown).
+
+One caveat: services with an attached volume cannot run two deployments at once, so a redeploy of a volume-backed service always has a small window of downtime. This is why the database rotation flow below never redeploys the database service itself.
+
+## Rotate a third-party API key
+
+The dual-key overlap pattern for a provider key (Stripe, SendGrid, OpenAI, and so on):
+
+1. **Issue the new key** in the provider's dashboard. Most providers let multiple keys coexist; both keys are now valid.
+2. **Update the variable on Railway.** In the service's Variables tab, edit `API_KEY` to the new value, or use the CLI:
+
+   ```bash
+   railway variable set STRIPE_SECRET_KEY=sk_live_new... --service backend
+   ```
+
+3. **Deploy the staged change.** The service redeploys with the new key. With a healthcheck configured, the old deployment keeps serving until the new one passes.
+4. **Verify.** Check deploy logs and confirm requests to the provider succeed from the new deployment.
+5. **Revoke the old key** at the provider. Only do this after the new deployment is active and verified. Any lingering old container is past its draining window by then.
+
+The old key stays valid through steps 2 to 4, so the deployment cutover happens while both keys work. There is no moment where a live container holds a dead key.
+
+### Handle providers that allow only one active key
+
+Some providers invalidate the old key the instant you generate a new one. You cannot get a true overlap from the provider, but you can build one in your application: accept a primary and a secondary key, and fall back when the primary is rejected.
+
+```js
+// apiKeys.js
+const KEYS = [process.env.API_KEY_PRIMARY, process.env.API_KEY_SECONDARY].filter(Boolean);
+
+export async function providerFetch(url, options = {}) {
+  let lastResponse;
+  for (const key of KEYS) {
+    lastResponse = await fetch(url, {
+      ...options,
+      headers: { ...options.headers, Authorization: `Bearer ${key}` },
+    });
+    // Retry with the next key only on auth failures.
+    if (lastResponse.status !== 401 && lastResponse.status !== 403) {
+      return lastResponse;
+    }
+  }
+  return lastResponse;
+}
+```
+
+The rotation flow becomes: set `API_KEY_SECONDARY` to the current key and deploy, regenerate the key at the provider, set `API_KEY_PRIMARY` to the new value and deploy. During the gap between regeneration and the redeploy, running containers fail on the stale primary and succeed on the secondary. Once the new deployment is verified, clear `API_KEY_SECONDARY`.
+
+## Use reference variables so one update fans out
+
+If three services use the same key, do not paste it into each one. Store it once as a project-level shared variable and reference it from each service:
+
+```
+API_KEY=${{ shared.API_KEY }}
+```
+
+Rotation is then a single edit. Update the shared variable in Project Settings, and the staged changeset covers every service that references it. One deploy moves every consumer to the new key together, so no service is left running on the old key when you revoke it. See [Reference variables](/variables#reference-variables).
+
+The same syntax works across services, which matters for databases: app services should consume `DATABASE_URL=${{ Postgres.DATABASE_URL }}` rather than a pasted connection string, so a credential change on the database service propagates to every consumer.
+
+## Rotate a database password
+
+Rotating a database credential has an extra step: the variable on Railway and the actual password inside the database engine must change together. The safe order uses a second database role as the overlap.
+
+Using Railway's [PostgreSQL](/databases/postgresql) template as the example:
+
+1. **Create a new role** with the same privileges, alongside the existing one. Connect with `railway connect` and run:
+
+   ```sql
+   CREATE ROLE app_v2 WITH LOGIN PASSWORD 'new-strong-password';
+   GRANT ALL PRIVILEGES ON DATABASE railway TO app_v2;
+   GRANT ALL ON SCHEMA public TO app_v2;
+   GRANT ALL ON ALL TABLES IN SCHEMA public TO app_v2;
+   ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL ON TABLES TO app_v2;
+   ```
+
+   Both roles can now log in. This is your overlap window.
+
+2. **Update the connection variables on your app services** to use `app_v2`. If your apps reference the database's `DATABASE_URL`, update the database service's `PGUSER` and `PGPASSWORD` (and `DATABASE_URL` if it is not composed from them) with `--skip-deploys`, so the database service itself is not restarted:
+
+   ```bash
+   railway variable set PGUSER=app_v2 PGPASSWORD=new-strong-password --service Postgres --skip-deploys
+   ```
+
+   The database engine does not read these variables after initialization; they exist so other services can reference them. Skipping the deploy also avoids restarting a volume-backed service, which always costs a few seconds of downtime.
+
+3. **Redeploy the app services.** Each one comes up connecting as `app_v2`, passes its healthcheck, and takes over. Old containers keep their existing connections as the old role until they are torn down.
+
+4. **Verify, then remove the old role:**
+
+   ```sql
+   REASSIGN OWNED BY app_v1 TO app_v2;
+   DROP ROLE app_v1;
+   ```
+
+If you cannot create a second role, the fallback is `ALTER USER ... PASSWORD` on the existing role. Established connections survive a password change, so running containers keep working until their pools open new connections. Change the password, immediately update the variables, and redeploy the app services. This gives a short window where a reconnect can fail, so prefer the dual-role pattern for production.
+
+## Rotating sealed variables
+
+[Sealed variables](/variables#sealed-variables) hide a value from the UI and API after you set it, which is a good default for production credentials; the Raw Editor can't touch them either. They rotate fine: edit the value from the variable's 3-dot menu and deploy. You cannot read the current value back, so verify the new credential works before revoking the old one.
+
+## Rotation checklist
+
+- A healthcheck is configured on every service that consumes the credential, and it exercises the credential.
+- The new credential is issued and valid before any variable changes.
+- Every consumer uses a reference variable, so one update covers all of them.
+- The staged changeset is reviewed and deployed in one batch.
+- The new deployments are active and verified before the old credential is revoked.
+- The old credential is revoked at the source: provider dashboard or `DROP ROLE`.
+
+## Next steps
+
+- [Managing Secrets on Railway](/guides/managing-secrets-on-railway)
+- [Healthchecks](/deployments/healthchecks)
+- [Staged Changes](/deployments/staged-changes)
+- [Variables](/variables)

--- a/content/guides/ship-logs-third-party.md
+++ b/content/guides/ship-logs-third-party.md
@@ -1,0 +1,249 @@
+---
+title: Ship Application Logs to a Third-Party Aggregator
+description: Build a log drain on Railway with a Vector forwarder service. Apps send logs over private networking, and Vector fans them out to any aggregator.
+date: "2026-07-29"
+tags:
+  - logging
+  - observability
+  - vector
+  - integrations
+topic: integrations
+---
+
+Railway retains logs for 7 to 90 days depending on your plan, but there is no built-in log drain setting that forwards stdout to an external intake URL. This guide builds the equivalent: a small [Vector](https://vector.dev) service that receives log events from your apps over [private networking](/networking/private-networking) and forwards them to any aggregator with an HTTP intake (Better Stack, Axiom, Grafana Loki, Datadog).
+
+If you want to instrument your app directly with a vendor SDK or OpenTelemetry instead, see [Connect a Third-Party Observability Tool](/guides/third-party-observability).
+
+## How the pattern works
+
+A log drain normally sits between your app and the aggregator: the platform copies stdout to an external URL. Railway does not do that copy for you, so the forwarder pattern recreates it with two pieces:
+
+1. Your app writes structured JSON logs to stdout as usual, so Railway's [log explorer](/observability/logs) keeps working.
+2. The app also sends a copy of each log event to a Vector service in the same environment, over the private network. Vector batches the events and delivers them to your aggregator.
+
+```
+┌──────────────── Project Environment ────────────────┐
+│                                                      │
+│  ┌─────────┐   stdout → Railway logs                 │
+│  │   app   │                                         │
+│  │ service │──── http://vector.railway.internal ──┐  │
+│  └─────────┘         (private network)            │  │
+│                                              ┌────▼──────┐
+│                                              │  vector   │──→ aggregator
+│                                              │  service  │    (public internet)
+│                                              └───────────┘
+└──────────────────────────────────────────────────────┘
+```
+
+Routing through Vector beats posting to the aggregator from every app:
+
+- **One credential, one egress point.** Only the Vector service holds the aggregator token and makes outbound requests.
+- **Batching and retries in one place.** Vector buffers, batches, and retries deliveries. Your app fires a request to the private network and moves on.
+- **Swap vendors without redeploying apps.** Changing aggregators means editing one Vector sink, not every service.
+- **Free traffic inside the environment.** App-to-Vector traffic goes over private networking, which does not count toward egress billing. You pay egress only once, from Vector to the aggregator.
+
+Private networking is scoped per environment, so deploy one Vector service per environment you want to drain.
+
+## Deploy the Vector service
+
+Create a directory with two files and deploy it as a new service in your project. Vector needs a config file, so deploy from a repository with a Dockerfile rather than from a bare Docker image. See [Dockerfiles](/builds/dockerfiles) for how Railway detects it.
+
+`Dockerfile`:
+
+```dockerfile
+FROM timberio/vector:latest-alpine
+
+COPY vector.yaml /etc/vector/vector.yaml
+
+CMD ["--config", "/etc/vector/vector.yaml"]
+```
+
+Pin a specific Vector version tag in production instead of `latest-alpine`.
+
+`vector.yaml`:
+
+```yaml
+sources:
+  app_logs:
+    type: http_server
+    # "[::]" binds IPv6 (and IPv4 on dual-stack hosts).
+    # Required: private networking resolves to IPv6 in legacy environments.
+    address: "[::]:9000"
+    decoding:
+      codec: json
+
+transforms:
+  stamp:
+    type: remap
+    inputs:
+      - app_logs
+    source: |
+      .received_at = now()
+
+sinks:
+  aggregator:
+    type: http
+    inputs:
+      - stamp
+    uri: "${SINK_URL}"
+    encoding:
+      codec: json
+    batch:
+      max_events: 100
+      timeout_secs: 2
+    request:
+      headers:
+        Authorization: "Bearer ${SINK_TOKEN}"
+```
+
+The `http` sink works with any aggregator that accepts JSON over HTTP. Vector also ships dedicated sinks (`loki`, `datadog_logs`, `axiom`, `elasticsearch`, and more) that handle vendor-specific formats; swap the sink block for one of those if your aggregator has one. See the <a href="https://vector.dev/docs/reference/configuration/sinks/" target="_blank">Vector sinks reference</a>.
+
+On the Vector service, set two variables:
+
+```
+SINK_URL=https://your-aggregator.example.com/ingest
+SINK_TOKEN=<your aggregator API token>
+```
+
+Vector interpolates `${SINK_URL}` and `${SINK_TOKEN}` from the environment at startup. It only needs to be reachable inside the environment, so do not add a public domain to this service.
+
+Two notes on the port:
+
+- Vector's own API defaults to port 8686, so this config uses 9000 for the log intake to avoid confusion.
+- Private networking does not require exposing or configuring the port in Railway. Other services reach Vector at `vector.railway.internal:9000` directly.
+
+## Send logs from your app
+
+Your app should keep writing JSON logs to stdout and also post copies to Vector. That forwarder must never take your app down: send in the background, batch, and swallow delivery errors.
+
+Here is a Node.js logger that does both. It uses only built-in modules, so there is nothing to install.
+
+`logger.js`:
+
+```javascript
+const VECTOR_URL = process.env.VECTOR_URL ?? "";
+
+const meta = {
+  service: process.env.RAILWAY_SERVICE_NAME,
+  environment: process.env.RAILWAY_ENVIRONMENT_NAME,
+  deployment: process.env.RAILWAY_DEPLOYMENT_ID,
+  replica: process.env.RAILWAY_REPLICA_ID,
+};
+
+const MAX_BATCH = 100;
+const FLUSH_MS = 1000;
+
+let queue = [];
+let timer = null;
+
+async function flush() {
+  timer = null;
+  if (queue.length === 0 || !VECTOR_URL) return;
+  const batch = queue;
+  queue = [];
+  const body = batch.map((e) => JSON.stringify(e)).join("\n");
+  try {
+    await fetch(VECTOR_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-ndjson" },
+      body,
+    });
+  } catch {
+    // Never crash or block the app because the forwarder is unreachable.
+    // stdout already has the log line, so nothing is lost from Railway logs.
+  }
+}
+
+function schedule() {
+  if (queue.length >= MAX_BATCH) {
+    void flush();
+  } else if (!timer) {
+    timer = setTimeout(() => void flush(), FLUSH_MS);
+    timer.unref();
+  }
+}
+
+function log(level, message, fields = {}) {
+  const entry = {
+    level,
+    message,
+    timestamp: new Date().toISOString(),
+    ...meta,
+    ...fields,
+  };
+  // Single-line JSON so Railway parses it as a structured log.
+  process.stdout.write(JSON.stringify(entry) + "\n");
+  if (VECTOR_URL) {
+    queue.push(entry);
+    schedule();
+  }
+}
+
+export const logger = {
+  debug: (msg, fields) => log("debug", msg, fields),
+  info: (msg, fields) => log("info", msg, fields),
+  warn: (msg, fields) => log("warn", msg, fields),
+  error: (msg, fields) => log("error", msg, fields),
+  flush,
+};
+```
+
+Use it in a minimal HTTP server, `server.js`:
+
+```javascript
+import { createServer } from "node:http";
+import { logger } from "./logger.js";
+
+const port = Number(process.env.PORT) || 3000;
+
+const server = createServer((req, res) => {
+  logger.info("request", { method: req.method, path: req.url });
+  res.writeHead(200, { "Content-Type": "application/json" });
+  res.end(JSON.stringify({ ok: true }));
+});
+
+server.listen(port, () => {
+  logger.info("server started", { port });
+});
+
+process.on("SIGTERM", async () => {
+  await logger.flush();
+  server.close(() => process.exit(0));
+});
+```
+
+On the app service, set:
+
+```
+VECTOR_URL=http://vector.railway.internal:9000
+```
+
+Use `http://`, not `https://`: private network traffic is already encrypted by WireGuard, and Vector is not serving TLS on that port. That URL assumes a service named `vector`; if you used a different name, adjust the hostname, since the internal DNS name is always `<service-name>.railway.internal`.
+
+The `RAILWAY_SERVICE_NAME`, `RAILWAY_ENVIRONMENT_NAME`, `RAILWAY_DEPLOYMENT_ID`, and `RAILWAY_REPLICA_ID` values are injected automatically into every deployment. Stamping them on each event lets you filter by service and environment in the aggregator. See the [variables reference](/variables/reference) for the full list.
+
+Any language works the same way: emit single-line JSON to stdout, and POST newline-delimited JSON to `http://vector.railway.internal:9000` in the background. In Python, for example, a `logging.Handler` that appends to a queue and a background thread that posts batches gives you the same behavior.
+
+## Failure behavior and limits
+
+- **stdout is the source of truth.** If Vector is down or redeploying, the app keeps logging to stdout and Railway retains those logs normally. You lose forwarding for that window, not logs.
+- **Private networking is runtime only.** `vector.railway.internal` does not resolve during builds or in code that runs at build time. Only send from the running app.
+- **Railway rate-limits logging at 500 log lines per second per replica.** The forwarder does not raise that limit, since events still go through stdout. If you exceed it, sample or reduce verbosity. See [logging throughput](/observability/logs#logging-throughput).
+- **Egress is billed once.** App-to-Vector traffic is free. Vector-to-aggregator traffic is billed as egress at $0.05 per GB, so high log volume shows up on your bill. Vector's `batch` settings and compression options on most sinks reduce request overhead.
+- **Vector is cheap to run.** A forwarder handling moderate volume idles at well under half a GB of RAM, and Railway bills resources by actual usage.
+
+## Verify the pipeline
+
+1. Deploy both services and confirm the Vector deploy logs show the `http_server` source listening.
+2. Hit your app's public URL a few times.
+3. Check the app's logs in Railway: you should see the structured `request` lines.
+4. Check your aggregator: the same events should arrive within a few seconds, carrying `service`, `environment`, and `received_at` fields.
+
+If events show up in Railway logs but not the aggregator, read the Vector service logs. Vector logs delivery errors, including bad tokens and unreachable sink URLs, to its own stdout.
+
+## Next steps
+
+- [Connect a Third-Party Observability Tool](/guides/third-party-observability) for the SDK and OpenTelemetry approaches to metrics and traces.
+- [Deploy an OpenTelemetry Collector Stack](/guides/deploy-an-otel-collector-stack) for a self-hosted collector with Grafana dashboards.
+- [Set Up a Datadog Agent in Railway](/guides/set-up-a-datadog-agent) if you are all-in on Datadog and want traces and metrics too.
+- [Logs](/observability/logs) for structured logging, retention, and the log explorer.

--- a/content/guides/ship-on-merge-pr-canaries.md
+++ b/content/guides/ship-on-merge-pr-canaries.md
@@ -1,0 +1,156 @@
+---
+title: Deploy on Merge with PR Environments as Canaries
+description: Set up a trunk-based promotion workflow on Railway. Every pull request gets a canary environment; every merge to main deploys production automatically.
+date: "2026-07-29"
+tags:
+  - ci-cd
+  - environments
+  - deployment
+  - github
+topic: infrastructure
+---
+
+Deploy on merge is a trunk-based promotion workflow. Every pull request spins up a disposable copy of your stack where the change is validated. Merging to `main` is the promotion step: Railway builds the merged commit and deploys it to production, with no manual deploy button and no separate release process.
+
+The PR environment is the canary. It runs the exact change that is about to land, on real infrastructure, before production ever sees it. If the canary looks wrong, you close or fix the PR. If it looks right, the merge itself is the deploy.
+
+Setting this up assumes PR environments already work. If you have not enabled them before, read [Preview Deployments with PR Environments](/guides/preview-deployments-with-pr-environments) first. From there, this guide wires production to deploy on merge, gates that deploy on CI, validates changes in PR environments, cuts over with zero downtime, and rolls back when a bad merge lands anyway.
+
+## How the pipeline fits together
+
+The full lifecycle of a change looks like this:
+
+1. You open a pull request against `main`.
+2. Railway creates a temporary [PR environment](/environments#pr-environments-1) that replicates your base environment and deploys the PR branch into it.
+3. You (and your reviewers) validate the change in the PR environment. CI runs in parallel on GitHub.
+4. You merge the PR. Railway deletes the PR environment.
+5. The push to `main` triggers a production deployment. With **Wait for CI** enabled, Railway holds the deployment in a `WAITING` state until your GitHub Actions pass.
+6. With a healthcheck configured, Railway keeps the old deployment serving traffic until the new one returns `200`, then cuts over.
+7. If something slips through, you roll back to the previous deployment in one action.
+
+Each step maps to a Railway setting. The rest of this guide configures them in order.
+
+## Step 1: Deploy production on merge to main
+
+Services linked to a GitHub repository automatically deploy when commits are pushed to the connected branch. A merged PR is a push to `main`, so this is the whole promotion mechanism.
+
+1. Open your production service settings.
+2. Under the GitHub integration, set the trigger branch to `main`.
+3. Confirm automatic deployments are enabled.
+
+See [Controlling GitHub Autodeploys](/deployments/github-autodeploys) for the requirements. The important one: at least one project member must have a connected GitHub account with contributor access to the repository, or autodeploy cannot be enabled.
+
+If your production environment inherits from a persistent staging environment instead, the same mechanism applies. Point the staging service at `main` and promote from staging to production by [syncing environments](/environments#sync-environments).
+
+## Step 2: Enable PR environments as the canary stage
+
+In Project Settings, open the Environments tab and enable PR environments. From then on, every PR opened by a project member gets its own temporary environment with all services, networking, and variables copied from your base environment. The environment is deleted automatically when the PR is merged or closed, so canaries do not accumulate.
+
+Two behaviors matter for the canary role:
+
+- **The base environment defines what the canary replicates.** By default that is production. Whatever variables and services exist in the base at PR-open time are what the canary runs against.
+- **PRs from outside contributors do not deploy.** Railway will not deploy a PR branch from a user who is not in your workspace or invited to your project with their GitHub account connected. This is a safety property: an external PR cannot spin up infrastructure or read your variables.
+
+For monorepos, enable [Focused PR environments](/environments#focused-pr-environments) so the canary only deploys the services whose files changed in the PR. A frontend-only PR does not need a fresh backend, and skipped services can still be deployed manually from the canvas if you need them.
+
+To get a shareable URL for each canary automatically, make sure the services in your base environment use Railway-provided domains: PR environment services only receive domains automatically when their base counterparts do.
+
+## Step 3: Gate the merge deploy with Wait for CI
+
+Autodeploy on its own deploys every push to `main`, including one where your tests fail. **Wait for CI** closes that gap: Railway holds the production deployment in a `WAITING` state until all GitHub Actions workflows on that commit succeed. If any workflow fails, the deployment is `SKIPPED` and production keeps running the previous version.
+
+Requirements:
+
+- Your repository has a GitHub workflow.
+- The workflow runs on push to the trigger branch:
+
+```yaml
+# .github/workflows/ci.yml
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - run: npm ci
+      - run: npm test
+```
+
+When the workflow satisfies these requirements, a **Wait for CI** toggle appears in your service settings. Turn it on. The `pull_request` trigger in the same workflow gives you the standard GitHub merge gate on the PR itself, so untested code does not reach `main` in the first place.
+
+See [Wait for CI](/deployments/github-autodeploys#wait-for-ci) for details, including the GitHub App permissions the feature needs.
+
+## Step 4: Cut over with zero downtime
+
+A merge deploy replaces a live production deployment, so configure a [healthcheck](/deployments/healthchecks). With a healthcheck path set, Railway queries the endpoint on the new deployment until it returns HTTP `200`, and only then routes traffic to it and retires the old deployment. Without one, there is no readiness gate on the cutover.
+
+Your server needs an endpoint that returns `200` only when it is ready to serve:
+
+```bash
+npm install express
+```
+
+```js
+// server.js
+const express = require("express");
+
+const app = express();
+
+app.get("/health", (req, res) => {
+  // Add real readiness checks here: database connectivity,
+  // required variables present, migrations applied.
+  res.status(200).json({ status: "ok" });
+});
+
+app.get("/", (req, res) => {
+  res.send(`Running commit ${process.env.RAILWAY_GIT_COMMIT_SHA || "local"}`);
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  console.log(`Listening on ${port}`);
+});
+```
+
+Set the healthcheck path to `/health` in your service settings. Railway performs the check against the `PORT` variable it injects, so listen on it. That check times out after 300 seconds by default; if the endpoint never returns `200` in that window, the deployment is marked failed and the previous one keeps serving traffic.
+
+One caveat: services with an attached volume cannot run two deployments at once, so a redeploy of a volume-backed service has a brief window of downtime even with a healthcheck configured. Keep stateful services (databases, queues) on their own service so your stateless application services get the zero-downtime path.
+
+The `RAILWAY_GIT_COMMIT_SHA` variable in the example above is injected automatically on every deployment. Expose it from an endpoint or log it at startup to confirm which commit production is running after a merge.
+
+## Step 5: Roll back a bad merge
+
+Canaries and CI reduce bad deploys; they do not eliminate them. When a bad merge reaches production:
+
+1. Open the production service and go to the Deployments tab.
+2. Click the three dots on the last good deployment and select **Rollback**.
+
+Rollback restores the previous deployment's Docker image and custom variables. It does not rebuild, so it is fast, and it does not depend on reverting the commit in Git. Deployments older than your plan's image retention policy cannot be restored this way. See [Deployment Actions](/deployments/deployment-actions#rollback).
+
+After rolling back, revert or fix-forward the offending commit in Git. Until `main` is fixed, the next merge would redeploy the bad code.
+
+## Keep canaries honest
+
+A canary is only useful if it resembles production. Two habits help:
+
+- **Sync long-lived PR environments.** If the base environment changes while a PR is open (a new variable, a new service), the canary is stale. Use [Sync environments](/environments#sync-environments) to pull those changes into the PR environment instead of closing and reopening the PR.
+- **Branch the canary's state, not just its code.** By default the canary copies production's variables, which may include a production `DATABASE_URL`. Use per-environment variables, or provision a per-PR database branch from your CI pipeline, so canary writes stay out of production data. [GitHub Actions PR Environment](/guides/github-actions-pr-environment) shows a CLI-driven variant of the workflow that injects a per-PR database URL into each environment.
+
+Inside your application, `RAILWAY_ENVIRONMENT_NAME` tells you which environment the code is running in, which is useful for disabling outbound side effects (emails, payment calls, webhooks) in canaries.
+
+## Next steps
+
+- [Preview Deployments with PR Environments](/guides/preview-deployments-with-pr-environments)
+- [Controlling GitHub Autodeploys](/deployments/github-autodeploys)
+- [Healthchecks](/deployments/healthchecks)
+- [Deployment Actions](/deployments/deployment-actions)

--- a/content/guides/storage-buckets-guide.md
+++ b/content/guides/storage-buckets-guide.md
@@ -1,7 +1,7 @@
 ---
 title: Use Storage Buckets for Uploads, Exports, and Assets
 description: Set up Railway storage buckets for file uploads via presigned URLs, background export generation, and asset serving through a backend proxy.
-date: "2026-03-30"
+date: "2026-07-29"
 tags:
   - architecture
   - storage
@@ -162,5 +162,6 @@ For high-traffic asset serving, consider using presigned GET URLs instead to avo
 ## Next steps
 
 - [Storage Buckets](/storage-buckets) - Full reference for bucket configuration, CORS, and credential injection
+- [Use Object Storage for AI Agent Outputs](/guides/object-storage-for-ai-agents) - The same patterns applied to agent artifacts, transcripts, and reports
 - [Running a Cron Job](/cron-jobs) - Schedule report generation
 - [Private Networking](/networking/private-networking) - Connect services over the internal network

--- a/content/guides/streaming-ai-responses.md
+++ b/content/guides/streaming-ai-responses.md
@@ -1,7 +1,7 @@
 ---
 title: Stream AI Responses to a Frontend with Server-Sent Events
 description: Stream LLM tokens from an API service to a frontend using Server-Sent Events on Railway. Covers Express and Hono server implementations, client-side consumption, and reconnection handling.
-date: "2026-04-14"
+date: "2026-07-29"
 tags:
   - frontend
   - ai
@@ -28,6 +28,10 @@ The frontend displays tokens as they arrive, giving the user immediate feedback 
 
 ### Express
 
+```bash
+npm install express @anthropic-ai/sdk
+```
+
 ```javascript
 import express from 'express';
 import Anthropic from '@anthropic-ai/sdk';
@@ -48,7 +52,7 @@ app.post('/api/chat', async (req, res) => {
   });
 
   const stream = client.messages.stream({
-    model: 'claude-sonnet-4-20250514',
+    model: 'claude-opus-4-8',
     max_tokens: 1024,
     messages,
   });
@@ -75,6 +79,10 @@ app.listen(port, '0.0.0.0', () => {
 
 ### Hono
 
+```bash
+npm install hono @hono/node-server @anthropic-ai/sdk
+```
+
 ```typescript
 import { Hono } from 'hono';
 import { streamSSE } from 'hono/streaming';
@@ -89,10 +97,13 @@ app.post('/api/chat', async (c) => {
 
   return streamSSE(c, async (stream) => {
     const response = client.messages.stream({
-      model: 'claude-sonnet-4-20250514',
+      model: 'claude-opus-4-8',
       max_tokens: 1024,
       messages,
     });
+
+    // Stop paying for tokens the client will never see
+    stream.onAbort(() => response.abort());
 
     response.on('text', async (text) => {
       await stream.writeSSE({ data: JSON.stringify({ text }) });
@@ -166,7 +177,7 @@ await streamChat(
 The <a href="https://sdk.vercel.ai/" target="_blank">Vercel AI SDK</a> provides higher-level React hooks for streaming. It works with any hosting provider, not just Vercel:
 
 ```jsx
-import { useChat } from 'ai/react';
+import { useChat } from '@ai-sdk/react';
 
 export default function Chat() {
   const { messages, input, handleInputChange, handleSubmit } = useChat({
@@ -192,7 +203,7 @@ SSE streaming works on Railway without special configuration.
 
 1. Deploy your API service from [GitHub](/deployments/github-autodeploys) or the [CLI](/cli).
 2. Set the `ANTHROPIC_API_KEY` (or `OPENAI_API_KEY`) as a [service variable](/variables).
-3. [Generate a domain](/networking/public-networking#railway-provided-domain) for your service.
+3. [Generate a domain](/networking/domains) for your service.
 
 Ensure your application binds to `0.0.0.0` and reads the port from the `PORT` environment variable.
 

--- a/content/guides/structured-logging-production.md
+++ b/content/guides/structured-logging-production.md
@@ -1,0 +1,271 @@
+---
+title: Set Up Structured Logging for a Production App
+description: Emit JSON logs from your Railway services so the Log Explorer can parse, color, and filter them by level and custom attributes.
+date: "2026-07-29"
+tags:
+  - logging
+  - observability
+  - monitoring
+  - debugging
+topic: infrastructure
+---
+
+Structured logging means emitting each log line as a single-line JSON object instead of plain text. Railway parses these objects automatically: the `level` field colors the line in the Log Explorer, the `message` field becomes the log text, and every other field becomes a custom attribute you can filter on with `@name:value` queries.
+
+This guide sets that up for a Node.js service with Pino, shows equivalents for Python and Go, and queries the results in the Log Explorer.
+
+## How Railway parses your logs
+
+Railway captures everything your service writes to standard output and standard error. If one of those lines is valid JSON, Railway reads these fields:
+
+```json
+{
+  "message": "A minimal structured log",
+  "level": "info",
+  "customAttribute": "value"
+}
+```
+
+- `message` is the log content shown in the explorer.
+- `level` is the severity: `debug`, `info`, `warn`, or `error`. Lines with a level are colored accordingly.
+- Any other field becomes a queryable attribute, including arrays and numbers.
+
+Railway normalizes common variations so most logging libraries work without custom configuration:
+
+- `msg` is converted to `message`
+- Levels are lowercased and matched to the closest of `debug`, `info`, `warn`, `error`
+- Plain-text lines are wrapped as `{"message": "...", "level": "..."}`
+- Lines written to stdout default to `level: info`; lines written to stderr become `level: error`
+
+The one hard requirement: each JSON object must be emitted on a single line, so disable pretty-printing in production. In return, multi-line content like stack traces stays intact inside the `message` field, where plain-text logging would split it into separate lines.
+
+## Set up Pino in a Node.js service
+
+Pino is a JSON logger for Node.js. Install it along with `pino-http` for request logging:
+
+```bash
+npm install express pino pino-http
+```
+
+Pino emits numeric levels (`"level": 30`) by default. Configure it to emit label strings instead so Railway can match them:
+
+```javascript
+// logger.js
+import { pino } from "pino";
+
+export const logger = pino({
+  // Emit "level": "info" instead of "level": 30
+  formatters: {
+    level: (label) => ({ level: label }),
+  },
+  // Emit "message" instead of "msg" (Railway normalizes "msg" too,
+  // but "message" matches the parsed format exactly)
+  messageKey: "message",
+});
+```
+
+Use it in an Express app, with a request logger that attaches a request ID to every line:
+
+```javascript
+// server.js
+import express from "express";
+import { pinoHttp } from "pino-http";
+import { randomUUID } from "node:crypto";
+import { logger } from "./logger.js";
+
+const app = express();
+app.use(express.json());
+
+app.use(
+  pinoHttp({
+    logger,
+    genReqId: (req) => req.headers["x-request-id"] ?? randomUUID(),
+    // Put the request ID at the top level so it is filterable
+    // as @requestId:<id> in the Log Explorer
+    customProps: (req) => ({ requestId: req.id }),
+  }),
+);
+
+app.post("/checkout", (req, res) => {
+  const start = Date.now();
+  const { userId, productId } = req.body ?? {};
+
+  // Custom fields become filterable attributes: @userId:456
+  req.log.info({ userId, productId }, "checkout started");
+
+  try {
+    // ... process the order ...
+    req.log.info(
+      { userId, productId, durationMs: Date.now() - start },
+      "checkout completed",
+    );
+    res.json({ ok: true });
+  } catch (err) {
+    // Pino serializes the error, stack trace included, into one line
+    req.log.error({ err, userId }, "checkout failed");
+    res.status(500).json({ ok: false });
+  }
+});
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => {
+  logger.info({ port: Number(port) }, "server listening");
+});
+```
+
+That `import` syntax needs `"type": "module"` set in your `package.json`.
+
+A checkout request now produces lines like this (Pino's `time`, `pid`, and `req` fields trimmed for brevity):
+
+```json
+{"level":"info","message":"checkout completed","userId":456,"productId":123,"durationMs":84,"requestId":"a1b2c3d4"}
+```
+
+Keep pretty-printing out of production. If you use `pino-pretty` locally, run it as a dev-only transport:
+
+```javascript
+const logger = pino({
+  formatters: { level: (label) => ({ level: label }) },
+  messageKey: "message",
+  transport:
+    process.env.NODE_ENV !== "production"
+      ? { target: "pino-pretty" }
+      : undefined,
+});
+```
+
+## Set up structlog in a Python service
+
+Install structlog:
+
+```bash
+pip install structlog
+```
+
+Configure it to emit single-line JSON with the fields Railway expects. structlog names the log text `event` by default, so rename it to `message`:
+
+```python
+# logger.py
+import structlog
+
+structlog.configure(
+    processors=[
+        structlog.processors.add_log_level,
+        structlog.processors.EventRenamer("message"),
+        structlog.processors.JSONRenderer(),
+    ]
+)
+
+log = structlog.get_logger()
+
+log.info("checkout completed", user_id=456, product_id=123, duration_ms=84)
+```
+
+Output:
+
+```json
+{"user_id": 456, "product_id": 123, "duration_ms": 84, "level": "info", "message": "checkout completed"}
+```
+
+## Set up slog in a Go service
+
+The standard library's `log/slog` package needs no dependencies. Its JSON handler emits `msg` and uppercase levels, both of which Railway normalizes automatically:
+
+```go
+package main
+
+import (
+	"log/slog"
+	"os"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	logger.Info("checkout completed", "userId", 456, "durationMs", 84)
+}
+```
+
+Output:
+
+```json
+{"time":"2026-07-29T12:00:00Z","level":"INFO","msg":"checkout completed","userId":456,"durationMs":84}
+```
+
+Railway converts `msg` to `message` and matches `INFO` to `info`.
+
+## Query structured logs in the Log Explorer
+
+Open the **Observability** tab in your project to reach the Log Explorer, which searches across all services in the environment. The same filter syntax works in a single deployment's log panel.
+
+Filter by level:
+
+```text
+@level:error
+```
+
+Filter by a custom attribute your app emitted:
+
+```text
+@userId:456
+```
+
+Combine filters with `AND`, `OR`, and `-` (negation), and group with parentheses:
+
+```text
+@level:error AND "checkout failed"
+```
+
+```text
+@productId:123 AND (@level:warn OR @level:error)
+```
+
+Numeric attributes support comparison operators and ranges:
+
+```text
+@durationMs:>500
+```
+
+```text
+@durationMs:100..500
+```
+
+Array attributes are filterable by element:
+
+```text
+@roles[0]:editor
+```
+
+In the environment-wide view, scope by service or exclude noisy ones:
+
+```text
+@service:<service_id> AND @level:error
+```
+
+```text
+-@service:<postgres_service_id>
+```
+
+To trace one request across log lines, filter on the request ID your logger attached:
+
+```text
+@requestId:a1b2c3d4
+```
+
+Right-click any matched line and select **View in Context** to see the surrounding logs.
+
+## Production practices
+
+**Stay under the rate limit.** Railway allows 500 log lines per replica per second; beyond that, lines are dropped and a warning appears in your logs. Structured logging helps here: one JSON object with ten fields is one line, where a pretty-printed object would be ten. Dropping `debug` level in production and sampling high-frequency events cuts that count further.
+
+**Log to stdout, not files.** Railway only captures standard output and standard error. File-based logs are invisible to the Log Explorer and lost on redeploy unless written to a volume.
+
+**Keep attribute names consistent.** Pick one convention (`userId` everywhere, not `user_id` in one service and `uid` in another) so a single filter works across the whole environment view.
+
+**Know your retention window.** Logs are retained 7 days on Hobby, 30 days on Pro, and up to 90 days on Enterprise. For longer retention, forward logs to a third-party tool. See [Connect a Third-Party Observability Tool](/guides/third-party-observability).
+
+## Next steps
+
+- [Logs reference](/observability/logs) for the full filter syntax, HTTP log attributes, and DNS log attributes
+- [Connect a Third-Party Observability Tool](/guides/third-party-observability) for retention beyond your plan's window
+- [Deploy an OpenTelemetry Collector Stack](/guides/deploy-an-otel-collector-stack) for metrics and traces alongside logs
+- [Metrics](/observability/metrics) for built-in CPU, memory, and network graphs

--- a/content/guides/uptime-kuma.md
+++ b/content/guides/uptime-kuma.md
@@ -1,0 +1,101 @@
+---
+title: Self-Host Uptime Kuma for Uptime Monitoring
+description: Deploy Uptime Kuma on Railway with a volume for persistent monitor history. Monitor public sites and internal services, and publish status pages.
+date: "2026-07-29"
+tags:
+  - uptime-kuma
+  - monitoring
+  - docker
+  - self-hosted
+topic: integrations
+---
+
+[Uptime Kuma](https://github.com/louislam/uptime-kuma) is an open-source uptime monitoring tool. It checks your sites and services on an interval (HTTP, TCP, ping, DNS, and more), records response times, sends alerts through 90+ notification providers, and publishes public status pages. It is a lightweight alternative to hosted monitoring services, and the monitoring data stays in your own database.
+
+Uptime Kuma runs as a single container with a SQLite database, so deploying it on Railway takes only one service, built from the official Docker image, plus a volume so your monitors and history survive redeploys.
+
+## What you will set up
+
+- An Uptime Kuma instance running from the official Docker image
+- Persistent storage via a Railway [Volume](/volumes)
+- A public domain for the dashboard and status pages
+- Optional monitoring of other Railway services over [private networking](/networking/private-networking)
+
+## One-click deploy from a template
+
+Railway has an Uptime Kuma template that provisions the service and volume in one step.
+
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/uptime-kuma)
+
+After deploying, skip to [Create your admin account](#create-your-admin-account).
+
+To set it up manually instead, continue with the steps below.
+
+## Deploy from a Docker image
+
+1. Create a new project in Railway.
+2. Click **+ New** and select **Docker Image**.
+3. Enter `louislam/uptime-kuma:1` as the image name and press Enter.
+4. Railway pulls the image and creates the service.
+
+Pinning the major version tag (`1`) is safer than `latest`. For images hosted on Docker Hub or GitHub Container Registry, Railway can also check for new versions and redeploy the service during a maintenance window you choose; enable this under **Settings → Source → Configure Auto Updates**. See [image auto updates](/deployments/image-auto-updates).
+
+## Attach a volume before first use
+
+Uptime Kuma stores everything in `/app/data`: the SQLite database, your monitors, notification settings, and uptime history. Without a volume, all of it is lost on every deployment.
+
+1. Right-click the project canvas and select **Volume**, or use the Command Palette (`⌘K`).
+2. Connect the volume to the Uptime Kuma service.
+3. Set the mount path to `/app/data`.
+
+Attach the volume before you create your admin account. If you configure Uptime Kuma first and add the volume later, the container restarts with an empty data directory and you start over.
+
+## Generate a public domain
+
+1. Open the **Settings** tab of the service.
+2. Under **Networking**, click **Generate Domain**.
+
+Uptime Kuma listens on port 3001. Railway detects that automatically and sets it as the domain's target port, so you get a domain like `uptime-kuma-production.up.railway.app`.
+
+## Create your admin account
+
+Open the generated domain in your browser. On first load, Uptime Kuma prompts you to create an admin username and password. Do this immediately: until an account exists, anyone with the URL can claim the instance.
+
+## Add your first monitor
+
+1. Click **Add New Monitor**.
+2. Choose a monitor type. **HTTP(s)** is the most common: it requests a URL on an interval and alerts when the response fails or is too slow.
+3. Enter the URL, check interval, and retry settings.
+4. Click **Save**.
+
+The dashboard charts response time and uptime percentage per monitor, and that history accumulates in the volume-backed database.
+
+## Monitor other Railway services privately
+
+Services in the same project and environment can reach each other at `<service>.railway.internal` without public exposure. Use this to monitor internal services that have no public domain:
+
+1. In Uptime Kuma, add an **HTTP(s)** or **TCP** monitor.
+2. Point it at the internal hostname and the port your service listens on, for example `http://api.railway.internal:8080/health`.
+
+Private networking is scoped per environment. An Uptime Kuma instance in your `production` environment can only reach other services in `production`.
+
+## Set up notifications
+
+Uptime Kuma configures notifications in the UI, not through environment variables. Go to **Settings → Notifications** and add a provider: Slack, Discord, Telegram, email (SMTP), PagerDuty, webhooks, and dozens more. Attach the notification to individual monitors or set it as a default for all of them.
+
+## Publish a status page
+
+Uptime Kuma serves public status pages from the same domain. Go to **Status Pages**, create a page, and pick which monitors it shows. The page is available at `https://<your-domain>/status/<slug>` and is safe to share: it exposes only the monitors you select, not the admin dashboard.
+
+## Keep the service always on
+
+Do not enable [serverless](/deployments/serverless) for this service. A monitor is only useful if it runs continuously. In practice Uptime Kuma's own outbound checks would prevent sleep anyway, but there is no reason to opt a monitoring service into it.
+
+Uptime Kuma is a single-instance application backed by SQLite. Run exactly one replica. Expect roughly 512 MB of RAM for a typical instance; Railway bills for the memory and CPU the service actually uses.
+
+## Next steps
+
+- [Use volumes](/volumes): Manage the persistent storage backing your monitor history.
+- [Back up your volume](/volumes/backups): Schedule backups of the Uptime Kuma database.
+- [Set up a custom domain](/networking/domains): Serve your status page from your own domain.
+- [Configure health checks](/deployments/healthchecks): Add deploy-time health checks to the services Uptime Kuma watches.

--- a/content/guides/webhooks-at-scale.md
+++ b/content/guides/webhooks-at-scale.md
@@ -1,0 +1,247 @@
+---
+title: Receive Webhooks at Scale
+description: Build a webhook receiver that verifies signatures, responds fast, and queues work for a background worker. Covers idempotency keys, retries, and how to run the pattern on Railway.
+date: "2026-07-29"
+tags:
+  - webhooks
+  - architecture
+  - queues
+  - workers
+topic: architecture
+---
+
+A webhook receiver at scale does three things, in this order: verify the signature, acknowledge with a 200 immediately, and queue the actual work for a separate process. Everything else (retries, deduplication, backpressure) follows from keeping those three steps separate.
+
+In this guide we build that pattern on Railway with two Node.js services and Redis: a receiver that stays thin, and a worker that processes jobs from a BullMQ queue.
+
+## Why you should not process webhooks inline
+
+Providers like Stripe, GitHub, and Shopify expect a response within a few seconds. If your handler updates a database, calls another API, and sends an email before responding, three things go wrong under load:
+
+- **Timeouts trigger retries.** The provider marks the delivery failed and sends it again, so slow processing multiplies your traffic.
+- **Retries create duplicates.** All three providers deliver at least once, so if a retry arrives while the first attempt is mid-flight, you process the same event twice.
+- **Spikes take down the receiver.** A backfill or a burst of activity can deliver thousands of events in seconds, and inline processing ties each one to an open HTTP request.
+
+Queuing decouples ingestion rate from processing rate. The receiver absorbs the spike; the worker drains the queue at its own pace.
+
+## Architecture on Railway
+
+Create one Railway project with three services in the same environment:
+
+1. **Receiver**: a public HTTP service. Verifies signatures, enqueues jobs, returns 200.
+2. **Redis**: deployed from the Railway Redis template. Holds the queue.
+3. **Worker**: a private service with no public domain. Consumes jobs and does the work.
+
+The receiver and worker talk to Redis over [private networking](/networking/private-networking) at `redis.railway.internal`. Private networking is scoped per environment, so production and staging queues never mix.
+
+None of that affects response time, though. Railway's edge allows HTTP requests to run for up to 15 minutes while data keeps transferring, but that limit is irrelevant here: your receiver should respond in well under a second, because the provider's own timeout is the constraint.
+
+## Step 1: Verify the signature
+
+Providers sign each delivery with a shared secret, usually an HMAC of the raw request body. Two rules matter:
+
+- **Verify against the raw bytes.** If your framework parses JSON before you compute the HMAC, re-serialized output will not match what the provider signed. In Express, mount `express.raw()` on the webhook route.
+- **Compare in constant time.** Use `crypto.timingSafeEqual`, not `===`, to avoid timing attacks.
+
+Reject anything that fails verification with a 401 and do not enqueue it.
+
+## Step 2: Respond 200, then do nothing else
+
+Once the signature checks out, enqueue the event and respond. The 200 means "received", not "processed". If enqueueing fails (Redis is unreachable), return a 500 so the provider retries later; that is what provider retries are for.
+
+## Step 3: Queue with an idempotency key
+
+An idempotency key is a stable identifier for one logical event. Processing an event twice under the same key has the same effect as processing it once. Most providers give you one: Stripe sends an event `id`, GitHub sends an `X-GitHub-Delivery` header, Shopify sends `X-Shopify-Webhook-Id`.
+
+Use that identifier as the BullMQ `jobId`. BullMQ refuses to enqueue a second job with the same `jobId` while the first is queued, active, or retained after completion, so provider retries collapse into one job.
+
+## The receiver
+
+Create the receiver service:
+
+```bash
+mkdir webhook-receiver && cd webhook-receiver
+npm init -y
+npm install express bullmq
+```
+
+`server.js`:
+
+```javascript
+const crypto = require("node:crypto");
+const express = require("express");
+const { Queue } = require("bullmq");
+
+const app = express();
+const secret = process.env.WEBHOOK_SECRET;
+
+const redisURL = new URL(process.env.REDIS_URL);
+
+const queue = new Queue("webhooks", {
+  connection: {
+    family: 0,
+    host: redisURL.hostname,
+    port: Number(redisURL.port),
+    username: redisURL.username,
+    password: redisURL.password,
+  },
+});
+
+function verifySignature(rawBody, signatureHeader) {
+  if (!signatureHeader) return false;
+  const expected = crypto
+    .createHmac("sha256", secret)
+    .update(rawBody)
+    .digest("hex");
+  const received = Buffer.from(signatureHeader, "utf8");
+  const computed = Buffer.from(expected, "utf8");
+  if (received.length !== computed.length) return false;
+  return crypto.timingSafeEqual(received, computed);
+}
+
+// Raw body on this route only: signature is computed over the exact bytes.
+app.post(
+  "/webhooks",
+  express.raw({ type: "application/json" }),
+  async (req, res) => {
+    if (!verifySignature(req.body, req.get("X-Signature-256"))) {
+      return res.status(401).send("invalid signature");
+    }
+
+    const event = JSON.parse(req.body.toString("utf8"));
+    const idempotencyKey = req.get("X-Delivery-Id") || event.id;
+
+    if (!idempotencyKey) {
+      return res.status(400).send("missing delivery id");
+    }
+
+    try {
+      await queue.add("process-event", event, {
+        jobId: idempotencyKey,
+        attempts: 5,
+        backoff: { type: "exponential", delay: 5000 },
+        removeOnComplete: { age: 86400 },
+        removeOnFail: false,
+      });
+    } catch (err) {
+      console.error("enqueue failed", err);
+      // 500 tells the provider to retry the delivery later.
+      return res.status(500).send("queueing failed");
+    }
+
+    res.status(200).send("ok");
+  }
+);
+
+app.get("/health", (req, res) => res.status(200).send("ok"));
+
+const port = process.env.PORT || 3000;
+app.listen(port, () => console.log(`receiver listening on ${port}`));
+```
+
+Adjust the header names (`X-Signature-256`, `X-Delivery-Id`) to match your provider. The signature scheme here is plain HMAC-SHA256 of the body; some providers prefix the header (GitHub uses `sha256=...`) or sign a timestamped payload (Stripe), so follow their docs for the exact string to hash.
+
+The `family: 0` option tells the underlying Redis client to resolve both IPv4 and IPv6 addresses, which is required for Railway's [private network](/networking/private-networking).
+
+Note `removeOnComplete: { age: 86400 }`: completed jobs are kept for 24 hours, so a provider retry arriving within that window hits the duplicate `jobId` and is dropped. Removing completed jobs immediately would reopen the duplicate window.
+
+## The worker
+
+Create the worker service:
+
+```bash
+mkdir webhook-worker && cd webhook-worker
+npm init -y
+npm install bullmq
+```
+
+`worker.js`:
+
+```javascript
+const { Worker } = require("bullmq");
+
+const redisURL = new URL(process.env.REDIS_URL);
+
+const worker = new Worker(
+  "webhooks",
+  async (job) => {
+    const event = job.data;
+    console.log(`processing ${job.id} (${event.type})`);
+
+    // Your actual work goes here: update the database, call APIs,
+    // send emails. Make each step idempotent where possible, for
+    // example with upserts keyed on job.id.
+    await handleEvent(event);
+  },
+  {
+    connection: {
+      family: 0,
+      host: redisURL.hostname,
+      port: Number(redisURL.port),
+      username: redisURL.username,
+      password: redisURL.password,
+    },
+    concurrency: 10,
+  }
+);
+
+async function handleEvent(event) {
+  switch (event.type) {
+    case "payment.succeeded":
+      // upsert payment record
+      break;
+    default:
+      console.log(`ignoring event type ${event.type}`);
+  }
+}
+
+worker.on("failed", (job, err) => {
+  console.error(`job ${job?.id} failed: ${err.message}`);
+});
+
+worker.on("error", (err) => {
+  console.error("worker error", err);
+});
+```
+
+The worker retries failed jobs 5 times with exponential backoff (configured on the queue side via `attempts` and `backoff`). Jobs that exhaust their retries stay in the failed set for inspection.
+
+The `jobId` deduplication protects you from enqueueing duplicates, but not from a job that crashes halfway through and retries. For work that must not repeat (charging a card, sending an email), add a second idempotency layer inside the handler: an upsert or a unique-constraint insert on the idempotency key in your database, checked before the side effect runs.
+
+## Deploy on Railway
+
+1. Create a project and deploy Redis from the template. It provides `REDIS_URL`.
+2. Deploy the receiver from its repo. In its variables, set `REDIS_URL` to a [reference variable](/variables) pointing at the Redis service's private URL, and set `WEBHOOK_SECRET` to the secret from your provider.
+3. Deploy the worker the same way. Do not generate a public domain for it; it only talks to Redis.
+4. Generate a public domain for the receiver under Settings, then register `https://<your-domain>/webhooks` with your provider.
+
+Two settings worth configuring on the receiver:
+
+- **Healthcheck**: set the healthcheck path to `/health` in service settings. Railway then performs [zero-downtime deploys](/deployments/healthchecks), so a deploy does not drop incoming deliveries.
+- **Restart policy**: the default restart-on-failure keeps the receiver up if it crashes.
+
+Do not enable serverless on the receiver. Webhooks arrive on the provider's schedule, and a cold start adds latency exactly when a delivery lands. That same logic rules it out for the worker too: it keeps a persistent Redis connection, which counts as outbound traffic, so it would not sleep anyway.
+
+## Scaling the pattern
+
+Each side scales independently:
+
+- **Receiver**: stateless, so add [replicas](/deployments/scaling) in service settings. Railway load-balances public traffic across them.
+- **Worker**: raise `concurrency` first, since it is the cheapest lever, then add replicas once a single instance's CPU is saturated. BullMQ distributes jobs across workers safely, and `jobId` deduplication holds across all of them because it lives in Redis.
+- **Queue depth is your backpressure signal.** If the queue grows faster than it drains for sustained periods, add worker capacity. A deep queue is the system working as designed during a spike; a permanently growing one is under-provisioning.
+
+Railway bills by usage (RAM at $10/GB-month, CPU at $20/vCPU-month), so an idle worker with low concurrency costs little between spikes.
+
+## Common mistakes
+
+- **Parsing the body before verifying.** Global `express.json()` middleware breaks signature checks. Keep `express.raw()` on the webhook route.
+- **Returning 200 before the job is enqueued.** If you acknowledge first and Redis fails after, the event is lost and the provider will not retry. Enqueue, then respond.
+- **Using a timestamp or a hash of the payload as the idempotency key.** Two distinct events can carry identical payloads. Use the provider's delivery or event ID.
+- **Doing "just one quick thing" inline.** The one quick database write becomes three writes and an API call over time. Keep the receiver at zero business logic.
+
+## Next steps
+
+- [Choose between cron jobs, background workers, and queues](/guides/cron-workers-queues)
+- [Deploy a SaaS backend with Postgres, workers, and webhooks](/guides/saas-backend)
+- [Private networking](/networking/private-networking)
+- [Scaling your application](/guides/scaling-your-application)


### PR DESCRIPTION
## What

Closes the 40-net-new how-to mandate from the AEO gap plan: **38 new guides** across secrets, observability, scaling/cost, static/edge, databases, queues, CI/CD, security, and AI orchestration, plus **5 hand-built agent-lane guides** (code-execution sandboxes, build-your-own LLM gateway, object storage for agent outputs, agent cost estimation, local-vs-remote MCP), a **full rewrite of the MCP server guide** for the 2026-07-28 stateless spec revision and TypeScript SDK v2, and **refreshes** of the SSE streaming / agent workers / cron-workers-queues cluster.

## Why these topics

Targets chosen from Gauge AI-engine visibility gaps (secrets 2.3%, code-execution sandboxes 3.5%, observability 4-7%, LLM gateway 7.5%, container registries 1.6%) cross-referenced with keyword demand. Two planned articles were dropped during drafting because `managing-secrets-on-railway.md` already covers them.

## Verification

- Every Railway capability, pricing, and limit claim checked against `content/docs/` (unsourced claims were cut, e.g. an undocumented Infisical integration)
- All internal links resolve; the stale `#railway-provided-domain` anchor replaced with `/networking/domains` everywhere touched
- All TS/JS code blocks compile-checked (strict tsc / node --check); the MCP server and LLM gateway examples also smoke-tested live over HTTP
- Four editorial passes over the batch: independent claim re-verification, PLG + stop-slop skills, voice (payoff-first intros, concrete over adjective), and a given-new cohesion pass

## Reviewer notes

Worth a human glance before/after merge (flagged during verification, details in each guide):
- `claude-agent-sdk-app`: external Anthropic facts (console URL, model id) unverifiable from this repo by definition
- `langfuse-llm-observability`, `keycloak-authentication`: template deploy URLs use name-style slugs (both return 200)
- `multi-region-api-failover`: 'replicas cannot mount volumes' matches platform behavior but is not stated in docs; also surfaced a real docs drift, `scaling.md` per-replica limits vs `pricing/plans.md`
- Upstream (not blocking): `postgresql-pgbouncer.md` now documents built-in pooling, so internal review tooling that claims otherwise is stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)