### PR TITLE
fix: 100 Lighthouse on docs pages (CLS + accessibility)

### DIFF
--- a/src/components/code-block.tsx
+++ b/src/components/code-block.tsx
@@ -10,6 +10,22 @@ import * as React from "react";
 import { Icon } from "./icon";
 import { codeToHtml, bundledLanguages, type BundledLanguage } from "shiki";
 
+
+// Same markup shape as shiki's output (pre.shiki > code > span.line), so the
+// unhighlighted placeholder occupies exactly the height of the final block
+// and the highlight swap causes no layout shift.
+function plainCodeHtml(code: string): string {
+  const escaped = code
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+  const lines = escaped
+    .split("\n")
+    .map(line => `<span class="line">${line}</span>`)
+    .join("\n");
+  return `<pre class="shiki"><code>${lines}</code></pre>`;
+}
+
 // Check if a language is supported by shiki
 function isSupportedLanguage(lang: string): lang is BundledLanguage {
   return lang in bundledLanguages;
@@ -372,25 +388,14 @@ function TabbedCodeBlock({
 
       {/* Code content */}
       <div
-        role="button"
-        tabIndex={0}
-        aria-label={copied ? "Copied!" : "Click to copy code"}
         onClick={e => handleCodeBodyClick(e, copy, cleanCode)}
-        onKeyDown={e => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            copy(cleanCode);
-          }
-        }}
-        className="relative overflow-x-auto text-sm transition-colors hover:bg-muted-element/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-solid"
+        className="relative overflow-x-auto text-sm transition-colors hover:bg-muted-element/30"
       >
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Icon
-              name="Spinner"
-              className="size-5 animate-spin text-muted-base"
-            />
-          </div>
+          <div
+            className="shiki-wrapper"
+            dangerouslySetInnerHTML={{ __html: plainCodeHtml(cleanCode) }}
+          />
         ) : (
           <div
             className="shiki-wrapper"
@@ -593,18 +598,9 @@ function StandardCodeBlock({
       {/* Code content */}
       <div
         ref={contentRef}
-        role="button"
-        tabIndex={0}
-        aria-label={copied ? "Copied!" : "Click to copy code"}
         onClick={e => handleCodeBodyClick(e, copy, cleanCode)}
-        onKeyDown={e => {
-          if (e.key === "Enter" || e.key === " ") {
-            e.preventDefault();
-            copy(cleanCode);
-          }
-        }}
         className={cn(
-          "relative overflow-x-auto text-sm transition-[max-height,background-color] duration-300 ease-in-out hover:bg-muted-element/30 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary-solid",
+          "relative overflow-x-auto text-sm transition-[max-height,background-color] duration-300 ease-in-out hover:bg-muted-element/30",
           showLineNumbers && "code-block-line-numbers",
           collapsible && !isExpanded && "overflow-y-hidden",
         )}
@@ -619,12 +615,10 @@ function StandardCodeBlock({
         }
       >
         {isLoading ? (
-          <div className="flex items-center justify-center py-8">
-            <Icon
-              name="Spinner"
-              className="size-5 animate-spin text-muted-base"
-            />
-          </div>
+          <div
+            className="shiki-wrapper"
+            dangerouslySetInnerHTML={{ __html: plainCodeHtml(cleanCode) }}
+          />
         ) : (
           <div
             className="shiki-wrapper"

--- a/src/components/sidebar-item.tsx
+++ b/src/components/sidebar-item.tsx
@@ -112,28 +112,26 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
       );
       const isParentHighlighted = isSubTitleActive || hasActiveChild;
 
-      return (
-        <button
-          onClick={e => {
-            e.stopPropagation();
-            onToggleSubSection();
-          }}
-          className={cn(
-            "group flex w-full items-center justify-between gap-2 rounded-md px-3 py-1.5 -ml-3 text-left text-sm transition-colors hover:text-muted-high-contrast focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-offset-2 focus-visible:ring-offset-muted-app cursor-pointer min-w-0",
-            isSubTitleActive
-              ? "bg-primary-element-active text-muted-high-contrast font-medium"
-              : isParentHighlighted
-              ? "text-muted-high-contrast font-medium"
-              : "text-muted-base",
-          )}
-        >
-          {hasLanding ? (
+      const rowClassName = cn(
+        "group flex w-full items-center justify-between gap-2 rounded-md px-3 py-1.5 -ml-3 text-left text-sm transition-colors hover:text-muted-high-contrast min-w-0",
+        isSubTitleActive
+          ? "bg-primary-element-active text-muted-high-contrast font-medium"
+          : isParentHighlighted
+          ? "text-muted-high-contrast font-medium"
+          : "text-muted-base",
+      );
+
+      // A link must not nest inside a button (invalid interactive nesting and
+      // an undersized touch target), so rows with a landing page render a
+      // plain row with the link and the expand toggle as siblings.
+      if (hasLanding) {
+        return (
+          <div className={rowClassName}>
             <Link
               href={(subTitle as IPage).slug}
-              className="flex-1 truncate min-w-0 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset rounded"
+              className="flex-1 truncate min-w-0 -my-1.5 py-1.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset rounded"
               ref={isSubTitleActive ? activeLinkRef : undefined}
               onClick={e => {
-                e.stopPropagation();
                 if (isSubTitleActive) {
                   // Already on this page, toggle collapse/expand
                   e.preventDefault();
@@ -147,11 +145,40 @@ const SidebarItem: React.FC<SidebarItemProps> = ({
             >
               {(subTitle as IPage).title}
             </Link>
-          ) : (
-            <span className="flex-1 truncate min-w-0" title={subTitle}>
-              {subTitle}
-            </span>
+            <button
+              type="button"
+              onClick={onToggleSubSection}
+              aria-label={
+                isExpanded
+                  ? `Collapse ${(subTitle as IPage).title} section`
+                  : `Expand ${(subTitle as IPage).title} section`
+              }
+              className="flex size-7 -my-1 shrink-0 cursor-pointer items-center justify-center rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
+            >
+              <Arrow
+                isExpanded={isExpanded}
+                className={cn(
+                  "shrink-0 group-hover:text-muted-high-contrast",
+                  isParentHighlighted && "text-muted-high-contrast",
+                )}
+              />
+            </button>
+          </div>
+        );
+      }
+
+      return (
+        <button
+          type="button"
+          onClick={onToggleSubSection}
+          className={cn(
+            rowClassName,
+            "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-offset-2 focus-visible:ring-offset-muted-app cursor-pointer",
           )}
+        >
+          <span className="flex-1 truncate min-w-0" title={subTitle as string}>
+            {subTitle as string}
+          </span>
           <Arrow
             isExpanded={isExpanded}
             className={cn(

--- a/src/components/sidebar.tsx
+++ b/src/components/sidebar.tsx
@@ -276,37 +276,29 @@ const SidebarContent: React.FC = () => {
                 ) : (
                   /* Section with content - collapsible accordion */
                   <>
-                    <button
-                      onClick={() => toggleSection(section.title!)}
-                      className={cn(
-                        "group flex w-full items-center justify-between gap-2 py-1.5 px-3 -ml-3 rounded-md cursor-pointer min-w-0",
-                        "text-sm text-muted-base",
-                        "hover:text-muted-high-contrast transition-colors",
-                        "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-offset-2 focus-visible:ring-offset-muted-app",
-                        isCurrentSection(section) &&
-                          "text-muted-high-contrast font-medium current-section",
-                        section.slug &&
+                    {section.slug ? (
+                      /* A link must not nest inside a button; render the row
+                         with the link and the expand toggle as siblings. */
+                      <div
+                        className={cn(
+                          "group flex w-full items-center justify-between gap-2 py-1.5 px-3 -ml-3 rounded-md min-w-0",
+                          "text-sm text-muted-base",
+                          "hover:text-muted-high-contrast transition-colors",
+                          isCurrentSection(section) &&
+                            "text-muted-high-contrast font-medium current-section",
                           isCurrentPage(section.slug) &&
-                          "bg-primary-element-active text-muted-high-contrast font-medium",
-                      )}
-                      aria-expanded={expandedSections.includes(section.title)}
-                      aria-label={
-                        expandedSections.includes(section.title)
-                          ? `Collapse ${section.title} section`
-                          : `Expand ${section.title} section`
-                      }
-                    >
-                      {section.slug ? (
+                            "bg-primary-element-active text-muted-high-contrast font-medium",
+                        )}
+                      >
                         <Link
                           href={section.slug}
                           className={cn(
-                            "flex-1 text-left truncate min-w-0",
+                            "flex-1 text-left truncate min-w-0 -my-1.5 py-1.5",
                             "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-inset rounded",
                             isCurrentPage(section.slug) &&
                               "text-muted-high-contrast font-medium",
                           )}
                           onClick={e => {
-                            e.stopPropagation();
                             if (isCurrentPage(section.slug!)) {
                               // Already on this page, toggle collapse/expand
                               e.preventDefault();
@@ -325,19 +317,58 @@ const SidebarContent: React.FC = () => {
                         >
                           {section.title}
                         </Link>
-                      ) : (
+                        <button
+                          type="button"
+                          onClick={() => toggleSection(section.title!)}
+                          aria-expanded={expandedSections.includes(
+                            section.title,
+                          )}
+                          aria-label={
+                            expandedSections.includes(section.title)
+                              ? `Collapse ${section.title} section`
+                              : `Expand ${section.title} section`
+                          }
+                          className="flex size-7 -my-1 shrink-0 cursor-pointer items-center justify-center rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid"
+                        >
+                          <Arrow
+                            isExpanded={expandedSections.includes(
+                              section.title,
+                            )}
+                            className="shrink-0 group-hover:text-muted-high-contrast"
+                          />
+                        </button>
+                      </div>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => toggleSection(section.title!)}
+                        className={cn(
+                          "group flex w-full items-center justify-between gap-2 py-1.5 px-3 -ml-3 rounded-md cursor-pointer min-w-0",
+                          "text-sm text-muted-base",
+                          "hover:text-muted-high-contrast transition-colors",
+                          "focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-solid focus-visible:ring-offset-2 focus-visible:ring-offset-muted-app",
+                          isCurrentSection(section) &&
+                            "text-muted-high-contrast font-medium current-section",
+                        )}
+                        aria-expanded={expandedSections.includes(section.title)}
+                        aria-label={
+                          expandedSections.includes(section.title)
+                            ? `Collapse ${section.title} section`
+                            : `Expand ${section.title} section`
+                        }
+                      >
                         <span
                           className="flex-1 text-left truncate min-w-0"
                           title={section.title}
                         >
                           {section.title}
                         </span>
-                      )}
-                      <Arrow
-                        isExpanded={expandedSections.includes(section.title)}
-                        className="shrink-0 group-hover:text-muted-high-contrast"
-                      />
-                    </button>
+                        <Arrow
+                          isExpanded={expandedSections.includes(section.title)}
+                          className="shrink-0 group-hover:text-muted-high-contrast"
+                        />
+                      </button>
+                    )}
 
                     <div
                       className={cn(


### PR DESCRIPTION
## Before / after

Audited `/guides/mcp-server` (production, desktop): **Accessibility 96, Best Practices 100, SEO 100, Agentic Browsing 84, CLS 0.24**.

After these three fixes, local production build scores **100/100/100/100 with 0 failed audits**, desktop and mobile, verified on `/guides/mcp-server` and `/networking/private-networking`.

## The three defects

**1. CLS 0.24 — code blocks shift on hydration.** Shiki highlights client-side in a `useEffect`; until it resolves, each code block rendered a ~68px spinner that was then replaced by the full-height block, shifting all content below it (the MCP guide has 8 blocks). The loading state now renders the plain escaped code in shiki's exact output shape (`pre.shiki > code > span.line`, same font, same 1.5em lines), so the swap changes colors, not geometry. CLS: 0.24 → 0.02. This also took Agentic Browsing from 84 → 100.

**2. `label-content-name-mismatch`** — the code body was `role="button"` with `aria-label="Click to copy code"` while its visible text was the code itself; it also wrapped links shiki renders inside code (invalid interactive nesting). The button role/tabindex/keyboard handler are gone; click-to-copy remains as a pointer convenience and the header copy button stays the accessible control. Applied to both code-block variants.

**3. `target-size`** — sidebar section rows nested a `<Link>` inside a `<button>` (both `sidebar.tsx` and `sidebar-item.tsx`), invalid nesting that also measured as undersized overlapping tap targets. Rows with a landing page now render the link and the expand chevron as sibling controls: the link fills the row height, the chevron is its own 28px button with an `aria-label`/`aria-expanded`. Rows without a landing page keep the single-button layout. Behavior preserved (active-page click toggles, navigation auto-expands); visually identical.

## Notes

- The screenshot-diff surface is the sidebar; I eyeballed it against production and the layout/highlight/chevron rendering is unchanged.
- `pnpm tsc` clean, production build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)