### PR TITLE
fix: replace broken /template/ links with /deploy/ in guides

### DIFF
--- a/content/guides/angular.md
+++ b/content/guides/angular.md
@@ -24,7 +24,7 @@ Now, let's create an Angular app!
 
 **Note:** If you already have an Angular app locally or on GitHub, you can skip this step and go straight to the [Deploy Angular App on Railway](#deploy-the-angular-app-to-railway).
 
-To create a new Angular app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) and [Angular CLI](https://angular.dev/installation#install-angular-cli) installed on your machine.
+To create a new Angular app, ensure that you have [Node](https://nodejs.org/en/download) and [Angular CLI](https://angular.dev/installation#install-angular-cli) installed on your machine.
 
 Run the following command in your terminal to create a new Angular app:
 

--- a/content/guides/astro.md
+++ b/content/guides/astro.md
@@ -24,7 +24,7 @@ Now, let's create an Astro app!
 
 **Note:** If you already have an Astro app locally or on GitHub, you can skip this step and go straight to the [Deploy Astro Apps on Railway](#deploy-the-astro-app-to-railway).
 
-To create a new Astro app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Astro app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Astro app:
 

--- a/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
+++ b/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
@@ -29,7 +29,7 @@ To successfully complete this guide, you'll need:
 - A [GitHub](https://github.com/) account with [git](https://git-scm.com/) configured
 - Node.js installed locally - you can use [nvm](https://github.com/nvm-sh/nvm) to manage your Node.js versions
 
-You can find the final code on [GitHub](https://github.com/railway/nodejs-express-tutorial).
+
 
 ## Project setup
 

--- a/content/guides/express.md
+++ b/content/guides/express.md
@@ -25,7 +25,7 @@ Now, let's create an Express app!
 
 **Note:** If you already have an Express app locally or on GitHub, you can skip this step and go straight to the [Deploy Express App to Railway](#deploy-the-express-app-to-railway).
 
-To create a new Express app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Express app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Create a directory, `helloworld`, and `cd` into it.
 

--- a/content/guides/flowise.md
+++ b/content/guides/flowise.md
@@ -24,7 +24,7 @@ Flowise runs on Railway as a CPU-based service. The LLM chains you build in Flow
 
 Railway has a Flowise template that provisions the full setup in one step.
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/flowise)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/flowise)
 
 After deploying, skip to [Configure authentication](#configure-authentication) to secure your instance.
 

--- a/content/guides/gatsby.md
+++ b/content/guides/gatsby.md
@@ -21,7 +21,7 @@ This guide covers how to deploy a Gatsby app to Railway in three ways:
 
 **Note:** If you already have a Gatsby app locally or on GitHub, skip to [Deploy the Gatsby app to Railway](#deploy-the-gatsby-app-to-railway).
 
-Ensure [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) is installed, then create a new Gatsby site:
+Ensure [Node](https://nodejs.org/en/download) is installed, then create a new Gatsby site:
 
 ```bash
 npm init gatsby my-gatsby-site
@@ -152,7 +152,7 @@ Railway automatically detects the `Dockerfile`, [and uses it to build and deploy
 
 ## Client-side routes
 
-Gatsby supports [client-only routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-in-gatsby/) for pages that handle routing in the browser. The `try_files {path} /index.html` directive in the Caddyfile ensures these routes work correctly on refresh. For more details on configuring this, see [Configure SPA Routing](/guides/spa-routing-configuration).
+Gatsby supports [client-only routes](https://www.gatsbyjs.com/docs/how-to/routing/client-only-routes-and-user-authentication/) for pages that handle routing in the browser. The `try_files {path} /index.html` directive in the Caddyfile ensures these routes work correctly on refresh. For more details on configuring this, see [Configure SPA Routing](/guides/spa-routing-configuration).
 
 ## Build memory
 

--- a/content/guides/n8n.md
+++ b/content/guides/n8n.md
@@ -27,7 +27,7 @@ Railway has an n8n template that provisions the full setup in one step.
 
 Click the button below to deploy:
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/n8n)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/n8n)
 
 After deploying, you can skip ahead to [Set up the webhook URL](#set-up-the-webhook-url) to configure webhooks for your instance.
 

--- a/content/guides/nest.md
+++ b/content/guides/nest.md
@@ -25,7 +25,7 @@ Now, let's go ahead and create a Nest app!
 
 **Note:** If you already have a Nest app locally or on GitHub, you can skip this step and go straight to the [Deploy Nest App to Railway](#deploy-the-nest-app-to-railway).
 
-To create a new Nest app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) and [NestJS](https://docs.nestjs.com/#installation) installed on your machine.
+To create a new Nest app, ensure that you have [Node](https://nodejs.org/en/download) and [NestJS](https://docs.nestjs.com/#installation) installed on your machine.
 
 Run the following command in your terminal to create a new Nest app:
 

--- a/content/guides/nextjs.md
+++ b/content/guides/nextjs.md
@@ -24,7 +24,7 @@ This guide covers how to deploy a Next.js app to Railway and connect it to a Pos
 
 **Note:** If you already have a Next.js app locally or on GitHub, you can skip this step and go straight to [Deploy the Next.js App to Railway](#deploy-the-nextjs-app-to-railway).
 
-To create a new Next.js app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Next.js app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Next.js app:
 

--- a/content/guides/nuxt.md
+++ b/content/guides/nuxt.md
@@ -27,7 +27,7 @@ Now, let's create a Nuxt app!
 
 **Note:** If you already have a Nuxt app locally or on GitHub, you can skip this step and go straight to the [Deploy Nuxt App on Railway](#deploy-the-nuxt-app-to-railway).
 
-To create a new Nuxt app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Nuxt app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Nuxt app:
 

--- a/content/guides/open-webui.md
+++ b/content/guides/open-webui.md
@@ -24,7 +24,7 @@ Open WebUI is commonly paired with Ollama for local model inference, but Railway
 
 Railway has an Open WebUI template that provisions the setup in one step.
 
-[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/template/open-webui)
+[![Deploy on Railway](https://railway.com/button.svg)](https://railway.com/deploy/open-webui)
 
 After deploying, skip to [Configure LLM providers](#configure-llm-providers).
 

--- a/content/guides/react.md
+++ b/content/guides/react.md
@@ -26,7 +26,7 @@ Now, let's create a React app!
 
 **Note:** If you already have a React app locally or on GitHub, you can skip this step and go straight to the [Deploy React App on Railway](#deploy-the-react-app-to-railway).
 
-To create a new React app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new React app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new React app using [Vite](https://vite.dev/guide/#scaffolding-your-first-vite-project):
 

--- a/content/guides/remix.md
+++ b/content/guides/remix.md
@@ -25,7 +25,7 @@ Now, let's create a Remix app!
 
 **Note:** If you already have a Remix app locally or on GitHub, you can skip this step and go straight to the [Deploy Remix App on Railway](#deploy-the-remix-app-to-railway).
 
-To create a new Remix app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Remix app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Remix app:
 

--- a/content/guides/sails.md
+++ b/content/guides/sails.md
@@ -18,7 +18,7 @@ Sails makes it easy to build custom, enterprise-grade Node.js apps.
 
 **Note:** If you already have a Sails app locally or on GitHub, you can skip this step and go straight to the [Deploy Sails App on Railway](#deploy-sails-app-on-railway).
 
-To create a new Sails app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Sails app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to install Sails:
 

--- a/content/guides/solid.md
+++ b/content/guides/solid.md
@@ -26,7 +26,7 @@ Now, let's create a Solid app!
 
 **Note:** If you already have a Solid app locally or on GitHub, you can skip this step and go straight to the [Deploy Solid App on Railway](#deploy-the-solid-app-to-railway).
 
-To create a new Solid app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Solid app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Solid app from a template:
 

--- a/content/guides/sveltekit.md
+++ b/content/guides/sveltekit.md
@@ -25,7 +25,7 @@ Now, let's create a SvelteKit app!
 
 **Note:** If you already have a SvelteKit app locally or on GitHub, you can skip this step and go straight to the [Deploy SvelteKit App to Railway](#deploy-sveltekit-app-to-railway).
 
-To create a new SvelteKit app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new SvelteKit app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new SvelteKit app using [Vite](https://vite.dev/guide/#scaffolding-your-first-vite-project):
 

--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -22,7 +22,7 @@ This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
 **Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Deploy the TanStack Start app to Railway](#deploy-the-tanstack-start-app-to-railway).
 
-Ensure [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) is installed, then create a new project:
+Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project:
 
 ```bash
 npx @tanstack/create-start@latest my-app

--- a/content/guides/vue.md
+++ b/content/guides/vue.md
@@ -27,7 +27,7 @@ Now, let's create a Vue app!
 
 **Note:** If you already have a Vue app locally or on GitHub, you can skip this step and go straight to the [Deploy Vue App on Railway](#deploy-the-vue-app-to-railway).
 
-To create a new Vue app, ensure that you have [Node](https://nodejs.org/en/learn/getting-started/how-to-install-nodejs) installed on your machine.
+To create a new Vue app, ensure that you have [Node](https://nodejs.org/en/download) installed on your machine.
 
 Run the following command in your terminal to create a new Vue app using [Vite](https://vite.dev/guide/#scaffolding-your-first-vite-project):
 


### PR DESCRIPTION
## Summary

Checked all 225 external links across 128 guide files. Fixed 19 broken links (404) in 18 files.

**Template links (3 files):**
- `flowise.md`, `n8n.md`, `open-webui.md`: `railway.com/template/<slug>` → `railway.com/deploy/<slug>`

**Node.js install link (14 files):**
- `nodejs.org/en/learn/getting-started/how-to-install-nodejs` → `nodejs.org/en/download`
- Affected: angular, astro, express, gatsby, nest, nextjs, nuxt, react, remix, sails, solid, sveltekit, tanstack-start, vue

**Gatsby docs link (1 file):**
- `gatsbyjs.com/docs/how-to/routing/client-only-routes-in-gatsby/` → `client-only-routes-and-user-authentication/`

**Deleted repo (1 file):**
- `deploy-node-express-api...`: removed dead link to `github.com/railway/nodejs-express-tutorial` (repo no longer exists)