### PR TITLE
Fix /cloud-agents/getting-started redirect

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -1005,6 +1005,11 @@ const redirects = [
     destination: "/builds/railpack",
     permanent: true,
   },
+  {
+    source: "/cloud-agents/getting-started",
+    destination: "/cloud-agents",
+    permanent: true,
+  },
 ];
 
 const hashRedirects = [
@@ -1051,11 +1056,6 @@ const hashRedirects = [
   {
     source: "/guides/healthchecks-and-restarts#continuous-healthchecks",
     destination: "/guides/healthchecks#continuous-healthchecks",
-    permanent: true,
-  },
-  {
-    source: "/cloud-agents/getting-started",
-    destination: "/cloud-agents",
     permanent: true,
   },
 ];


### PR DESCRIPTION
## What

#1287 added the `/cloud-agents/getting-started` → `/cloud-agents` redirect to the wrong array in `redirects.js`: it landed in `hashRedirects` (client-side `#anchor` rewrites) instead of `redirects` (the array `next.config.js` serves), so the URL 404s in production. This link was shared externally as the getting-started link.

This moves the entry into the `redirects` array.

## Verification

Ran the dev server locally: `curl -sI localhost:3001/cloud-agents/getting-started` returns `308` with `Location: /cloud-agents`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)