### PR TITLE
seo: server-render all guide links in hidden nav for crawlers

### DIFF
--- a/src/pages/guides/index.tsx
+++ b/src/pages/guides/index.tsx
@@ -632,6 +632,17 @@ const GuidesPage: NextPage<GuidesPageProps> = ({ guides }) => {
           </button>
         )}
 
+        {/* All guide links for search engines (visually hidden) */}
+        <nav className="sr-only" aria-label="All guides">
+          <ul>
+            {guides.map(guide => (
+              <li key={guide.url}>
+                <Link href={guide.url}>{guide.title}</Link>
+              </li>
+            ))}
+          </ul>
+        </nav>
+
         {/* Deploy an app in minutes */}
           <div className="mt-20">
             <h2


### PR DESCRIPTION
## What

Adds a visually-hidden `<nav class="sr-only">` block to `/guides` containing `<a>` links to **every** guide (~128), so crawlers that don't execute JavaScript can discover them from the server-rendered HTML.

## Why

The page slices the guide list to 20 before rendering, and "Show all" is a client-side `useState` toggle. Crawlers (Googlebot, AI bots) only see those first 20 links — the other ~108 guides get zero internal link equity from the index page, stalling their rankings.

## How (Option B — most conservative)

- Leaves the existing rendering, `showAll` state, search, and filter logic **100% untouched**
- Appends an `sr-only` `<nav aria-label="All guides">` with a `<ul>` of all guide links
- Uses the raw `guides` prop (all guides from `getStaticProps`), not the filtered/sliced subset

## Verification

- Build succeeds, no hydration warnings
- `grep -c 'href="/guides/' .next/server/pages/guides.html` → **128** unique guide links (was ~20)
- Visually identical — the nav is screen-reader-only