### PR TITLE
fix: remove broken railway.com/compare links and fix http:// URLs

### DIFF
--- a/content/docs/platform/compare-to-bolt.md
+++ b/content/docs/platform/compare-to-bolt.md
@@ -5,8 +5,6 @@ description: Compare Railway and Bolt on what they do, infrastructure control, a
 
 _Last updated: June 2026_
 
-> See how Railway compares to other platforms at [railway.com/compare](https://railway.com/compare).
-
 Bolt (bolt.new) is an AI-powered development tool that generates full-stack web applications from prompts. Railway is an intelligent cloud provider that deploys and hosts your code. While they serve different purposes, there is some overlap:
 
 - Deploy web applications

--- a/content/docs/platform/compare-to-digitalocean.md
+++ b/content/docs/platform/compare-to-digitalocean.md
@@ -5,8 +5,6 @@ description: Compare Railway and DigitalOcean App Platform on infrastructure, pr
 
 _Last updated: June 2026_
 
-> See how Railway compares to other platforms at [railway.com/compare](https://railway.com/compare).
-
 At a high level, both Railway and DigitalOcean App Platform can be used to deploy your app. Both platforms share many similarities:
 
 - You can deploy your app from a Docker image or by importing your app’s source code from GitHub.
@@ -122,7 +120,7 @@ Railway’s dashboard offers a real-time collaborative canvas where you can view
 
 Additionally, Railway offers a template directory that makes it easy to self-host open-source projects with just a few clicks. If you publish a template and others deploy it in their projects, you’ll earn a 25% kickback of their usage costs.
 
-Check out all templates at [railway.com/deploy](http://railway.com/deploy)
+Check out all templates at [railway.com/deploy](https://railway.com/deploy)
 
 <video src="https://res.cloudinary.com/railway/video/upload/v1753470547/docs/comparison-docs/railway-templates-marketplace_v0svnv.mp4" controls autoplay loop muted></video>
 

--- a/content/docs/platform/compare-to-fly.md
+++ b/content/docs/platform/compare-to-fly.md
@@ -114,7 +114,7 @@ Similarly, Fly doesn't include native environment support for development, stagi
 
 For monitoring, Fly automatically collects metrics from every application using a fully-managed Prometheus service based on VictoriaMetrics. The system scrapes metrics from all application instances and provides data on HTTP responses, TCP connections, memory usage, CPU performance, disk I/O, network traffic, and filesystem utilization.
 
-The Fly dashboard includes a basic Metrics tab displaying this automatically collected data. Beyond the basic dashboard, Fly offers a managed Grafana instance at [fly-metrics.net](http://fly-metrics.net) with detailed dashboards and query capabilities using MetricsQL as the querying language. You can also connect external tools through the Prometheus API.
+The Fly dashboard includes a basic Metrics tab displaying this automatically collected data. Beyond the basic dashboard, Fly offers a managed Grafana instance at [fly-metrics.net](https://fly-metrics.net) with detailed dashboards and query capabilities using MetricsQL as the querying language. You can also connect external tools through the Prometheus API.
 
 ![fly-metrics.net](https://res.cloudinary.com/railway/image/upload/v1753083710/docs/fly-metrics.net_d6r3cs.png)
 
@@ -130,7 +130,7 @@ Railway follows a dashboard-first experience, while [also providing a CLI](/cli)
 
 Additionally, Railway offers a template directory that makes it easy to self-host open-source projects with just a few clicks. If you publish a template and others deploy it in their projects, you’ll earn a 25% kickback of their usage costs.
 
-Check out all templates at [railway.com/deploy](http://railway.com/deploy)
+Check out all templates at [railway.com/deploy](https://railway.com/deploy)
 
 <video
 src="https://res.cloudinary.com/railway/video/upload/v1753083712/docs/railway.com_templates_zcydjb.mp4"

--- a/content/docs/platform/compare-to-heroku.md
+++ b/content/docs/platform/compare-to-heroku.md
@@ -119,7 +119,7 @@ You can also share environment variables between services, streamlining config m
 
 Additionally, Railway offers a template directory that makes it easy to self-host open-source projects with just a few clicks. If you publish a template and others deploy it in their projects, you’ll earn a 25% kickback of their usage costs.
 
-Check out all templates at [railway.com/deploy](http://railway.com/deploy)
+Check out all templates at [railway.com/deploy](https://railway.com/deploy)
 
 <video src="https://res.cloudinary.com/railway/video/upload/v1753470547/docs/comparison-docs/railway-templates-marketplace_v0svnv.mp4" controls autoplay loop muted></video>
 

--- a/content/docs/platform/compare-to-lovable.md
+++ b/content/docs/platform/compare-to-lovable.md
@@ -5,8 +5,6 @@ description: Compare Railway and Lovable on what they do, infrastructure control
 
 _Last updated: June 2026_
 
-> See how Railway compares to other platforms at [railway.com/compare](https://railway.com/compare).
-
 Lovable and Railway are both fantastic products, and they share some similarities: both can deploy a web application to the internet, connect to a database to store your data, handle environment variables and configuration, and set up a custom domain. But they're ultimately different tools for solving different problems.
 
 Lovable is built to take you from zero to one. You describe what you want, and it writes the code and hosts the result. The value is in the high-quality code that Lovable generates from human language. Railway takes over from there: you bring the code, and Railway handles everything you need to run and scale that application reliably as it grows, including packaging, infrastructure, deployment, and observability.

--- a/content/docs/platform/compare-to-render.md
+++ b/content/docs/platform/compare-to-render.md
@@ -119,7 +119,7 @@ Railway’s dashboard offers a real-time collaborative canvas where you can view
 
 Additionally, Railway offers a template directory that makes it easy to self-host open-source projects with just a few clicks. If you publish a template and others deploy it in their projects, you’ll earn a 25% kickback of their usage costs.
 
-Check out all templates at [railway.com/deploy](http://railway.com/deploy)
+Check out all templates at [railway.com/deploy](https://railway.com/deploy)
 
 <video src="https://res.cloudinary.com/railway/video/upload/v1753470547/docs/comparison-docs/railway-templates-marketplace_v0svnv.mp4" controls autoplay loop muted></video>
 

--- a/content/docs/platform/compare-to-replit.md
+++ b/content/docs/platform/compare-to-replit.md
@@ -5,8 +5,6 @@ description: Compare Railway and Replit on development workflow, infrastructure 
 
 _Last updated: June 2026_
 
-> See how Railway compares to other platforms at [railway.com/compare](https://railway.com/compare).
-
 At a high level, both Railway and Replit can be used to deploy web applications. Both platforms share some similarities:
 
 - Deploy web applications from code with public URLs.

--- a/content/docs/platform/compare-to-vercel.md
+++ b/content/docs/platform/compare-to-vercel.md
@@ -63,7 +63,7 @@ Railway uses a [custom builder](/builds) that takes your source code or Dockerfi
 
 Your code runs on a long-running server, making it ideal for apps that need to stay running or maintain a persistent connection.
 
-All deployments come with smart defaults out of the box, but you can tweak things as needed. This makes Railway flexible across [different runtimes and programming languages](http://railway.com/deploy).
+All deployments come with smart defaults out of the box, but you can tweak things as needed. This makes Railway flexible across [different runtimes and programming languages](https://railway.com/deploy).
 
 Each service you deploy can automatically scale up vertically to handle incoming workload. You also get the option to horizontally scale a service by spinning up replicas. Replicas can be deployed in multiple regions simultaneously.
 
@@ -143,7 +143,7 @@ Template directory
 
 Finally, Railway offers a template directory that makes it easy to self-host open-source projects with just a few clicks. If you publish a template and others deploy it in their projects, you’ll earn a 25% kickback of their usage costs.
 
-Check out all templates at [railway.com/deploy](http://railway.com/deploy)
+Check out all templates at [railway.com/deploy](https://railway.com/deploy)
 
 <video src="https://res.cloudinary.com/railway/video/upload/v1753470547/docs/comparison-docs/railway-templates-marketplace_v0svnv.mp4" controls autoplay loop muted></video>
 

--- a/content/docs/platform/compare-to-vps.md
+++ b/content/docs/platform/compare-to-vps.md
@@ -5,8 +5,6 @@ description: Compare Railway and VPS hosting on infrastructure management, secur
 
 _Last updated: June 2026_
 
-> See how Railway compares to other platforms at [railway.com/compare](https://railway.com/compare).
-
 At a high level, both Railway and a VPS (Virtual Private Server) can be used to deploy applications. The fundamental difference lies in the level of abstraction and operational overhead you're willing to manage.
 
 VPS hosting providers like [AWS EC2](https://aws.amazon.com/ec2/), [DigitalOcean Droplets](https://www.digitalocean.com/products/droplets), [Hetzner Cloud](https://www.hetzner.com/cloud), [Linode](https://www.linode.com/), or [Vultr](https://www.vultr.com/) give you a virtual machine where you have full control over the operating system, software stack, and configuration. This offers maximum flexibility but requires significant DevOps expertise and ongoing maintenance.


### PR DESCRIPTION
## Summary

- **Remove broken link**: The `railway.com/compare` URL returns 404. Five comparison pages had a callout linking to it: bolt, digitalocean, lovable, replit, vps. Removed the callout from all five.
- **Fix http:// URLs**: Several comparison pages linked to `http://railway.com/deploy` and `http://fly-metrics.net` instead of `https://`. Updated to HTTPS in: digitalocean, fly, heroku, render, vercel.

All remaining external links across all 10 comparison pages were verified and return 200.