### PR TITLE
Document cloud agents

### DIFF
--- a/content/docs/agents.md
+++ b/content/docs/agents.md
@@ -42,6 +42,13 @@ railway setup agent
     icon="Star"
     tone="green"
   />
+  <Card
+    title="Cloud agents"
+    description="Run Claude Code, Codex, or Grok CLI on a persistent Railway VM with your own credentials. Launch from the terminal and reconnect to sessions later."
+    href="/cloud-agents"
+    icon="Bash"
+    tone="purple"
+  />
 </CardGrid>
 
 ## When to use each
@@ -50,3 +57,4 @@ railway setup agent
 - **Railway MCP (Remote)** — preferred when the user wants hosted OAuth MCP, or when local CLI configuration is unavailable. Also exposes the powerful `railway-agent` tool for multi-step operations.
 - **Railway CLI** — preferred when the task depends on local machine state: current-directory deploys, `railway up`, `railway run`, SSH, and local linking.
 - **Agent Skills** — install alongside any of the above so agents arrive with Railway-specific procedural knowledge instead of guessing.
+- **Cloud agents** are preferred when the work should outlive the local terminal: a persistent VM running the coding agent, with sessions you can leave and reattach to.

--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -17,6 +17,16 @@ The [Railway Agent](/ai/railway-agent) is a chat-based assistant built directly 
 
 [Get started with the Railway Agent →](/ai/railway-agent)
 
+### Cloud agents
+
+[Cloud agents](/cloud-agents) run Claude Code, Codex, or Grok CLI on a persistent Railway virtual machine, signed in as you. Launch one from the terminal and reconnect to it later with your work still in place.
+
+- Runs the coding agent you already use, with your own credentials
+- Keeps its disk between runs, and sleeps when you disconnect
+- Manages agents and sessions from `railway ca`
+
+[Get started with cloud agents →](/cloud-agents/getting-started)
+
 ### Agent integrations
 
 [Agent integrations](/ai/agent-integrations) bring the Railway Agent into your team chat on Slack and Discord. Mention **@Railway** to inspect deployments, read logs, and make changes without leaving the conversation.

--- a/content/docs/cli/ca.md
+++ b/content/docs/cli/ca.md
@@ -1,0 +1,141 @@
+---
+title: railway ca
+description: Browse, launch, and manage cloud agents from a terminal interface.
+---
+
+Browse your projects, launch [cloud agents](/cloud-agents), and connect to the sessions running on them.
+
+<Banner variant="info">The `ca` command requires cloud agents to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
+
+## Usage
+
+```bash
+railway ca [COMMAND] [OPTIONS]
+```
+
+Running `railway ca` with no arguments opens the terminal interface. Passing any launch option skips it and launches directly, the same as [`railway code`](/cli/code).
+
+## Subcommands
+
+| Subcommand | Description |
+|------------|-------------|
+| `setup` | Configure the default project, coding agent, skills sync, and theme |
+| `start` | Launch a cloud agent without opening the interface |
+
+## Options
+
+These options apply to `railway ca` and `railway ca start`, and are the same ones [`railway code`](/cli/code) takes.
+
+| Option | Description |
+|--------|-------------|
+| `--claude` | Launch Claude Code |
+| `--codex` | Launch Codex |
+| `--grok` | Launch Grok CLI |
+| `--new` | Create a fresh agent instead of reusing this environment's |
+| `--keep-awake` | Leave the agent running on disconnect instead of sleeping it |
+| `--rm` | Destroy this environment's agent and exit |
+| `--refresh-auth` | Re-mint the Claude credential on an agent that already has one |
+| `--name <NAME>` | Name a newly created agent |
+| `--gh` | Include your GitHub token, read with `gh auth token` |
+| `--variable <KEY=VALUE>` | Set a variable on a newly created agent (repeatable) |
+| `--env-file <PATH>` | Load variables from a `.env` file (repeatable) |
+| `-p`, `--project <PROJECT>` | Project ID |
+| `-e`, `--environment <ENVIRONMENT>` | Environment name or ID |
+
+With no agent option, `railway ca` launches the coding agent saved by `railway ca setup`. Set `RAILWAY_CA_AGENT` to override the saved agent for one run.
+
+## Configure cloud agents
+
+`railway ca setup` asks four questions and writes the answers to `~/.railway/agent-prefs.json`: where agents run, which coding agent to launch, whether to sync your skills, and which theme to draw with. See [Getting started](/cloud-agents/getting-started) for a walkthrough.
+
+| Option | Description |
+|--------|-------------|
+| `-y`, `--yes` | Skip the prompts, keeping existing preferences |
+| `--show` | Print the saved preferences and exit |
+
+Running `railway ca` on a machine with no preferences opens the same flow.
+
+## The interface
+
+The menu offers three actions, a prompt to describe a task, and the target project the prompt lands in.
+
+| Action | Description |
+|--------|-------------|
+| **New Session** | Start another session on an agent you already have |
+| **New Cloud Agent** | Create a machine in the target project |
+| **Manage Cloud Agents** | Open the tree of projects, agents, and sessions |
+
+Typing a task into the prompt and pressing `enter` launches an agent with that task. Press `^t` to change the target project, which also updates the default saved by setup.
+
+**Note:** New Session asks which agent to use when the target holds more than one. When the target holds none, it says so rather than creating a machine, which is what New Cloud Agent is for.
+
+### Keys
+
+Press `?` for the full list. The keys below act on whatever the cursor is on.
+
+| Key | Does |
+|-----|------|
+| `↑` `↓` | Move up and down |
+| `→` `←` | Open and close a row |
+| `enter` | Open a row, or connect to a session and type in it |
+| `shift+esc` or `^]` | Stop typing in a session |
+| `n` | Start a session on an agent, or an agent on a project |
+| `x` | End the session |
+| `s` | Sleep the agent |
+| `w` | Wake the agent |
+| `d` | Delete the agent, after a confirmation |
+| `c` | Copy an SSH command for the session |
+| `r` | Refresh |
+| `t` | Set the prompt's target |
+| `⌥f` | Give the session the whole screen, and restore the tree when pressed again |
+| `shift+enter` | Leave the interface and connect to the session full screen |
+| `⌥t` | Cycle the color theme |
+| `⌥s` | Open setup |
+| `esc` | Return to the menu |
+| `^c` | Quit |
+
+### Mouse
+
+Click a menu card to open it, or the prompt box to type in it. In the tree, click a row to select it and double-click a session to connect.
+
+In a connected session, the wheel scrolls the agent's output and clicking a link opens it in your browser. Drag to select text, which copies it when you release.
+
+When the coding agent handles the mouse itself, clicks reach the agent so its own clickable output works. Hold `shift` while dragging to select text instead.
+
+## Examples
+
+### Open the interface
+
+```bash
+railway ca
+```
+
+### Configure cloud agents
+
+```bash
+railway ca setup
+```
+
+### Print your preferences
+
+```bash
+railway ca setup --show
+```
+
+### Launch without the interface
+
+```bash
+railway ca start --claude
+```
+
+### Launch a fresh agent
+
+```bash
+railway ca start --codex --new
+```
+
+### Launch into a specific environment
+
+```bash
+railway ca start --claude --project my-project --environment production
+```

