### PR TITLE
Drop the beta/Priority Boarding banner from the MySQL HA guide

### DIFF
--- a/content/docs/databases/mysql-ha.md
+++ b/content/docs/databases/mysql-ha.md
@@ -5,10 +5,6 @@ description: Convert an existing Railway MySQL service to a high-availability Gr
 
 Railway can convert an existing MySQL service into a high-availability cluster backed by [MySQL Group Replication](https://dev.mysql.com/doc/refman/8.4/en/group-replication.html) and [HAProxy](https://www.haproxy.org/). The data nodes form a single-primary Group Replication group — consensus runs inside MySQL itself, so there is no separate coordinator tier — and HAProxy routes client connections to whichever node is currently the primary. If the primary goes down, the group elects a new one and HAProxy begins routing to it within seconds.
 
-<Banner variant="info">
-MySQL High Availability is in beta and available through [Priority Boarding](/platform/priority-boarding).
-</Banner>
-
 ## How the cluster is shaped
 
 A converted cluster consists of:


### PR DESCRIPTION
## What

Removes the `<Banner variant="info">` telling readers MySQL High Availability is in beta and gated behind Priority Boarding.

MySQL HA is going GA: the Convert-to-HA flow stops resolving `HA_FOR_MYSQL`, so the section appears for every user. The banner would then be telling readers to join Priority Boarding for something they already have.

## Why no replacement copy

The GA reference pages carry no banner at all — [PostgreSQL HA](/databases/postgresql-ha) and [Redis HA](/databases/redis-ha) (whose banner came off in #1305) both open straight into what the cluster is. This matches that shape instead of swapping in different banner copy.

## Sequencing

**Do not merge before the mono-side flag removal is deployed to production**, otherwise the docs promise a section some users still cannot see. Merge order: railwayapp/mono#36661 → deploy → this PR.