### PR TITLE
Update Railpack's support of .NET/C#

### DIFF
--- a/content/docs/builds/railpack.md
+++ b/content/docs/builds/railpack.md
@@ -17,6 +17,7 @@ Currently, we support the following languages out of the box:
 - [HTML/Staticfile](https://railpack.com/languages/staticfile)
 - [Java](https://railpack.com/languages/java)
 - [Ruby](https://railpack.com/languages/ruby)
+- [.NET/C#](https://railpack.com/languages/dotnet)
 - [Deno](https://railpack.com/languages/deno)
 - [Rust](https://railpack.com/languages/rust)
 - [Elixir](https://railpack.com/languages/elixir)

--- a/content/guides/aspnet-core.md
+++ b/content/guides/aspnet-core.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy an ASP.NET Core App
 description: Learn how to deploy an ASP.NET Core app to Railway with this step-by-step guide. It covers deployment from GitHub, the CLI, and using a Dockerfile.
-date: "2026-03-30"
+date: "2026-08-10"
 tags:
   - deployment
   - aspnet-core
@@ -18,7 +18,7 @@ This guide covers how to deploy an ASP.NET Core app on Railway in three ways:
 2. [Using the CLI](#deploy-from-the-cli).
 3. [Using a Dockerfile](#use-a-dockerfile).
 
-**Note:** [Railpack](/builds/railpack) does not yet support .NET, so a Dockerfile is required for all deployment methods.
+During the deployment process, Railway will automatically [detect that it's a .NET app via Railpack](https://railpack.com/languages/dotnet) when a `*.csproj` file is present in the project root. Railpack also sets `ASPNETCORE_URLS` so your app listens on the `PORT` environment variable.
 
 You can also explore <a href="https://railway.com/templates?q=dotnet" target="_blank">.NET templates</a> created by the community.
 
@@ -32,8 +32,6 @@ To deploy an ASP.NET Core app on Railway directly from GitHub, follow the steps 
    - Railway requires a valid GitHub account to be linked. If your Railway account isn't associated with one, you will be prompted to link it.
 4. Click **Deploy Now**.
 
-**Note:** ASP.NET Core apps require a `Dockerfile` for deployment on Railway, since [Railpack](/builds/railpack) does not yet support .NET.
-
 Once the deployment is successful, a Railway [service](/services) will be created for you. By default, this service will not be publicly accessible.
 
 To set up a publicly accessible URL for the service, navigate to the **Networking** section in the [Settings](/overview/the-basics#service-settings) tab of your new service and click on [Generate Domain](/networking/public-networking#railway-provided-domain).
@@ -44,9 +42,7 @@ To set up a publicly accessible URL for the service, navigate to the **Networkin
 2. `cd` into your ASP.NET Core app directory.
 3. Run `railway init` within the app directory to create a new project.
 4. Run `railway up` to deploy.
-   - The CLI will now scan, compress and upload your app files to Railway's backend for deployment.
-
-**Note:** ASP.NET Core apps require a `Dockerfile` for deployment on Railway, since [Railpack](/builds/railpack) does not yet support .NET.
+  - The CLI will now scan, compress and upload your app files to Railway's backend for deployment.
 
 ## Use a Dockerfile
 
@@ -55,7 +51,7 @@ To set up a publicly accessible URL for the service, navigate to the **Networkin
 3. Add the content below to the `Dockerfile`:
 
    ```docker
-   FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+   FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
    WORKDIR /app
 
    COPY *.csproj ./
@@ -64,7 +60,7 @@ To set up a publicly accessible URL for the service, navigate to the **Networkin
    COPY . ./
    RUN dotnet publish -c Release -o out
 
-   FROM mcr.microsoft.com/dotnet/aspnet:9.0
+   FROM mcr.microsoft.com/dotnet/aspnet:10.0
    WORKDIR /app
    COPY --from=build /app/out ./
 
@@ -72,7 +68,6 @@ To set up a publicly accessible URL for the service, navigate to the **Networkin
    ```
 
    **Note:** Replace `App.dll` with the actual assembly name of your project (e.g., `MyWebApp.dll`).
-
 4. Either deploy via the CLI or from GitHub.
 
 Railway automatically detects the `Dockerfile`, [and uses it to build and deploy the app.](/builds/dockerfiles)


### PR DESCRIPTION
## Summary
[Railpack has natively supported .NET since Nov 2025](https://github.com/railwayapp/railpack/releases/tag/v0.11.0), yet Railway's docs are still showing its not supported and requiring the usage of Dockerfile.

- Document Railpack’s built-in .NET support by adding [.NET/C#](https://railpack.com/languages/dotnet) to the supported languages list
- Update the ASP.NET Core guide so GitHub/CLI deploys no longer say a Dockerfile is required, and note `*.csproj` detection plus automatic `ASPNETCORE_URLS` / `PORT` binding
- Keep Dockerfile as an optional path and bump the sample images to .NET 10

<img width="551" height="548" alt="image" src="https://github.com/user-attachments/assets/8d20bd38-6d5f-478b-86ac-d10f28e17d01" />

## Test plan
- [x] Confirm `/builds/railpack` lists .NET/C# and the Dotnet docs link works
- [x] Confirm `/guides/aspnet-core` no longer says Railpack lacks .NET support