--- a/content/docs/cli/ca.md
+++ b/content/docs/cli/ca.md
@@ -13,7 +13,7 @@ Browse your projects, launch [cloud agents](/cloud-agents), and connect to the s
 railway ca [COMMAND] [OPTIONS]
 ```
 
-Running `railway ca` with no arguments opens the terminal interface. Passing any launch option skips it and launches directly, the same as [`railway code`](/cli/code).
+Running `railway ca` with no arguments opens the terminal interface. Passing any launch option skips it and launches directly, the same as [`railway code`](/cli/code). Railway also skips the interface when stdout isn't a terminal, so scripts get the launcher.
 
 ## Subcommands
 
@@ -46,11 +46,11 @@ With no agent option, `railway ca` launches the coding agent saved by `railway c
 
 ## Configure cloud agents
 
-`railway ca setup` asks four questions and writes the answers to `~/.railway/agent-prefs.json`: where agents run, which coding agent to launch, whether to sync your skills, and which theme to draw with. See [Getting started](/cloud-agents/getting-started) for a walkthrough.
+`railway ca setup` asks where agents run, which coding agent to launch, whether to sync your skills, and which theme to draw with, then writes the answers to `~/.railway/agent-prefs.json`. See [Getting started](/cloud-agents/getting-started) for a walkthrough.
 
 | Option | Description |
 |--------|-------------|
-| `-y`, `--yes` | Skip the prompts, keeping existing preferences |
+| `-y`, `--yes` | Skip the prompts. Keeps existing preferences, and otherwise picks the first detected agent with skills sync off. Railway engages this when stdout isn't a terminal |
 | `--show` | Print the saved preferences and exit |
 
 Running `railway ca` on a machine with no preferences opens the same flow.
@@ -100,7 +100,7 @@ Click a menu card to open it, or the prompt box to type in it. In the tree, clic
 
 In a connected session, the wheel scrolls the agent's output and clicking a link opens it in your browser. Drag to select text, which copies it when you release.
 
-When the coding agent handles the mouse itself, clicks reach the agent so its own clickable output works. Hold `shift` while dragging to select text instead.
+When the coding agent handles the mouse itself, clicks reach the agent so its own clickable output works. This starts once the pane has the keyboard, so the click that focuses a pane stays with the interface. Hold `shift` while dragging to select text instead.
 
 ## Examples
 
