### PR TITLE
Fix Railway CLI documentation accuracy

### DIFF
--- a/content/docs/ai/mcp-server.md
+++ b/content/docs/ai/mcp-server.md
@@ -108,20 +108,25 @@ The Railway MCP Server exposes the following tools. Your AI assistant selects to
 
 Local MCP runs through the Railway CLI and exposes these tools:
 
-* **Status**
-  * `check-railway-status`: verify CLI installation and authentication
-* **Projects & services**
-  * `list-projects`, `create-project-and-link`
-  * `list-services`, `link-service`
-  * `deploy`: deploy a service
-  * `deploy-template`: deploy from the <a href="https://railway.com/deploy" target="_blank">Railway Template Library</a>
-* **Environments**
-  * `create-environment`, `link-environment`
-* **Configuration**
-  * `list-variables`, `set-variables`
-  * `generate-domain`
-* **Observability**
-  * `get-logs`
+* **Account:** `whoami`
+* **Projects and services:** `list_workspaces`, `list_projects`,
+  `create_project`, `list_services`, `create_service`, `remove_service`,
+  `connect_service_source`, `disconnect_service_source`, `link_service`,
+  `get_service_config`, `update_service`, and `scale_service`
+* **Environments and deployments:** `create_environment`, `link_environment`,
+  `environment_status`, `list_deployments`, and `deploy`
+* **Variables:** `list_variables`, `set_variables`, and
+  `add_reference_variable`
+* **Domains:** `generate_domain`, `list_domains`, `domain_status`,
+  `update_domain`, `delete_domain`, and `retry_domain_certificate`
+* **Networking:** `list_tcp_proxies`, `get_tcp_proxy`, `create_tcp_proxy`,
+  `remove_tcp_proxy`, `private_network_status`, and `private_network_update`
+* **Templates:** `search_templates` and `deploy_template`
+* **Storage:** `create_bucket`, `remove_bucket`, `create_volume`,
+  `update_volume`, and `remove_volume`
+* **Observability:** `get_logs`, `service_metrics`, `http_requests`,
+  `http_error_rate`, and `http_response_time`
+* **Documentation:** `docs_search` and `docs_fetch`
 
 ### Remote MCP
 
@@ -143,9 +148,14 @@ operations.
 
 ## Security considerations
 
-The Railway MCP Server runs CLI commands or invokes Railway APIs on your behalf. Destructive operations are intentionally excluded from the local server's tool list, but you should still:
+The Railway MCP Server runs CLI commands or invokes Railway APIs on your
+behalf. Local MCP marks destructive tools with protocol-level hints and returns
+a preview before requiring `confirm: true`. You should still:
 
-* **Review actions** requested by the LLM before approving them, especially destructive ones (`redeploy`, `accept-deploy`, `railway-agent`).
+* **Review actions** requested by the LLM before approving them, especially
+  destructive ones (`remove_service`, `delete_domain`, `remove_tcp_proxy`,
+  `remove_bucket`, `remove_volume`, `redeploy`, `accept-deploy`, and
+  `railway-agent`).
 * **Restrict access** to ensure only trusted users can invoke the MCP server.
 * **Avoid production risks** by limiting usage to non-critical environments where possible.
 

--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -70,7 +70,10 @@ railway config pull
 | `--json` | Print the imported graph as JSON instead of writing files |
 | `--runner <PATH>` | Use a specific TypeScript configuration runner |
 | `--omit-preserved-variables` | Omit unknown variables instead of rendering `preserve()` |
-| `--agent` | Ask an agent to turn imported state into idiomatic TypeScript |
+| `--agent` | Print a suggestion to ask an agent to turn imported state into idiomatic TypeScript |
+
+`--agent` doesn't invoke an agent or change the generated file. The flag has
+no effect with `--json`, which prints only the imported graph.
 
 Review an imported configuration with `railway config plan` before applying
 it.
@@ -100,7 +103,8 @@ Plan output redacts variable values by default. Treat output from
 
 ## Apply changes
 
