### PR TITLE
deprecate Config as Code docs (CaC → IaC PR1)

### DIFF
--- a/content/docs/config-as-code.md
+++ b/content/docs/config-as-code.md
@@ -3,6 +3,10 @@ title: Using Config as Code
 description: Learn how to manage and deploy apps on Railway using config as code with toml and json files.
 ---
 
+<Banner variant="warning">
+**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code) (`.railway/railway.ts`) for project configuration. Existing `railway.json` / `railway.toml` files continue to work for services that already use them until **2028-03-01** (hard cutoff). New services cannot opt into Config as Code. See [Migrating from Config as Code](/infrastructure-as-code#migrating-from-config-as-code).
+</Banner>
+
 Railway supports defining the configuration for a single deployment in a file
 alongside your code in a `railway.toml` or `railway.json` file.
 

--- a/content/docs/config-as-code.md
+++ b/content/docs/config-as-code.md
@@ -4,7 +4,7 @@ description: Learn how to manage and deploy apps on Railway using config as code
 ---
 
 <Banner variant="warning">
-**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code) (`.railway/railway.ts`) for project configuration. Existing `railway.json` / `railway.toml` files continue to work for services that already use them until **2028-03-01** (hard cutoff). New services cannot opt into Config as Code. See [Migrating from Config as Code](/infrastructure-as-code#migrating-from-config-as-code).
+**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code) (`.railway/railway.ts`) for project configuration. Existing `railway.json` / `railway.toml` files continue to work for services that already use them until **2026-12-01** (hard cutoff). New services cannot opt into Config as Code. See [Migrating from Config as Code](/infrastructure-as-code#migrating-from-config-as-code).
 </Banner>
 
 Railway supports defining the configuration for a single deployment in a file

--- a/content/docs/config-as-code/reference.md
+++ b/content/docs/config-as-code/reference.md
@@ -3,6 +3,10 @@ title: Config as Code
 description: Learn how to manage and deploy apps on Railway using config as code with toml and json files.
 ---
 
+<Banner variant="warning">
+**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code). Existing files keep working for legacy services until **2028-03-01**; migrate with the guide in [Infrastructure as Code](/infrastructure-as-code#migrating-from-config-as-code).
+</Banner>
+
 Railway supports defining the configuration for a single deployment in a file
 alongside your code. By default, we will look for a `railway.toml` or
 `railway.json` file.

--- a/content/docs/config-as-code/reference.md
+++ b/content/docs/config-as-code/reference.md
@@ -4,7 +4,7 @@ description: Learn how to manage and deploy apps on Railway using config as code
 ---
 
 <Banner variant="warning">
-**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code). Existing files keep working for legacy services until **2028-03-01**; migrate with the guide in [Infrastructure as Code](/infrastructure-as-code#migrating-from-config-as-code).
+**Config as Code is deprecated.** Prefer [Infrastructure as Code](/infrastructure-as-code). Existing files keep working for legacy services until **2026-12-01**; migrate with the guide in [Infrastructure as Code](/infrastructure-as-code#migrating-from-config-as-code).
 </Banner>
 
 Railway supports defining the configuration for a single deployment in a file

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -11,20 +11,20 @@ Railway Infrastructure as Code lets you define the services and resources in a R
 
 Use Railway IaC when you want one editable file for project-level configuration: services, databases, volumes, buckets, custom domains, environment variables, replicas, and canvas groups.
 
-> **TypeScript only (for now).** Railway IaC is authored in TypeScript via the [`railway`](https://www.npmjs.com/package/railway) SDK and a `.railway/railway.ts` file. TypeScript is currently the only supported language; other languages may follow.
+> **TypeScript, Python, and Go.** Railway IaC is authored via `.railway/railway.ts`, `.railway/railway.py`, or `.railway/railway.go`. TypeScript is the most mature surface; Python and Go mirrors share the same graph contract. Other languages may follow on demand.
 
 <PriorityBoardingBanner />
 
 ## IaC vs Config as Code
 
-Railway has two code-based configuration systems:
+[Config as Code](/config-as-code) (`railway.json` / `railway.toml`) is **deprecated**. Infrastructure as Code (`.railway/railway.ts`) is the replacement.
 
-| Feature | Scope | File |
-|---------|-------|------|
-| Config as Code | One service deployment | `railway.json` or `railway.toml` |
-| Infrastructure as Code | A Railway project/environment | `.railway/railway.ts` |
+| Feature | Scope | File | Status |
+|---------|-------|------|--------|
+| Config as Code | One service deployment | `railway.json` or `railway.toml` | Deprecated |
+| Infrastructure as Code | A Railway project/environment | `.railway/railway.ts` | Current |
 
-[Config as Code](/config-as-code) is read from your service repository during deploy. It overrides dashboard values for that service.
+Config as Code is still read from your service repository during deploy for existing (legacy) services, and it overrides dashboard values for that service. New services cannot opt into Config as Code. Existing Config as Code files stop being read on **2028-03-01** (hard cutoff).
 
 Infrastructure as Code is evaluated by the Railway CLI. The CLI compares `.railway/railway.ts` with the selected Railway environment, shows the changes it would make, and applies those changes only after confirmation.
 
@@ -205,7 +205,27 @@ For the full TypeScript DSL, including services, sources, replicas, variables, d
 
 ## Migrating from Config as Code
 
-If you currently use `railway.json` or `railway.toml`, migrate one service at a time. Do not leave the same service managed by both files.
+If you currently use `railway.json` or `railway.toml`, migrate with the CLI:
+
+```bash
+# Preview the generated .railway/railway.ts
+railway config migrate
+
+# Write the file and clear the service's Railway Config File setting
+railway config migrate --apply
+
+# Optionally delete the old CaC file
+railway config migrate --apply --delete-files
+```
+
+Then review and apply:
+
+```bash
+railway config plan
+railway config apply
+```
+
+You can also migrate manually:
 
 1. Import your current Railway project:
 

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -24,7 +24,7 @@ Use Railway IaC when you want one editable file for project-level configuration:
 | Config as Code | One service deployment | `railway.json` or `railway.toml` | Deprecated |
 | Infrastructure as Code | A Railway project/environment | `.railway/railway.ts` | Current |
 
-Config as Code is still read from your service repository during deploy for existing (legacy) services, and it overrides dashboard values for that service. New services cannot opt into Config as Code. Existing Config as Code files stop being read on **2028-03-01** (hard cutoff).
+Config as Code is still read from your service repository during deploy for existing (legacy) services, and it overrides dashboard values for that service. New services cannot opt into Config as Code. Existing Config as Code files stop being read on **2026-12-01** (hard cutoff).
 
 Infrastructure as Code is evaluated by the Railway CLI. The CLI compares `.railway/railway.ts` with the selected Railway environment, shows the changes it would make, and applies those changes only after confirmation.
 


### PR DESCRIPTION
## Summary
- Mark Config as Code (`railway.json` / `railway.toml`) as deprecated on guide + reference pages
- Position Infrastructure as Code as the replacement, with hard cut **2028-03-01**
- Document `railway config migrate` as the preferred migration path

Part of the [IaC and CaC are redundant](https://app.notion.com/p/38f0e4c5456380439d5ecb15a3ea0fc5) initiative (plan PR1).

## Test plan
- [ ] Preview docs pages: `/config-as-code`, `/config-as-code/reference`, `/infrastructure-as-code`
- [ ] Confirm deprecation banners render and links resolve
- [ ] Confirm migrate section matches CLI once CLI PR lands


Made with [Cursor](https://cursor.com)