### PR TITLE
docs(redis-ha): drop the beta/Priority Boarding banner — redis-ha is GA

### DIFF
--- a/content/docs/databases/redis-ha.md
+++ b/content/docs/databases/redis-ha.md
@@ -5,10 +5,6 @@ description: Convert an existing Railway Redis service to a high-availability cl
 
 Railway can convert an existing Redis service into a high-availability cluster backed by [Redis Sentinel](https://redis.io/docs/latest/operate/oss_and_stack/management/sentinel/) and [HAProxy](https://www.haproxy.org/). Every Redis node runs a colocated Sentinel process — Sentinel handles primary election and failover, and HAProxy routes client connections to whichever node is currently the primary. If the primary goes down, Sentinel promotes a replica and HAProxy begins routing to it within seconds.
 
-<Banner variant="info">
-Redis High Availability is in beta and available through [Priority Boarding](/platform/priority-boarding).
-</Banner>
-
 ## How the cluster is shaped
 
 A converted cluster consists of:


### PR DESCRIPTION
Redis High Availability went GA on 2026-08-20 — mono#36164 removed the `HA_FOR_REDIS` gate from the Convert-to-HA flow, so the Convert to HA section is now visible to everyone whose Redis service qualifies. The page's banner still told readers the feature was in beta and reachable only through Priority Boarding, which is no longer true.

## Changes

- `content/docs/databases/redis-ha.md` — removed the beta / Priority Boarding `<Banner variant="info">`.

## Notes

I swept the whole page for other beta / Priority-Boarding / early-access / preview phrasing (`beta`, `priority.boarding`, `early access`, `preview`, `coming soon`, `experimental`, case-insensitive); the banner was the only occurrence, so this is a pure deletion with no rewording. The other pages that link to the guide (`databases.md`, `databases/redis.md`, the sidebar entry) carry no beta label either, so nothing else needed adjusting.

No new claims were added — the page already documents the flow as generally usable; only the contradicting gate notice is gone.