### PR TITLE
Document Context Sources (MCP context for Railway Agent and dev.new)

### DIFF
--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -17,6 +17,16 @@ The [Railway Agent](/ai/railway-agent) is a chat-based assistant built directly 
 
 [Get started with the Railway Agent →](/ai/railway-agent)
 
+### Context Sources
+
+[Context Sources](/ai/context-sources) connect Notion, Linear, Sentry, and your own MCP servers to Railway's agents. Attach a source to a chat from the Context picker, and the agent can use its tools while it works.
+
+- One-click connections for Notion, Linear, and Sentry, plus support for any custom MCP server
+- Works in both the Railway Agent and dev.new
+- Each connection is personal: it runs with the credentials of whichever member connected it
+
+[Get started with Context Sources →](/ai/context-sources)
+
 ### Agent integrations
 
 [Agent integrations](/ai/agent-integrations) bring the Railway Agent into your team chat on Slack and Discord. Mention **@Railway** to inspect deployments, read logs, and make changes without leaving the conversation.

--- a/content/docs/ai/context-sources.md
+++ b/content/docs/ai/context-sources.md
@@ -1,0 +1,59 @@
+---
+title: Context Sources
+description: Connect Notion, Linear, Sentry, and your own MCP servers, then attach their tools to Railway Agent and dev.new chats from the Context picker.
+---
+
+<Banner variant="primary">Context Sources are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+Context Sources connect external tools to Railway's agents. Once you connect a source, attach it to a chat from the Context picker, and the agent can call its tools while it works.
+
+**Note:** This is the opposite direction from the [Railway MCP Server](/ai/mcp-server), which lets external AI tools like Cursor and Claude Code call into Railway. Context Sources let Railway's own agents call out to Notion, Linear, Sentry, and other MCP servers.
+
+## Where you can use it
+
+Context Sources attach to chats in two places:
+
+- **[Railway Agent](/ai/railway-agent)** — the chat assistant built into the Railway dashboard.
+- **dev.new** — Railway's AI app builder, where an agent scaffolds, previews, and deploys an app for you in a sandboxed environment.
+
+Both surfaces read from the same connections. Connect a source once in your workspace, and it's available to attach in either place.
+
+## Standard context sources
+
+Railway maintains one-click connections for commonly used tools:
+
+- Notion
+- Linear
+- Sentry
+
+Click **Connect** on any of these cards in your workspace's <a href="https://railway.com/workspace/agents" target="_blank">Agents settings</a>, then authenticate through the provider's OAuth flow. Once connected, the source's tools are available to attach from the Context picker.
+
+## Custom MCP servers
+
+You can also register any remote MCP server that supports streamable HTTP, so agents can use the tools it exposes.
+
+To add a custom server:
+
+1. Navigate to your workspace's <a href="https://railway.com/workspace/agents" target="_blank">Agents settings</a>.
+2. Under **Context Sources**, expand **Custom MCP Servers**.
+3. Enter a **Name** for the server. The name becomes part of the tool names the agent sees (`<name>_<toolName>`), so it must be 1-32 characters of lowercase letters, digits, hyphens, or underscores.
+4. Enter the server's **URL**. Railway adds `https://` if you omit a scheme, and only connects over HTTPS.
+5. Optional: Add headers, such as an `Authorization` token, if the server requires them.
+
+Railway tests the connection automatically after you add or edit a server, and shows the result, connected with a tool count, or an error, on the server's row. If the server supports OAuth instead of a static header, authenticate from the same row.
+
+You can register up to 20 custom servers per workspace member.
+
+## Attach context to a chat
+
+Available sources appear in the composer's Context picker, grouped by kind. A source attaches automatically the first time it becomes available in a session, and stays attached until you remove it from the picker.
+
+Only the sources you have attached are sent to the agent for that message. Removing a source stops the agent from using its tools from that point on, without affecting earlier messages.
+
+## Permissions and scope
+
+Connecting and managing context sources requires workspace admin access. Workspace admins can see every member's connected sources for oversight, by name and host, never credentials, and can remove a member's server.
+
+Every context source is personal: it runs with the credentials of whichever member connected it, and its tools are only ever available on that member's own chats. Connecting a source doesn't share it with the rest of the workspace.
+
+Header values (such as an `Authorization` token) are encrypted at rest and can't be read back through the dashboard or API after you save them.