@@ -137,5 +137,7 @@ railway ca start --codex --new
 ### Launch into a specific environment
 
 ```bash
-railway ca start --claude --project my-project --environment production
+railway ca start --claude --project 5a4b3c2d-1e0f-4a5b-8c7d-6e5f4a3b2c1d --environment production
 ```
+
+`--project` takes a project ID. `--environment` takes a name or an ID.

--- a/content/docs/cli/code.md
+++ b/content/docs/cli/code.md
@@ -1,6 +1,6 @@
 ---
 title: railway code
-description: Launch a coding agent on a cloud agent VM using your local sign-in.
+description: Launch a coding agent on a cloud agent VM with your own credentials.
 ---
 
 Launch Claude Code, Codex, or Grok CLI on a [cloud agent](/cloud-agents) and hand your terminal to it.
@@ -42,13 +42,13 @@ Railway resolves the target project and environment in this order:
 1. The `--project` and `--environment` options.
 2. The default project saved by `railway ca setup`.
 3. The [linked project](/cli/link) in the working directory.
-4. The setup flow, which saves your answer for later launches.
+4. `railway ca setup`, which Railway opens for you. Setup saves the answer, so later launches skip this step.
 
 Within that environment, Railway reuses the agent it remembers, adopts your existing agent when there's no local record, and creates one when you have none. See [Reuse and create agents](/cloud-agents#reuse-and-create-agents).
 
 ## Credentials
 
-Railway reads your local credential, tells you which one it's using, and writes it to the agent over SSH. Credentials never reach a machine specification, an image, a command line, or Railway's servers.
+Railway reads your local credential, tells you which one it's using, and writes it to the agent over SSH. It doesn't store the credential: it never becomes a Railway variable, part of an image, or an argument on a command line.
 
 Claude Code needs a token minted for the VM, because its local sign-in uses a rotating refresh token. Railway runs `claude setup-token` for you, caches the result, and reuses it on later launches. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` to supply your own instead.
 

--- a/content/docs/cli/code.md
+++ b/content/docs/cli/code.md
@@ -1,0 +1,123 @@
+---
+title: railway code
+description: Launch a coding agent on a cloud agent VM using your local sign-in.
+---
+
+Launch Claude Code, Codex, or Grok CLI on a [cloud agent](/cloud-agents) and hand your terminal to it.
+
+<Banner variant="info">The `code` command requires cloud agents to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
+
+## Usage
+
+```bash
+railway code [OPTIONS] [-- <AGENT_ARGS>...]
+```
+
+`railway code` is the launcher on its own. [`railway ca`](/cli/ca) opens a terminal interface over the same launcher, reads the same preferences, and takes the same options.
+
+## Options
+
+| Option | Description |
+|--------|-------------|
+| `--claude` | Launch Claude Code, minting a token with `claude setup-token` |
+| `--codex` | Launch Codex using `~/.codex/auth.json` |
+| `--grok` | Launch Grok CLI using `~/.grok/auth.json` |
+| `--new` | Create a fresh agent instead of reusing this environment's |
+| `--keep-awake` | Leave the agent running on disconnect instead of sleeping it |
+| `--rm` | Destroy this environment's agent and exit |
+| `--refresh-auth` | Re-mint the Claude credential on an agent that already has one |
+| `--name <NAME>` | Name a newly created agent |
+| `--gh` | Include your GitHub token, read with `gh auth token` |
+| `--variable <KEY=VALUE>` | Set a variable on a newly created agent (repeatable) |
+| `--env-file <PATH>` | Load variables from a `.env` file (repeatable) |
+| `-p`, `--project <PROJECT>` | Project ID |
+| `-e`, `--environment <ENVIRONMENT>` | Environment name or ID |
+
+With no agent option, `railway code` launches the coding agent saved by `railway ca setup`. Set `RAILWAY_CA_AGENT` to override the saved agent for one run.
+
+## Where the agent runs
+
+Railway resolves the target project and environment in this order:
+
+1. The `--project` and `--environment` options.
+2. The default project saved by `railway ca setup`.
+3. The [linked project](/cli/link) in the working directory.
+4. The setup flow, which saves your answer for later launches.
+
+Within that environment, Railway reuses the agent it remembers, adopts your existing agent when there's no local record, and creates one when you have none. See [Reuse and create agents](/cloud-agents#reuse-and-create-agents).
+
+## Credentials
+
+Railway reads your local credential, tells you which one it's using, and writes it to the agent over SSH. Credentials never reach a machine specification, an image, a command line, or Railway's servers.
+
+Claude Code needs a token minted for the VM, because its local sign-in uses a rotating refresh token. Railway runs `claude setup-token` for you, caches the result, and reuses it on later launches. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` to supply your own instead.
+
+Codex and Grok CLI read their local `auth.json`, so a missing sign-in fails before Railway creates a machine.
+
+Running `railway logout` deletes the cached Claude token from your machine.
+
+## Agent arguments
+
+Arguments after `--` pass through to the coding agent. Railway runs them and exits when the agent finishes, rather than leaving you in a session:
+
+```bash
+railway code --codex -- exec "explain this codebase"
+```
+
+To start an interactive session with a task already handed to the agent, use the prompt in [`railway ca`](/cli/ca).
+
+## Examples
+
+### Launch your configured agent
+
+```bash
+railway code
+```
+
+### Launch Codex with your local sign-in
+
+```bash
+railway code --codex
+```
+
+### Force a fresh agent
+
+```bash
+railway code --codex --new
+```
+
+### Include your GitHub authentication
+
+```bash
+railway code --claude --gh
+```
+
+### Create an agent with variables
+
+```bash
+railway code --codex --new --variable DATABASE_URL=postgres.DATABASE_URL
+```
+
+Values can reference variables from other services in the environment. Railway resolves them when the agent is created, so pair `--variable` with `--new`.
+
+### Create an agent from a variables file
+
+```bash
+railway code --codex --new --env-file .env
+```
+
+### Keep the agent running after you disconnect
+
+```bash
+railway code --claude --keep-awake
+```
+
+A running agent bills for compute even when nothing is connected to it.
+
+### Destroy the agent
+
+```bash
+railway code --rm
+```
+
+This deletes the agent for the target environment along with its disk.

