### PR TITLE
Document staged changes in the template editor

### DIFF
--- a/content/docs/ai/railway-agent.md
+++ b/content/docs/ai/railway-agent.md
@@ -14,6 +14,8 @@ The agent has access to the same primitives you do, so it can act across your en
 - Walk through a failing deployment, read build and runtime logs, and explain what went wrong.
 - Identify the cause of a failed deployment and open a pull request against your repository with a proposed fix.
 
+The agent is also available in the template editor, where it builds and edits templates. Changes it makes there are staged for your review before they apply. See [Staged changes](/templates/staged-changes#chat-with-the-agent).
+
 ## Reach beyond Railway
 
 [Agent Connectors](/ai/agent-connectors) extend the agent past your Railway resources. Connect Notion, Linear, Sentry, or your own MCP server, and the agent can read from them while it works on your projects.

--- a/content/docs/templates/best-practices.md
+++ b/content/docs/templates/best-practices.md
@@ -135,9 +135,9 @@ Since the author is publicly visible and shown with the template to the users, i
 
 The overview is the first thing users will see when they click on the template, so it is important to make it count.
 
-The overview should include the following:
+Publishing requires the section structure below. In the template editor, click **Fill Required Structure** on the overview field to insert it with placeholders to replace.
 
-- **H1: Deploy and Host [X] with Railway**
+- **H1: Deploy and Host [X] on Railway**
 
   What is X? Your description in roughly ~ 50 words.
 
@@ -153,15 +153,11 @@ The overview should include the following:
 
   In bullet form, what other technologies are incorporated in using this template besides [X]?
 
-- **H3: Deployment Dependencies**
-
-  Include any external links relevant to the template.
-
 - **H3: Implementation Details (Optional)**
 
   Include any code snippets or implementation details. This section is optional. Exclude if nothing to add.
 
-- **H3: Why Deploy [X] on Railway?**
+- **H2: Why Deploy [X] on Railway?**
 
   Railway is a singular platform to deploy your infrastructure stack. Railway will host your infrastructure so you don't have to deal with configuration, while allowing you to vertically and horizontally scale it.
 

--- a/content/docs/templates/create.md
+++ b/content/docs/templates/create.md
@@ -173,6 +173,8 @@ You can see all of your templates on your <a href="https://railway.com/workspace
 
 You can edit, publish/unpublish and delete templates.
 
+When you edit a template, your changes are staged for review before they apply, and every applied change shows up in the editor's activity panel where you can roll it back. See [Staged changes](/templates/staged-changes).
+
 <Image src="https://res.cloudinary.com/railway/image/upload/v1743199089/docs/templates_xyphou.png"
  alt="Account templates page"
  layout="intrinsic"

--- a/content/docs/templates/staged-changes.md
+++ b/content/docs/templates/staged-changes.md
@@ -1,0 +1,51 @@
+---
+title: Staged Changes
+description: Review changes before applying them to your template, and roll back applied changes from the activity panel.
+---
+
+The template editor stages your edits as a change set that you review and apply, instead of saving every edit immediately. The activity panel keeps a history of applied change sets, and you can undo or revert any of them.
+
+## How staging works
+
+Edits you make in the template editor are staged into a single change set rather than applied right away. This includes changes to services, volumes, variables, storage buckets, and template details such as the name, description, and readme.
+
+A banner appears at the top of the editor canvas showing how many changes are staged. Staged changes are shared: teammates editing the same template see and stage into the same change set.
+
+Canvas layout is not part of the change set. Moving services around the canvas saves immediately and doesn't stage anything.
+
+## Review staged changes
+
+Click **Details** on the staged-changes banner to open the review modal. Changes are grouped by service, storage bucket, and template details, with the old and new value shown for each change.
+
+From the banner or the review modal, you can:
+
+- Click **Apply** to apply the change set to the template. You can also press `Shift + Enter` anywhere in the editor.
+- Click **Discard Changes** to throw away all staged changes and return the editor to the template's live content.
+
+Applying updates the template immediately. New deploys of the template use the updated configuration.
+
+## Chat with the agent
+
+The template editor includes the [Railway Agent](/ai/railway-agent) in a sidebar. Click **Agent** in the top-right corner of the editor to open it.
+
+The agent edits your template by staging changes into the same change set as your manual edits, so nothing it does applies without your review. Ask it to:
+
+- Add or configure services, databases, functions, and storage buckets
+- Set up variables, generate secrets, and use reference variables and private networking between services
+- Write or improve the template's description and overview
+- Check the template against the publishing requirements and [best practices](/templates/best-practices)
+
+While changes are staged, the chat shows a review card summarizing them. You can apply from the card, the staged-changes banner, or the review modal.
+
+## Activity panel
+
+The activity panel lists every change set applied to the template, newest first, with who applied it and when. The most recent entry is marked **Current**, which is what the template looks like now.
+
+To open it, click the **Activity** icon in the top-right corner of the template editor. Click any entry to see exactly what it changed.
+
+## Roll back a change
+
+Open an entry in the activity panel to roll the template back. There are two ways to do it:
+
+- **Undo** appears on the current entry. It reverses that change set and applies the reversal in one click.
+- **Revert to this version** appears on older entries. It stages a change set that returns the template to how it looked right after that entry was applied. Review the staged revert and apply it to complete the rollback.

--- a/src/data/sidebar.ts
+++ b/src/data/sidebar.ts
@@ -145,6 +145,7 @@ export const sidebarContent: ISidebarContent = [
         pages: [
           makePage("Deploy", "templates"),
           makePage("Create", "templates"),
+          makePage("Staged changes", "templates"),
           makePage("Updates", "templates"),
           makePage("Best practices", "templates", "/templates/best-practices"),
           makePage("Publish and share", "templates"),


### PR DESCRIPTION
The template editor now stages edits into a change set that you review and apply, rather than saving each edit immediately. Applied change sets show up in the activity panel, where they can be undone or reverted.

- **New page** — `/templates/staged-changes` covers how staging works, the review modal, the agent in the editor sidebar, the activity panel, and undo/revert.
- **Cross-links** — from `/templates/create` and `/ai/railway-agent`, plus a sidebar entry.
- **Best practices** — updated the overview structure to match what the publishing check now requires: `Deploy and Host [X] on Railway`, `Why Deploy [X] on Railway?` as an H2, and no more Deployment Dependencies section.