### PR TITLE
Document the pre-deploy command timeout

### DIFF
--- a/content/docs/config-as-code/reference.md
+++ b/content/docs/config-as-code/reference.md
@@ -162,6 +162,24 @@ This field can be omitted.
 
 Read more about the pre-deploy command [here](/deployments/pre-deploy-command).
 
+### Pre-deploy timeout
+
+How long the pre-deploy command may run, in seconds, before the deployment is failed. Accepts 1 to 3600.
+
+```json
+{
+  "$schema": "https://railway.com/railway.schema.json",
+  "deploy": {
+    "preDeployCommand": ["npm run db:migrate"],
+    "preDeployTimeoutSeconds": 300
+  }
+}
+```
+
+This field can be omitted, in which case the pre-deploy command runs without a time limit.
+
+Read more about the pre-deploy timeout [here](/deployments/pre-deploy-command#pre-deploy-timeout).
+
 ### Multi-region configuration
 
 Horizontal scaling across multiple regions, with two replicas in each region.

--- a/content/docs/config-as-code/reference.md
+++ b/content/docs/config-as-code/reference.md
@@ -162,24 +162,6 @@ This field can be omitted.
 
 Read more about the pre-deploy command [here](/deployments/pre-deploy-command).
 
-### Pre-deploy timeout
-
-How long the pre-deploy command may run, in seconds, before the deployment is failed. Accepts 1 to 3600.
-
-```json
-{
-  "$schema": "https://railway.com/railway.schema.json",
-  "deploy": {
-    "preDeployCommand": ["npm run db:migrate"],
-    "preDeployTimeoutSeconds": 300
-  }
-}
-```
-
-This field can be omitted, in which case the pre-deploy command runs without a time limit.
-
-Read more about the pre-deploy timeout [here](/deployments/pre-deploy-command#pre-deploy-timeout).
-
 ### Multi-region configuration
 
 Horizontal scaling across multiple regions, with two replicas in each region.

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -17,7 +17,7 @@ width={1494} height={644} quality={80} />
 For pre-deploy commands to work correctly, ensure that:
 
 - It exits with a status code of `0` to indicate success or non-zero to indicate failure.
-- It runs in a reasonable amount of time. It will occupy a slot in your build queue. See [Pre-deploy timeout](#pre-deploy-timeout) to cap how long it can run.
+- It runs in a reasonable amount of time — it occupies a slot in your build queue, and you can [cap how long it runs](#pre-deploy-timeout).
 - It does not rely on the application running.
 - It has the dependencies it needs to run installed in the application image.
 - It does not attempt to read or write data to the volume or filesystem, that should instead be done as part of the start command.
@@ -30,7 +30,7 @@ Set **Pre-deploy Timeout** on the service settings page to cap how long the comm
 
 <Banner variant="info">Leaving the timeout empty keeps the default behavior: the command runs without a time limit.</Banner>
 
-If the command is still running when the timeout expires, its container is removed and the deployment fails with:
+If the command is still running when the timeout expires, its container is removed and the deployment fails. With a 300-second timeout, that looks like:
 
 ```
 Pre-deploy command timed out after 300 seconds

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -17,7 +17,7 @@ width={1494} height={644} quality={80} />
 For pre-deploy commands to work correctly, ensure that:
 
 - It exits with a status code of `0` to indicate success or non-zero to indicate failure.
-- It runs in a reasonable amount of time. It will occupy a slot in your build queue. See [Pre-deploy timeout](#pre-deploy-timeout) to bound how long it may run.
+- It runs in a reasonable amount of time. It will occupy a slot in your build queue. See [Pre-deploy timeout](#pre-deploy-timeout) to cap how long it can run.
 - It does not rely on the application running.
 - It has the dependencies it needs to run installed in the application image.
 - It does not attempt to read or write data to the volume or filesystem, that should instead be done as part of the start command.
@@ -26,7 +26,7 @@ For pre-deploy commands to work correctly, ensure that:
 
 By default a pre-deploy command has no time limit. It runs until it exits, so a command that hangs — waiting on a lock, or on input that never arrives — will hold your deployment in progress rather than failing it.
 
-To bound it, set **Pre-deploy Timeout** on the service settings page. The field appears once a pre-deploy command is set and accepts 1 to 3600 seconds (1 hour).
+Set **Pre-deploy Timeout** on the service settings page to cap how long the command can run. The field appears once a pre-deploy command is set and accepts 1 to 3600 seconds (1 hour).
 
 <Banner variant="info">Leaving the timeout empty keeps the default behavior: the command runs without a time limit.</Banner>
 

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -22,6 +22,8 @@ For pre-deploy commands to work correctly, ensure that:
 - It has the dependencies it needs to run installed in the application image.
 - It does not attempt to read or write data to the volume or filesystem, that should instead be done as part of the start command.
 
+<Banner variant="warning">Pre-deploy commands execute in a separate container from your application. Changes to the filesystem are not persisted and [volumes](/volumes) are not mounted.</Banner>
+
 ## Pre-deploy timeout
 
 By default a pre-deploy command has no time limit. It runs until it exits, so a command that hangs — waiting on a lock, or on input that never arrives — will hold your deployment in progress rather than failing it.
@@ -39,5 +41,3 @@ Pre-deploy command timed out after 300 seconds
 Choose a value with room to spare over your command's normal runtime — a migration that usually takes 30 seconds may take considerably longer against a larger database.
 
 Clearing the pre-deploy command also clears its timeout.
-
-<Banner variant="warning">Pre-deploy commands execute in a separate container from your application. Changes to the filesystem are not persisted and [volumes](/volumes) are not mounted.</Banner>

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -28,7 +28,9 @@ For pre-deploy commands to work correctly, ensure that:
 
 By default a pre-deploy command has no time limit. It runs until it exits, so a command that hangs — waiting on a lock, or on input that never arrives — will hold your deployment in progress rather than failing it.
 
-Set **Pre-deploy Timeout** on the service settings page to cap how long the command can run. The field appears once a pre-deploy command is set and accepts 1 to 3600 seconds (1 hour).
+Set **Pre-deploy Timeout** on the service settings page to cap how long the command can run. It accepts 1 to 3600 seconds (1 hour).
+
+**The Pre-deploy Timeout field only appears once you have entered a pre-deploy command.** Adding an empty pre-deploy step is not enough — type the command first, and the timeout field appears beneath it. A timeout with no command does nothing, so it is not offered.
 
 <Banner variant="info">Leaving the timeout empty keeps the default behavior: the command runs without a time limit.</Banner>
 

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -26,20 +26,9 @@ For pre-deploy commands to work correctly, ensure that:
 
 By default a pre-deploy command has no time limit. It runs until it exits, so a command that hangs — waiting on a lock, or on input that never arrives — will hold your deployment in progress rather than failing it.
 
-Set a **Pre-deploy Timeout** to bound it. The field accepts 1 to 3600 seconds (1 hour) and appears on the service settings page once a pre-deploy command is set.
+To bound it, set **Pre-deploy Timeout** on the service settings page. The field appears once a pre-deploy command is set and accepts 1 to 3600 seconds (1 hour).
 
 <Banner variant="info">Leaving the timeout empty keeps the default behavior: the command runs without a time limit.</Banner>
-
-You can also set it in your [config file](/config-as-code):
-
-```json
-{
-  "deploy": {
-    "preDeployCommand": ["npm run migrate"],
-    "preDeployTimeoutSeconds": 300
-  }
-}
-```
 
 If the command is still running when the timeout expires, its container is removed and the deployment fails with:
 

--- a/content/docs/deployments/pre-deploy-command.md
+++ b/content/docs/deployments/pre-deploy-command.md
@@ -17,9 +17,38 @@ width={1494} height={644} quality={80} />
 For pre-deploy commands to work correctly, ensure that:
 
 - It exits with a status code of `0` to indicate success or non-zero to indicate failure.
-- It runs in a reasonable amount of time. It will occupy a slot in your build queue.
+- It runs in a reasonable amount of time. It will occupy a slot in your build queue. See [Pre-deploy timeout](#pre-deploy-timeout) to bound how long it may run.
 - It does not rely on the application running.
 - It has the dependencies it needs to run installed in the application image.
 - It does not attempt to read or write data to the volume or filesystem, that should instead be done as part of the start command.
+
+## Pre-deploy timeout
+
+By default a pre-deploy command has no time limit. It runs until it exits, so a command that hangs — waiting on a lock, or on input that never arrives — will hold your deployment in progress rather than failing it.
+
+Set a **Pre-deploy Timeout** to bound it. The field accepts 1 to 3600 seconds (1 hour) and appears on the service settings page once a pre-deploy command is set.
+
+<Banner variant="info">Leaving the timeout empty keeps the default behavior: the command runs without a time limit.</Banner>
+
+You can also set it in your [config file](/config-as-code):
+
+```json
+{
+  "deploy": {
+    "preDeployCommand": ["npm run migrate"],
+    "preDeployTimeoutSeconds": 300
+  }
+}
+```
+
+If the command is still running when the timeout expires, its container is removed and the deployment fails with:
+
+```
+Pre-deploy command timed out after 300 seconds
+```
+
+Choose a value with room to spare over your command's normal runtime — a migration that usually takes 30 seconds may take considerably longer against a larger database.
+
+Clearing the pre-deploy command also clears its timeout.
 
 <Banner variant="warning">Pre-deploy commands execute in a separate container from your application. Changes to the filesystem are not persisted and [volumes](/volumes) are not mounted.</Banner>


### PR DESCRIPTION
Documents the pre-deploy command timeout added in [railwayapp/mono#36619](https://github.com/railwayapp/mono/pull/36619).

**Please hold the merge until that PR ships** — the setting isn't live yet, and the dashboard already links here from the Pre-deploy Timeout description, so the two should land close together.

**Preview:** [Pre-deploy timeout section](https://docs-frontend-docs-pr-1311.up.railway.app/deployments/pre-deploy-command#pre-deploy-timeout)

## What's added

A **Pre-deploy timeout** section on the pre-deploy command page covering:

- the default, which is **no time limit** — a hung command holds the deployment rather than failing it
- the 1–3600s range, and that the field appears on service settings only once a command is set
- the failure message: `Pre-deploy command timed out after N seconds`
- that clearing the command clears the timeout

The existing "runs in a reasonable amount of time" bullet now links to the new section — it predates the setting and read as vague advice with no way to act on it.

## Documented as a dashboard setting only

The timeout does work in `railway.json` / `railway.toml`, since it rides the same deploy config schema. This page deliberately doesn't say so.

Config as Code is deprecated: new opt-in closes **2026-08-28** and files stop being read on **2026-12-01**. Documenting a brand-new field there would push people into a system they mostly can't adopt and would have to migrate off within months. So the dashboard is the documented path, and IaC support can be layered in once the DSL exposes deploy config.

Open question for @futurepastori: does the IaC DSL support `preDeployCommand` / `preDeployTimeoutSeconds`? If not, this setting is dashboard-only after the hard cutoff.

## Note

Says nothing about the internal 96h deploy-workflow ceiling — that's a Temporal implementation limit, not a user-facing guarantee.
