### PR TITLE
docs(databases): databases deploy private by default

### DIFF
--- a/content/docs/databases/mongodb.md
+++ b/content/docs/databases/mongodb.md
@@ -36,7 +36,7 @@ Connect to MongoDB from another service in your project by [referencing the envi
 
 #### Connecting externally
 
-It is possible to connect to MongoDB externally (from outside of the [project](/projects) in which it is deployed), by using the [TCP Proxy](/networking/tcp-proxy) which is enabled by default.
+It is possible to connect to MongoDB externally (from outside of the [project](/projects) in which it is deployed). Databases are deployed private by default — to expose one, open the service's **Settings → Networking** and add **Public Access**. This creates a [TCP Proxy](/networking/tcp-proxy) and populates a `MONGO_PUBLIC_URL` variable with the external connection string.
 
 _Keep in mind that you will be billed for [Network Egress](/pricing/plans#resource-usage-pricing) when using the TCP Proxy._
 

--- a/content/docs/databases/mysql.md
+++ b/content/docs/databases/mysql.md
@@ -33,7 +33,7 @@ Connect to MySQL from another service in your project by [referencing the enviro
 
 #### Connecting externally
 
-It is possible to connect to MySQL externally (from outside of the [project](/projects) in which it is deployed), by using the [TCP Proxy](/networking/tcp-proxy) which is enabled by default.
+It is possible to connect to MySQL externally (from outside of the [project](/projects) in which it is deployed). Databases are deployed private by default — to expose one, open the service's **Settings → Networking** and add **Public Access**. This creates a [TCP Proxy](/networking/tcp-proxy) and populates a `MYSQL_PUBLIC_URL` variable with the external connection string.
 
 _Keep in mind that you will be billed for [Network Egress](/pricing/plans#resource-usage-pricing) when using the TCP Proxy._
 

--- a/content/docs/databases/postgresql-ha.md
+++ b/content/docs/databases/postgresql-ha.md
@@ -55,7 +55,7 @@ Railway automatically migrates all variable references within your project as pa
 
 The only case that requires manual action is if you have hardcoded connection strings anywhere — in application code, Railway variables set to a literal URL (rather than a reference), other Railway projects, external tools, or CI pipelines. After deploying the cluster, update those to use the connection details from the **Postgres HA** service.
 
-For external connections (from outside Railway), use `DATABASE_PUBLIC_URL` from the **Postgres HA** service. This routes through the [TCP Proxy](/networking/tcp-proxy).
+For external connections (from outside Railway), use `DATABASE_PUBLIC_URL` from the **Postgres HA** service. This routes through the [TCP Proxy](/networking/tcp-proxy). If your standalone Postgres was publicly exposed, the conversion carries the public endpoint over to **Postgres HA** automatically; otherwise the cluster is private by default — add **Public Access** in the **Postgres HA** service's networking settings to create the proxy and the variable.
 
 ## Step 4 — Wait for Cluster Warm-Up
 

--- a/content/docs/databases/postgresql-ha.md
+++ b/content/docs/databases/postgresql-ha.md
@@ -55,7 +55,7 @@ Railway automatically migrates all variable references within your project as pa
 
 The only case that requires manual action is if you have hardcoded connection strings anywhere — in application code, Railway variables set to a literal URL (rather than a reference), other Railway projects, external tools, or CI pipelines. After deploying the cluster, update those to use the connection details from the **Postgres HA** service.
 
-For external connections (from outside Railway), use `DATABASE_PUBLIC_URL` from the **Postgres HA** service. This routes through the [TCP Proxy](/networking/tcp-proxy). If your standalone Postgres was publicly exposed, the conversion carries the public endpoint over to **Postgres HA** automatically; otherwise the cluster is private by default — add **Public Access** in the **Postgres HA** service's networking settings to create the proxy and the variable.
+For external connections (from outside Railway), use `DATABASE_PUBLIC_URL` from the **Postgres HA** service. This routes through the [TCP Proxy](/networking/tcp-proxy). If your standalone Postgres was publicly exposed, the conversion carries the public endpoint over to **Postgres HA** automatically; otherwise the cluster is private by default — click **Connect** on the cluster view and add **Public Access** to create the proxy and the variable.
 
 ## Step 4 — Wait for Cluster Warm-Up
 

--- a/content/docs/databases/postgresql-pgbouncer.md
+++ b/content/docs/databases/postgresql-pgbouncer.md
@@ -25,7 +25,7 @@ After confirming, Railway stages the changes. Deploy to complete the setup.
 
 ## Connection strings
 
-Once PgBouncer is deployed, four connection variables are available:
+Once PgBouncer is deployed, these connection variables are available:
 
 | Variable | Points to | Use for |
 |---|---|---|
@@ -33,6 +33,8 @@ Once PgBouncer is deployed, four connection variables are available:
 | `DATABASE_PUBLIC_URL` | PgBouncer — TCP proxy | Connecting from outside Railway |
 | `DATABASE_UNPOOLED_URL` | Postgres or HAProxy — private network | Operations that require a dedicated session |
 | `DATABASE_PUBLIC_UNPOOLED_URL` | Postgres or HAProxy — TCP proxy | Unpooled connections from outside Railway |
+
+The two public variables exist only while public access is enabled — if your Postgres was publicly exposed before adding PgBouncer, the public endpoint carries over to the pooler automatically; otherwise click **Connect** on the cluster view and add **Public Access**. `DATABASE_PUBLIC_UNPOOLED_URL` bypasses the pooler, so it additionally requires the database behind PgBouncer to be publicly exposed itself.
 
 Railway automatically migrates any service within your project that references your Postgres variables to point to PgBouncer. Hardcoded connection strings outside of Railway must be updated manually.
 

--- a/content/docs/databases/postgresql.md
+++ b/content/docs/databases/postgresql.md
@@ -36,7 +36,7 @@ it to connect to PostgreSQL but you can use these variables in whatever way work
 
 #### Connecting externally
 
-It is possible to connect to PostgreSQL externally (from outside of the [project](/projects) in which it is deployed), by using the [TCP Proxy](/networking/tcp-proxy) which is enabled by default.
+It is possible to connect to PostgreSQL externally (from outside of the [project](/projects) in which it is deployed). Databases are deployed private by default — to expose one, open the service's **Settings → Networking** and add **Public Access**. This creates a [TCP Proxy](/networking/tcp-proxy) and populates a `DATABASE_PUBLIC_URL` variable with the external connection string.
 
 _Keep in mind that you will be billed for [Network Egress](/pricing/plans#resource-usage-pricing) when using the TCP Proxy._
 

--- a/content/docs/databases/redis.md
+++ b/content/docs/databases/redis.md
@@ -32,7 +32,7 @@ Connect to the Redis server from another service in your project by [referencing
 
 #### Connecting externally
 
-It is possible to connect to Redis externally (from outside of the [project](/projects) in which it is deployed), by using the [TCP Proxy](/networking/tcp-proxy) which is enabled by default.
+It is possible to connect to Redis externally (from outside of the [project](/projects) in which it is deployed). Databases are deployed private by default — to expose one, open the service's **Settings → Networking** and add **Public Access**. This creates a [TCP Proxy](/networking/tcp-proxy) and populates a `REDIS_PUBLIC_URL` variable with the external connection string.
 
 _Keep in mind that you will be billed for [Network Egress](/pricing/plans#resource-usage-pricing) when using the TCP Proxy._
 

--- a/content/guides/connection-pooling-pgbouncer.md
+++ b/content/guides/connection-pooling-pgbouncer.md
@@ -37,7 +37,7 @@ Railway can deploy and manage PgBouncer for you, in front of either a standalone
 
 Railway automatically rewrites variable references within your project so services that used your Postgres variables now point at PgBouncer. Connection strings hardcoded outside Railway must be updated by hand.
 
-After deployment you get four connection variables:
+After deployment you get these connection variables:
 
 | Variable | Points to | Use for |
 |---|---|---|
@@ -45,6 +45,8 @@ After deployment you get four connection variables:
 | `DATABASE_PUBLIC_URL` | PgBouncer, TCP proxy | Connections from outside Railway |
 | `DATABASE_UNPOOLED_URL` | Postgres (or HAProxy for HA), private network | Operations that need a dedicated session |
 | `DATABASE_PUBLIC_UNPOOLED_URL` | Postgres (or HAProxy for HA), TCP proxy | Unpooled connections from outside Railway |
+
+The two public variables exist only while public access is enabled — a publicly exposed Postgres hands its endpoint to the pooler automatically; otherwise click **Connect** on the cluster view and add **Public Access**.
 
 The full reference for this feature, including scaling PgBouncer replicas and removing the pooler, is in the [PostgreSQL Connection Pooling docs](/databases/postgresql-pgbouncer).
 


### PR DESCRIPTION
## What

The database templates no longer ship with a TCP proxy enabled — databases deploy **private by default**, and public access is opt-in from the service's **Settings → Networking** (**Public Access**), which creates the [TCP Proxy] and populates the `*_PUBLIC_URL` variable.

- `postgresql.md`, `redis.md`, `mysql.md`, `mongodb.md`: the *Connecting externally* section still said the TCP Proxy "is enabled by default" — rewritten for the opt-in flow.
- `postgresql-ha.md`: clarified that converting a **publicly exposed** Postgres carries the public endpoint over to the **Postgres HA** service automatically, while private clusters stay private until Public Access is added.

Matches the current platform behavior (private-by-default database templates).