--- a/content/docs/cloud-agents.md
+++ b/content/docs/cloud-agents.md
@@ -1,0 +1,166 @@
+---
+title: Cloud agents
+description: Run Claude Code, Codex, or Grok CLI on a persistent Railway virtual machine using your own credentials. Launch from the CLI, keep several sessions open at once, and pick up where you left off.
+---
+
+<Banner variant="primary">Cloud agents are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+A cloud agent is a persistent Linux virtual machine that runs a coding agent signed in as you.
+
+Each cloud agent is scoped to a Railway [environment](/environments) and keeps its disk between runs, so the work an agent did yesterday is still there when you reconnect.
+
+Railway supports three coding agents: Claude Code, Codex, and Grok CLI.
+
+## How it works
+
+The `cloud-agent-base` image ships every supported coding agent, and the VM configures them on each boot. Launching doesn't install or configure anything, so an agent is ready to work as soon as the machine is running.
+
+Your credentials are read on your machine and written to the VM over SSH. They never reach a machine specification, an image, a command line, or Railway's servers.
+
+Work happens in durable sessions. A session survives the SSH connection that started it, so closing your terminal doesn't stop the agent, and reconnecting attaches to the same screen rather than starting over.
+
+## Launch an agent
+
+Two commands launch a cloud agent, and both accept the same flags.
+
+Use [`railway code`](/cli/code) to launch one agent and hand your terminal to it:
+
+```bash
+railway code --claude
+```
+
+Use [`railway ca`](/cli/ca) to browse your projects, agents, and sessions in a terminal interface first:
+
+```bash
+railway ca
+```
+
+Both read the same preferences, so the choice between them is whether you want to browse before you launch.
+
+## Choose where agents run
+
+Cloud agents live in a project environment. Set a default once, and every launch uses it:
+
+```bash
+railway ca setup
+```
+
+The setup flow can create a project named "Cloud Agents" for you, or point at one you already have. You can change the default later in setup, or with `^t` in `railway ca`.
+
+Railway resolves the target in this order:
+
+| Order | Source |
+|-------|--------|
+| 1 | The `--project` and `--environment` flags |
+| 2 | The default project saved by `railway ca setup` |
+| 3 | The [linked project](/cli/link) in the working directory |
+| 4 | The setup flow, which saves your answer for later launches |
+
+The saved default takes precedence over a linked directory. Linking describes what you deploy, so running `railway code` inside a service's checkout doesn't put an agent in that project.
+
+## Reuse and create agents
+
+Railway remembers one agent per environment. Running `railway code` again reuses it, which keeps your disk and avoids paying for a second machine.
+
+When there's no local record of which agent to use, such as on a second computer, Railway adopts your existing agent in that environment. It only considers agents you own, so it can't attach your credentials to a teammate's machine. If you own several and Railway can't tell which one you mean, it lists them and asks you to pick one with `railway ca`.
+
+Pass `--new` to create a fresh agent instead of reusing one:
+
+```bash
+railway code --claude --new
+```
+
+## Manage the agent lifecycle
+
+Cloud agents have no idle timeout, so nothing stops one on its own. Disconnecting puts the agent to sleep, which stops billing for compute and keeps the disk. The next launch wakes it with your work in place.
+
+| Action | How |
+|--------|-----|
+| Sleep on disconnect | Default behavior |
+| Stay running after you disconnect | `railway code --keep-awake` |
+| Destroy the agent and its disk | `railway code --rm` |
+| Sleep, wake, or delete a specific agent | `railway ca`, then `s`, `w`, or `d` |
+
+<Banner variant="warning">
+A running agent bills for compute even when nothing is connected to it. Use `--keep-awake` when you want a task to continue after you disconnect, and expect the cost.
+</Banner>
+
+Waking a machine takes longer than resuming a session. Railway reports the agent as waking until the VM is up, then as running.
+
+## Deliver credentials
+
+Each coding agent signs in differently, so each one carries its credential differently.
+
+| Agent | Flag | Credential |
+|-------|------|------------|
+| Claude Code | `--claude` | A token minted by `claude setup-token`, cached locally and reused. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` to skip minting |
+| Codex | `--codex` | Your local `~/.codex/auth.json` |
+| Grok CLI | `--grok` | Your local `~/.grok/auth.json` |
+
+Claude Code's local sign-in uses a rotating refresh token, which is why Railway mints a separate token for the VM instead of copying it. Minting opens your browser once. To mint a replacement after revoking a token, or when authentication fails on an agent you already have, run:
+
+```bash
+railway code --claude --refresh-auth
+```
+
+Add `--gh` to include your GitHub token, read with `gh auth token`, so `git` and `gh` can reach your repositories over HTTPS from inside the agent:
+
+```bash
+railway code --claude --gh
+```
+
+Running `railway logout` deletes the cached Claude token from your machine. Revoking the token upstream is separate.
+
+## Sync your skills
+
+Cloud agents can bring the [agent skills](/ai/agent-skills) you use locally. Turn this on in `railway ca setup` and pick which directory to read:
+
+- `~/.claude/skills`
+- `~/.codex/skills`
+- `~/.grok/skills`
+- `~/.agents/skills`
+
+Railway packs that directory on each launch and unpacks it into `~/.railway-skills` on the VM, then links each skill into every coding agent's skills directory. Syncing is add-only: it never replaces a skill name the agent already has, so Railway's own skills stay the versions baked into the image.
+
+Two limits apply. A packed directory over 2 MB warns, and one over 10 MB fails before a machine is created. Railway skips the upload when the contents haven't changed since the last launch.
+
+## Set variables
+
+Variables reach a cloud agent when it's created, so pair them with `--new`:
+
+```bash
+railway code --codex --new --variable DATABASE_URL=postgres.DATABASE_URL
+```
+
+Values can reference variables from other services in the environment, using either the short form above or the full `${{postgres.DATABASE_URL}}` form. Railway resolves them when the agent is created. See [Variables](/variables) for the reference syntax.
+
+Load variables from a file with `--env-file`. Any `--variable` flag overrides a file entry with the same key:
+
+```bash
+railway code --codex --new --env-file .env
+```
+
+## Store preferences
+
+`railway ca setup` writes your answers to `~/.railway/agent-prefs.json` with owner-only permissions.
+
+| Field | Holds |
+|-------|-------|
+| `agent` | The coding agent to launch when no flag is passed |
+| `default_project` | The project and environment agents run in |
+| `skills` | Whether to sync skills, and which directory to read |
+| `theme` | The color theme `railway ca` draws with |
+
+A flag always beats the file. `RAILWAY_CA_AGENT` overrides the saved agent for a single run.
+
+To read the file back without opening it:
+
+```bash
+railway ca setup --show
+```
+
+## Work in the VM
+
+Sessions start in `/app`, which is where the agent's configuration grants it permission to work. Files you write outside `/app` persist on the disk, but the coding agent may prompt before touching them.
+
+Every session runs on the same machine, so several agents working at once share one disk. Two agents editing the same files will conflict, the same as two terminals would.

--- a/content/docs/cloud-agents.md
+++ b/content/docs/cloud-agents.md
@@ -93,7 +93,7 @@ Each coding agent signs in differently, so each one carries its credential diffe
 
 | Agent | Flag | Credential |
 |-------|------|------------|
-| Claude Code | `--claude` | A token minted by `claude setup-token`, cached locally and reused. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` to skip minting |
+| Claude Code | `--claude` | A token minted by `claude setup-token`, cached in `~/.railway/claude-code-token` and reused. Set `CLAUDE_CODE_OAUTH_TOKEN` or `ANTHROPIC_API_KEY` to skip minting |
 | Codex | `--codex` | Your local `~/.codex/auth.json` |
 | Grok CLI | `--grok` | Your local `~/.grok/auth.json` |
 
