### PR TITLE
Redirect /api and other common guesses to the Public API reference

### DIFF
--- a/redirects.js
+++ b/redirects.js
@@ -816,6 +816,32 @@ const redirects = [
     destination: "/integrations/api",
     permanent: true,
   },
+  // Bare /api — a common guess for the Public API reference (agents, links)
+  {
+    source: "/api",
+    destination: "/integrations/api",
+    permanent: true,
+  },
+  {
+    source: "/api.md",
+    destination: "/integrations/api.md",
+    permanent: true,
+  },
+  {
+    source: "/api-reference",
+    destination: "/integrations/api",
+    permanent: true,
+  },
+  {
+    source: "/public-api",
+    destination: "/integrations/api",
+    permanent: true,
+  },
+  {
+    source: "/reference/api",
+    destination: "/integrations/api",
+    permanent: true,
+  },
   {
     source: "/guides/templates",
     destination: "/templates",


### PR DESCRIPTION
## Problem

`docs.railway.com/api` is a hard 404. It's the most obvious URL to guess for our API reference — both for humans and for coding agents crawling the docs — but the Public API page actually lives at `/integrations/api`.

We already redirect `/reference/public-api` and `/guides/public-api` there; the bare `/api` (and a few other natural guesses) were never covered.

Verified 404 today:

- `/api`
- `/api-reference`
- `/public-api`
- `/reference/api`

## Change

Adds five exact-path redirects in `redirects.js`, alongside the existing `/reference/public-api` entry:

| Source | Destination |
| --- | --- |
| `/api` | `/integrations/api` |
| `/api.md` | `/integrations/api.md` |
| `/api-reference` | `/integrations/api` |
| `/public-api` | `/integrations/api` |
| `/reference/api` | `/integrations/api` |

The `.md` variant is included because agents follow the "append `.md` to any page URL" convention documented in `llms.txt`.

## Safety

These are **exact-path** redirects, not a `/api/:path*` wildcard. A wildcard would have shadowed the real Next.js API routes, since redirects are evaluated before rewrites and filesystem routing:

- `/api/llms.txt` (rewrite target for `/llms.txt`)
- `/api/llms-full.txt` (rewrite target for `/llms-full.txt`)
- `/api/export`
- the existing `/api/llms-docs.md` → `/llms-full.txt` redirect

None of those are affected. `redirects.js` parses cleanly with 205 entries and no duplicate sources.