--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -20,6 +20,10 @@ When a deployment fails, the agent can automatically investigate. It reads the b
 
 If the fix is in your code, the agent can open a pull request with the change so you can review and merge it.
 
+## Context Sources
+
+Connect Notion, Linear, Sentry, or your own MCP servers, then attach them to a chat from the Context picker so the agent can use their tools while it works. See [Context Sources](/ai/context-sources) for setup and details.
+
 ## Pricing
 
 Usage of the Railway Agent is billed based on the underlying LLM tokens consumed, at the exact per-token rates published on <a href="https://www.anthropic.com/pricing" target="_blank">anthropic.com/pricing</a>, with no markup. See [Pricing](/pricing#railway-agent) for details.

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -108,6 +108,7 @@ export const sidebarContent: ISidebarContent = [
     slug: "/ai",
     content: [
       makePage("Railway Agent", "ai"),
+      makePage("Context Sources", "ai"),
       {
         subTitle: makePage("Agent integrations", undefined, "/ai/agent-integrations"),
         pages: [

--- a/src/generated/page-urls.json
+++ b/src/generated/page-urls.json
@@ -13,6 +13,7 @@
   "/ai/claude-code-plugin",
   "/ai/claude-connector",
   "/ai/codex-plugin",
+  "/ai/context-sources",
   "/ai/cursor-plugin",
   "/ai/grok-build-plugin",
   "/ai/mcp-server",


### PR DESCRIPTION
## Summary

Adds documentation for Context Sources — the feature that lets Railway's agents connect out to external MCP servers and use their tools during a chat.

- New page: `content/docs/ai/context-sources.md`, covering:
  - Standard (one-click) context sources: Notion, Linear, Sentry, connected via OAuth
  - Custom MCP servers: registering any streamable-HTTP MCP endpoint by URL, with optional auth headers
  - The Context picker: attach-by-default behavior and per-chat scoping
  - That it works identically in both the **Railway Agent** (dashboard chat) and **dev.new** (Railway's AI app builder)
  - Permissions (workspace admin to connect/manage) and personal scoping (a source only ever serves its owner's runs)
- Cross-links from `content/docs/ai.md` and `content/docs/ai/railway-agent.md`
- Sidebar entry in `src/data/sidebar.ts`, generated `src/generated/page-urls.json` updated

## Placement rationale

This lives under `/ai/` alongside `railway-agent.md`, not under `/agents.md` ("Railway for Agents"). Those are the opposite direction: `/agents.md` and `/ai/mcp-server.md` cover *external* AI tools (Cursor, Claude Code) calling *into* Railway via `mcp.railway.com`. Context Sources is Railway's own agents calling *out* to Notion/Linear/Sentry/custom MCP servers — the new page calls out this distinction explicitly to avoid confusion between the two "MCP" features.

## Status note for reviewers

This documents a feature currently gated behind the admin-only `AGENT_CONTEXT_SOURCES` flag in `railwayapp/mono`. It's marked with the same `Priority Boarding` banner pattern already used for other flagged features ahead of GA (see `sandboxes.md`, `feature-flags.md`). `dev.new` itself has no other public docs page yet, so it's introduced here with a one-line description rather than a full product page — worth a second look from whoever owns that launch.

## Test plan

- [x] Ran `pnpm install` + `pnpm dev`, confirmed `/ai/context-sources`, `/ai`, and `/ai/railway-agent` all return 200 and render correctly (Banner, links, headings compile through content-collections/MDX without errors)
- [x] Verified all internal links resolve to existing pages
- [x] Verified technical claims (OAuth flow, HTTPS-only, header encryption, name pattern, 20-server limit, admin-gated settings UI, personal-only scoping) against `railwayapp/mono` source (`packages/backboard/src/controllers/workspaces/mcpServers.ts`, `mcpCatalog.ts`, `contextIntegrationRegistry.ts`, and the frontend settings/chat components)