@@ -109,7 +109,9 @@ Add `--gh` to include your GitHub token, read with `gh auth token`, so `git` and
 railway code --claude --gh
 ```
 
-Running `railway logout` deletes the cached Claude token from your machine. Revoking the token upstream is separate.
+Minting runs the `claude` binary on your machine, so Claude Code must be installed locally even though the VM is what uses the token.
+
+Running `railway logout` deletes the cached token from your machine. Revoking it upstream is separate.
 
 ## Sync your skills
 
@@ -120,9 +122,11 @@ Cloud agents can bring the [agent skills](/ai/agent-skills) you use locally. Tur
 - `~/.grok/skills`
 - `~/.agents/skills`
 
-Railway packs that directory on each launch and unpacks it into `~/.railway-skills` on the VM, then links each skill into every coding agent's skills directory. Syncing is add-only: it never replaces a skill name the agent already has, so Railway's own skills stay the versions baked into the image.
+Railway packs that directory on each launch and unpacks it into `~/.railway-skills` on the VM, then links each skill into `~/.claude/skills`, `~/.codex/skills`, and `~/.grok/skills`. Syncing is add-only: it links a skill only when nothing already holds that name, so Railway's own skills stay the versions baked into the image.
 
-Two limits apply. A packed directory over 2 MB warns, and one over 10 MB fails before a machine is created. Railway skips the upload when the contents haven't changed since the last launch.
+Two limits apply. A packed directory over 2 MB warns, and one over 10 MB fails before Railway creates a machine. Railway skips the upload when the contents haven't changed since the last launch.
+
+Turning skills sync off later leaves whatever is already on an agent.
 
 ## Set variables
 
@@ -161,6 +165,6 @@ railway ca setup --show
 
 ## Work in the VM
 
-Sessions start in `/app`, which is where the agent's configuration grants it permission to work. Files you write outside `/app` persist on the disk, but the coding agent may prompt before touching them.
+Sessions start in `/app`, which is where the coding agent is configured to work. Files written anywhere on the disk persist between runs.
 
 Every session runs on the same machine, so several agents working at once share one disk. Two agents editing the same files will conflict, the same as two terminals would.

--- a/content/docs/cloud-agents.md
+++ b/content/docs/cloud-agents.md
@@ -13,9 +13,9 @@ Railway supports three coding agents: Claude Code, Codex, and Grok CLI.
 
 ## How it works
 
-The `cloud-agent-base` image ships every supported coding agent, and the VM configures them on each boot. Launching doesn't install or configure anything, so an agent is ready to work as soon as the machine is running.
+Every supported coding agent is already installed on the machine image, and Railway configures them on each boot. Launching installs nothing, so an agent is ready to work as soon as the machine is running.
 
-Your credentials are read on your machine and written to the VM over SSH. They never reach a machine specification, an image, a command line, or Railway's servers.
+Railway reads your credentials on your own machine and writes them to the VM over SSH. It doesn't store them: they never become a Railway variable, part of an image, or an argument on a command line.
 
 Work happens in durable sessions. A session survives the SSH connection that started it, so closing your terminal doesn't stop the agent, and reconnecting attaches to the same screen rather than starting over.
 
@@ -54,7 +54,7 @@ Railway resolves the target in this order:
 | 1 | The `--project` and `--environment` flags |
 | 2 | The default project saved by `railway ca setup` |
 | 3 | The [linked project](/cli/link) in the working directory |
-| 4 | The setup flow, which saves your answer for later launches |
+| 4 | `railway ca setup`, which Railway opens when nothing above applies |
 
 The saved default takes precedence over a linked directory. Linking describes what you deploy, so running `railway code` inside a service's checkout doesn't put an agent in that project.
 

--- a/content/docs/cloud-agents/getting-started.md
+++ b/content/docs/cloud-agents/getting-started.md
@@ -1,0 +1,116 @@
+---
+title: Getting started with cloud agents
+description: Configure cloud agents with railway ca setup, launch your first agent, and manage agents and sessions from the terminal.
+---
+
+<Banner variant="primary">Cloud agents are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+
+This page takes you from an unconfigured machine to a running [cloud agent](/cloud-agents) you can reconnect to.
+
+Setup asks four questions once and saves the answers, so later launches need no flags.
+
+## Before you start
+
+You need three things in place:
+
+- The [Railway CLI](/cli) installed and signed in with `railway login`
+- Cloud agents enabled for your account through [Priority Boarding](/platform/priority-boarding)
+- A local sign-in for at least one supported coding agent: Claude Code, Codex, or Grok CLI
+
+Railway carries your local credential to the agent, so sign in to the coding agent on your own machine first.
+
+## Set up cloud agents
+
+Start the configuration flow:
+
+```bash
+railway ca setup
+```
+
+Running `railway ca` on a machine with no preferences opens the same flow, so you can start there instead. Setup asks four questions:
+
+<Steps>
+  <Step title="Choose where agents run">
+    Select **Create a project** to have Railway make a project named "Cloud Agents", or select **Use an existing project** to pick one you already have.
+
+    This becomes your default project. Every launch creates and finds agents there unless you pass `--project` and `--environment`.
+  </Step>
+  <Step title="Choose a coding agent">
+    Select Claude Code, Codex, or Grok CLI. Setup marks the agents it detects a local sign-in for.
+
+    This is the agent that runs when you launch without `--claude`, `--codex`, or `--grok`.
+  </Step>
+  <Step title="Decide about skills">
+    Select **Bring my skills** to copy your local [agent skills](/ai/agent-skills) to each agent, or **Do not sync skills** to run with the skills baked into the image.
+
+    Syncing is add-only, so it never replaces a skill the agent already has.
+  </Step>
+  <Step title="Pick a theme">
+    Select a color theme for `railway ca`. The preview updates as you move through the options.
+
+    Setup writes everything to `~/.railway/agent-prefs.json`. Run `railway ca setup --show` to read it back.
+  </Step>
+</Steps>
+
+## Launch your first agent
+
+With setup finished, launch the agent you configured:
+
+```bash
+railway code
+```
+
+Railway creates a machine in your default project, delivers your credential, and starts the coding agent in your terminal. The first launch takes longer than later ones because it creates the VM.
+
+To describe the task up front instead, open the terminal interface and type it into the prompt:
+
+```bash
+railway ca
+```
+
+Press `enter` to launch. Railway hands the text to the agent as it starts.
+
+## Manage agents and sessions
+
+`railway ca` opens on a menu with three actions:
+
+| Action | Does |
+|--------|------|
+| **New Session** | Starts another session on an agent you already have |
+| **New Cloud Agent** | Creates a machine in the target project |
+| **Manage Cloud Agents** | Opens the tree of projects, agents, and sessions |
+
+Select **Manage Cloud Agents** to see your workspaces, projects, environments, agents, and the sessions running on each agent. The pane on the right shows the session you're connected to.
+
+These keys act on whatever the cursor is on:
+
+| Key | Does |
+|-----|------|
+| `enter` | Connects to a session and types in it |
+| `shift+esc` or `^]` | Stops typing and returns the keyboard to the tree |
+| `n` | Starts another session on this agent |
+| `x` | Ends the session |
+| `s` | Puts the agent to sleep |
+| `w` | Wakes the agent |
+| `d` | Deletes the agent, after a confirmation |
+| `c` | Copies an SSH command for the session |
+| `⌥f` | Gives the session the whole screen, and restores the tree when pressed again |
+| `shift+enter` | Leaves the interface and connects to the session full screen |
+| `?` | Lists every key |
+
+Press `esc` to return to the menu, and `^c` to quit.
+
+## Reconnect to your work
+
+Sessions outlive the connection that started them. Closing your terminal leaves the agent working, and the next `railway ca` shows the session still running.
+
+Disconnecting puts the agent to sleep, which stops compute billing and keeps the disk. Running `railway code` again wakes it with your files in place. To keep an agent running after you disconnect, launch it with `--keep-awake`.
+
+## Next steps
+
+Explore these resources to get more out of cloud agents:
+
+- [Cloud agents](/cloud-agents)
+- [`railway ca`](/cli/ca)
+- [`railway code`](/cli/code)
+- [Agent skills](/ai/agent-skills)

--- a/content/docs/cloud-agents/getting-started.md
+++ b/content/docs/cloud-agents/getting-started.md
@@ -7,7 +7,7 @@ description: Configure cloud agents with railway ca setup, launch your first age
 
 This page takes you from an unconfigured machine to a running [cloud agent](/cloud-agents) you can reconnect to.
 
-Setup asks four questions once and saves the answers, so later launches need no flags.
+Setup asks where agents run, which coding agent to launch, whether to bring your skills, and which theme to use. It saves the answers, so later launches need no flags.
 
 ## Before you start
 
@@ -15,9 +15,9 @@ You need three things in place:
 
 - The [Railway CLI](/cli) installed and signed in with `railway login`
 - Cloud agents enabled for your account through [Priority Boarding](/platform/priority-boarding)
-- A local sign-in for at least one supported coding agent: Claude Code, Codex, or Grok CLI
+- Claude Code, Codex, or Grok CLI installed on your machine
 
-Railway carries your local credential to the agent, so sign in to the coding agent on your own machine first.
+Railway reads the coding agent's credential from your machine. Codex and Grok CLI need a completed local sign-in. Claude Code mints a token in your browser the first time you launch, so it doesn't.
 
 ## Set up cloud agents
 
@@ -27,28 +27,28 @@ Start the configuration flow:
 railway ca setup
 ```
 