-Use `apply` to run a fresh plan and apply it after confirmation.
+Use `apply` to run a fresh plan and apply its changes. Without a
+non-interactive flag, the CLI asks for confirmation.
 
 ```bash
 railway config apply
@@ -111,13 +115,27 @@ accepts these confirmation flags:
 
 | Flag | Description |
 |------|-------------|
-| `--yes` | Confirm non-destructive changes without prompting |
-| `--confirm-destructive` | Permit destructive changes in non-interactive or agent sessions |
+| `--yes` | Skip the confirmation prompt and run non-interactively |
+| `--confirm-destructive` | Permit destructive changes in non-interactive, JSON, or agent sessions |
 
-For a destructive non-interactive apply, pass both flags:
+<Banner variant="warning">
+`railway config apply --json` applies non-destructive changes without
+prompting. Use `railway config plan --json` when you only need a
+machine-readable preview.
+</Banner>
+
+For a destructive non-interactive apply with human-readable output, pass both
+confirmation flags:
 
 ```bash
 railway config apply --yes --confirm-destructive
+```
+
+In JSON mode, pass `--confirm-destructive` to apply destructive changes. The
+`--json` flag already skips the confirmation prompt, so `--yes` isn't required:
+
+```bash
+railway config apply --json --confirm-destructive
 ```
 
 ## Related

--- a/content/docs/cli/setup.md
+++ b/content/docs/cli/setup.md
@@ -84,7 +84,12 @@ configurations. The MCP client manages the OAuth flow.
 
 `railway setup agent` installs the `use-railway` skill for supported coding tools, configures the Railway MCP server where supported, and checks your Railway authentication.
 
-Skills are installed for Claude Code, Cursor, OpenAI Codex, OpenCode, and the universal `.agents` skills directory. MCP is additionally configured for Factory Droid and GitHub Copilot. See [`railway skills`](/cli/skills) and [`railway mcp`](/cli/mcp) for the per-command target lists.
+The command can install skills for Claude Code, Cursor, OpenAI Codex, OpenCode,
+Factory Droid, GitHub Copilot, and the universal `.agents` skills directory. It
+configures MCP for each selected named coding tool. The universal directory
+doesn't have an MCP configuration convention. See
+[`railway skills`](/cli/skills) and [`railway mcp`](/cli/mcp) for the
+per-command target lists.
 
 The setup is idempotent. Re-running it updates Railway-owned skill directories and merges Railway MCP entries into existing tool configs without removing other MCP servers.
 

--- a/content/docs/cli/skills.md
+++ b/content/docs/cli/skills.md
@@ -3,7 +3,9 @@ title: railway skills
 description: Install or remove Railway agent skills for AI coding tools.
 ---
 
-Install or remove the Railway [agent skills](/ai/agent-skills) for AI coding tools such as Claude Code, Cursor, OpenAI Codex, and OpenCode.
+Install or remove the Railway [agent skills](/ai/agent-skills) for AI coding
+tools such as Claude Code, Cursor, OpenAI Codex, OpenCode, Factory Droid, and
+GitHub Copilot.
 
 Skills are always installed to `~/.agents/skills` (the universal `.agents` directory). They are also installed to any detected tool directories (for example `~/.claude/skills`, `~/.cursor/skills`). Use `--agent` to target specific tools instead of auto-detection.
 
@@ -37,6 +39,8 @@ Running `railway skills` with no subcommand is equivalent to `railway skills ins
 | Cursor | `cursor` | `~/.cursor/skills` |
 | OpenAI Codex | `codex` | `~/.codex/skills` |
 | OpenCode | `opencode` | `~/.config/opencode/skills` |
+| Factory Droid | `factory-droid` | `~/.factory/skills` |
+| GitHub Copilot | `copilot` | `~/.copilot/skills` |
 
 When run without `--agent`, the universal `.agents` directory is always included, and other tools are added when their config directory exists on disk.
 


### PR DESCRIPTION
## Summary

Follows #1290 by aligning the CLI documentation with behavior shipped in Railway CLI 5.37.2.

## Changes

- Replace the stale Local MCP tool inventory with the 47 identifiers returned by `tools/list`.
- Document Local MCP destructive-tool hints and confirmation behavior.
- Clarify that `config pull --agent` prints guidance without invoking an agent.
- Document how `config apply --json` skips prompts and handles destructive changes.
- Add Factory Droid and GitHub Copilot to the supported skill targets.

## Validation

- `./node_modules/.bin/prettier --check content/docs/ai/mcp-server.md content/docs/cli/config.md content/docs/cli/setup.md content/docs/cli/skills.md`
- `./node_modules/.bin/next typegen`
- `./node_modules/.bin/tsc -p .`
- `git diff --check`
- Queried Railway CLI 5.37.2 through MCP `tools/list` and confirmed all 47 documented Local MCP tools match.
