### PR TITLE
Document VM pricing under a beta tag

### DIFF
--- a/content/docs/cloud-agents.md
+++ b/content/docs/cloud-agents.md
@@ -74,6 +74,10 @@ railway code --claude --new
 
 Cloud agents have no idle timeout, so nothing stops one on its own. Disconnecting puts the agent to sleep, which stops billing for compute and keeps the disk. The next launch wakes it with your work in place.
 
+<Banner variant="info">
+Cloud agents run on Railway's virtual machine primitive and bill at [VM rates](/pricing/plans#vm-pricing-beta): $50 per vCPU and $50 per GB of memory per month, prorated to the minute, plus $0.05 per GB of network egress.
+</Banner>
+
 | Action | How |
 |--------|-----|
 | Sleep on disconnect | Default behavior |

--- a/content/docs/pricing/plans.md
+++ b/content/docs/pricing/plans.md
@@ -62,6 +62,18 @@ You are only charged for the resources you actually use, which helps prevent run
 
 To learn more about controlling your resource usage costs, read the FAQ on [How do I prevent spending more than I want to?](/pricing/faqs#how-do-i-prevent-spending-more-than-i-want-to)
 
+### VM pricing (Beta)
+
+Workloads that run on Railway's virtual machine primitive, such as [sandboxes](/sandboxes), are billed at VM rates. You are only charged for the resources a VM consumes while it runs.
+
+| Resource           | Resource Price                                 |
+| ------------------ | ---------------------------------------------- |
+| **RAM**            | $50 / GB / month ($0.001157 / GB / minute)     |
+| **CPU**            | $50 / vCPU / month ($0.001157 / vCPU / minute) |
+| **Network Egress** | $0.05 / GB                                     |
+
+VMs are in beta and available through [Priority Boarding](/platform/priority-boarding).
+
 ## Included usage
 
 The Hobby plan includes $5 of resource usage per month.


### PR DESCRIPTION
## What

Adds a **VM pricing (Beta)** section to the pricing plans page, under the existing Resource usage pricing section.

## Rates

| Resource | Price |
|----------|-------|
| RAM | $50 / GB / month ($0.001157 / GB / minute) |
| CPU | $50 / vCPU / month ($0.001157 / vCPU / minute) |
| Network Egress | $0.05 / GB |

## Verification

Verified against the billing configuration in the mono repo:

- `common/javascript/pricing/src/plans.ts` defines VM CPU / VM Memory meter prices at `$0.00000115740741` per milli-vCPU-minute and per MB-minute respectively, which is exactly `50 / 43,200,000`, i.e. $50 per vCPU/month and $50 per GB memory/month (43,200 minutes in a 30-day month).
- VM Network is `$0.00000005` per KB = $0.05 / GB.
- Same rates are already published on the [sandboxes page](https://docs.railway.com/sandboxes#pricing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)