-Running `railway ca` on a machine with no preferences opens the same flow, so you can start there instead. Setup asks four questions:
+Running `railway ca` on a machine with no preferences opens the same flow, so you can start there instead.
 
 <Steps>
   <Step title="Choose where agents run">
-    Select **Create a project** to have Railway make a project named "Cloud Agents", or select **Use an existing project** to pick one you already have.
+    Select **Create a default project** to have Railway make a project named "Cloud Agents", or **Use an existing project** to pick one you already have. Select **Skip** to choose a target on each launch instead.
 
     This becomes your default project. Every launch creates and finds agents there unless you pass `--project` and `--environment`.
   </Step>
   <Step title="Choose a coding agent">
-    Select Claude Code, Codex, or Grok CLI. Setup marks the agents it detects a local sign-in for.
+    Select Claude Code, Codex, or Grok CLI. Setup marks the agents it finds a local configuration directory for.
 
     This is the agent that runs when you launch without `--claude`, `--codex`, or `--grok`.
   </Step>
   <Step title="Decide about skills">
-    Select **Bring my skills** to copy your local [agent skills](/ai/agent-skills) to each agent, or **Do not sync skills** to run with the skills baked into the image.
+    Answer whether to bring your own [agent skills](/ai/agent-skills) to cloud agents. Setup counts what it found and asks which directory to read when more than one holds skills.
 
-    Syncing is add-only, so it never replaces a skill the agent already has.
+    Syncing is add-only, so it never replaces a skill the agent already has. Setup skips this question when it finds no skills of yours to send.
   </Step>
   <Step title="Pick a theme">
-    Select a color theme for `railway ca`. The preview updates as you move through the options.
+    Select a color theme for `railway ca`.
 
-    Setup writes everything to `~/.railway/agent-prefs.json`. Run `railway ca setup --show` to read it back.
+    Setup then prints what it saved and the path it wrote to, `~/.railway/agent-prefs.json`. Run `railway ca setup --show` to read it back later.
   </Step>
 </Steps>
 

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -109,6 +109,10 @@ export const sidebarContent: ISidebarContent = [
     content: [
       makePage("Railway Agent", "ai"),
       {
+        subTitle: makePage("Cloud agents", undefined, "/cloud-agents"),
+        pages: [makePage("Getting started", "cloud-agents")],
+      },
+      {
         subTitle: makePage("Agent integrations", undefined, "/ai/agent-integrations"),
         pages: [
           makePage("Slack", "ai/agent-integrations"),
@@ -265,7 +269,9 @@ export const sidebarContent: ISidebarContent = [
       makeCliCommand("api"),
       makeCliCommand("autoupdate"),
       makeCliCommand("bucket"),
+      makeCliCommand("ca"),
       makeCliCommand("cdn"),
+      makeCliCommand("code"),
       makeCliCommand("completion"),
       makeCliCommand("connect"),
       makeCliCommand("delete"),


### PR DESCRIPTION
Docs for cloud agents: persistent VMs running Claude Code, Codex, or Grok CLI with the reader's own credentials.

Depends on railwayapp/cli#1013 for the commands.

## New pages

| Page | Covers |
|---|---|
| `/cloud-agents` | Definition, target resolution, reuse, lifecycle and billing, credentials per agent, skills sync, variables, preferences file |
| `/cloud-agents/getting-started` | `railway ca setup` walkthrough, first launch, managing agents and sessions |
| `/cli/ca` | Subcommands, options, setup flags, interface, keys, mouse |
| `/cli/code` | Options, target resolution, credentials, agent arguments, examples |

## Edited

- `ai.md` — cloud agents entry in the integration list
- `agents.md` — card in the integration grid, entry in "When to use each"
- `sidebar.ts` — cloud agents under AI with its child page, `ca` and `code` in the CLI list

## Beta treatment

Matches the Priority Boarding precedent in `sandboxes.md`, `feature-flags.md`, and `cli/sandbox.md`:

- Concept and getting started: `<Banner variant="primary">` with "Breaking changes may occur"
- CLI reference: `<Banner variant="info">` noting commands and flags may change in breaking ways
- Lifecycle section: `<Banner variant="warning">` because `--keep-awake` bills compute with nothing attached

## Corrections from pressure testing

Second commit fixes six claims that didn't match the code:

| Claim | Reality |
|---|---|
| Setup options "Create a project" / "Bring my skills" / theme previews | Those are the interface wizard's. `railway ca setup` uses "Create a default project", a yes/no skills question plus a directory pick, and a plain theme select |
| Setup asks four questions | The skills question is skipped when nothing of yours is syncable |
| `--project my-project` | `--project` takes an ID; `--environment` takes a name or ID |
| Local sign-in required for any agent | Codex and Grok need one; Claude Code mints in a browser |
| Agent "may prompt" outside `/app` | Not verifiable from the CLI. Removed |
| Skills link into "every coding agent's directory" | `~/.claude/skills`, `~/.codex/skills`, `~/.grok/skills` |

Verified and added: token cache path, minting runs the local `claude` binary, `-y` behavior, interface skipped when stdout isn't a terminal, clicks reach the agent only once the pane has the keyboard, sleep-on-quit covers open sessions, skills sync off leaves what's on the agent.

## Verification

Claim-by-claim against `railwayapp/cli` on the shipping branch: command and subcommand names, every flag and its help text, prompt strings, `RAILWAY_CA_AGENT`, preferences path and fields, skills sources and the 2 MB / 10 MB limits, key bindings, no aliases on `railway ca`. `--idle-timeout` doesn't exist on these commands and isn't documented.

Links and anchors checked programmatically. CI `Build` passes and all four pages render on the preview deploy.
