### PR TITLE
docs(mcp): make Remote MCP the default, reframe as one MCP server

### DIFF
--- a/content/docs/agents.md
+++ b/content/docs/agents.md
@@ -3,7 +3,7 @@ title: Railway for Agents
 description: Set up Railway for AI coding agents — install the CLI, configure MCP, and add agent skills in one step.
 ---
 
-Railway exposes a CLI, a local MCP server, a hosted remote MCP server, and an open agent skills format. AI coding agents can use any of them to deploy services, manage environments, and operate Railway on behalf of a user.
+Railway exposes a CLI, a hosted MCP server, and an open agent skills format. AI coding agents can use any of them to deploy services, manage environments, and operate Railway on behalf of a user.
 
 ## Get set up
 
@@ -30,7 +30,7 @@ railway setup agent
   />
   <Card
     title="Railway MCP"
-    description="Remote MCP through the CLI or OAuth, with a local option. Works with Cursor, Claude Code, VS Code, Codex, Copilot, Droid, OpenCode, Windsurf, and more."
+    description="Connect through the CLI or OAuth. Works with Cursor, Claude Code, VS Code, Codex, Copilot, Droid, OpenCode, Windsurf, and more."
     href="/ai/mcp-server"
     icon="Monitor"
     tone="blue"
@@ -53,8 +53,7 @@ railway setup agent
 
 ## When to use each
 
-- **Railway MCP (Remote)** — the default. The `railway mcp` command connects to `mcp.railway.com` and reuses your `railway login` credentials, and editors that support OAuth can connect directly without the CLI. Exposes the powerful `railway-agent` tool for multi-step operations.
-- **Railway MCP (Local)** — runs in-process through the CLI (`railway mcp local`) for machines that can't reach `mcp.railway.com`: project and service discovery, deployment status, bounded logs, variables, domains, templates, metrics, and scoped mutations.
+- **Railway MCP** — preferred for agent-native operations. The `railway mcp` command connects to `mcp.railway.com` and reuses your `railway login` credentials, and editors that support OAuth can connect directly without the CLI. Exposes the powerful `railway-agent` tool for multi-step operations. (An in-process local server, `railway mcp local`, exists for machines that can't reach `mcp.railway.com`.)
 - **Railway CLI** — preferred when the task depends on local machine state: current-directory deploys, `railway up`, `railway run`, SSH, and local linking.
 - **Agent Skills** — install alongside any of the above so agents arrive with Railway-specific procedural knowledge instead of guessing.
 - **Cloud agents** are preferred when the work should outlive the local terminal: a persistent VM running the coding agent, with sessions you can leave and reattach to.

--- a/content/docs/agents.md
+++ b/content/docs/agents.md
@@ -30,7 +30,7 @@ railway setup agent
   />
   <Card
     title="Railway MCP"
-    description="Local stdio or hosted OAuth — toggle between modes on a single page. Works with Cursor, Claude Code, VS Code, Codex, Copilot, Droid, OpenCode, Windsurf, and more."
+    description="Remote MCP through the CLI or OAuth, with a local option. Works with Cursor, Claude Code, VS Code, Codex, Copilot, Droid, OpenCode, Windsurf, and more."
     href="/ai/mcp-server"
     icon="Monitor"
     tone="blue"
@@ -53,8 +53,8 @@ railway setup agent
 
 ## When to use each
 
-- **Railway MCP (Local)** — preferred for agent-native operations on a logged-in machine: project and service discovery, deployment status, bounded logs, variables, domains, templates, metrics, and scoped mutations.
-- **Railway MCP (Remote)** — preferred when the user wants hosted OAuth MCP, or when local CLI configuration is unavailable. Also exposes the powerful `railway-agent` tool for multi-step operations.
+- **Railway MCP (Remote)** — the default. The `railway mcp` command connects to `mcp.railway.com` and reuses your `railway login` credentials, and editors that support OAuth can connect directly without the CLI. Exposes the powerful `railway-agent` tool for multi-step operations.
+- **Railway MCP (Local)** — runs in-process through the CLI (`railway mcp local`) for machines that can't reach `mcp.railway.com`: project and service discovery, deployment status, bounded logs, variables, domains, templates, metrics, and scoped mutations.
 - **Railway CLI** — preferred when the task depends on local machine state: current-directory deploys, `railway up`, `railway run`, SSH, and local linking.
 - **Agent Skills** — install alongside any of the above so agents arrive with Railway-specific procedural knowledge instead of guessing.
 - **Cloud agents** are preferred when the work should outlive the local terminal: a persistent VM running the coding agent, with sessions you can leave and reattach to.

--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -69,10 +69,10 @@ Railway provides [official plugins and connectors](/ai/plugins-and-connectors) f
 
 ### MCP server
 
-The [Railway MCP Server](/ai/mcp-server) implements the Model Context Protocol, enabling direct communication between AI assistants and your Railway infrastructure. Connect to Remote MCP at `mcp.railway.com` through the CLI, which reuses your `railway login` credentials without a second authentication.
+The [Railway MCP Server](/ai/mcp-server) implements the Model Context Protocol, enabling direct communication between AI assistants and your Railway infrastructure. Connect to the server at `mcp.railway.com` through the CLI, which reuses your `railway login` credentials without a second authentication.
 
 - One command to install: `railway mcp install`
-- Add `--oauth` for direct OAuth, or `--local` to run the MCP server on your machine
+- Add `--oauth` for direct OAuth
 - Create projects, deploy templates, manage environments, pull variables
 - Works with Cursor, VS Code, Claude Code, Codex, Copilot, Factory Droid, OpenCode, Windsurf, Cline, and Devin
 

--- a/content/docs/ai.md
+++ b/content/docs/ai.md
@@ -69,10 +69,10 @@ Railway provides [official plugins and connectors](/ai/plugins-and-connectors) f
 
 ### MCP server
 
-The [Railway MCP Server](/ai/mcp-server) implements the Model Context Protocol, enabling direct communication between AI assistants and your Railway infrastructure. Run Local MCP on your machine, or connect to Remote MCP using your Railway CLI credentials or OAuth.
+The [Railway MCP Server](/ai/mcp-server) implements the Model Context Protocol, enabling direct communication between AI assistants and your Railway infrastructure. Connect to Remote MCP at `mcp.railway.com` through the CLI, which reuses your `railway login` credentials without a second authentication.
 
 - One command to install: `railway mcp install`
-- Add `--remote` to reuse Railway CLI credentials through the proxy, or add `--remote --oauth` for direct OAuth
+- Add `--oauth` for direct OAuth, or `--local` to run the MCP server on your machine
 - Create projects, deploy templates, manage environments, pull variables
 - Works with Cursor, VS Code, Claude Code, Codex, Copilot, Factory Droid, OpenCode, Windsurf, Cline, and Devin
 

--- a/content/docs/ai/mcp-server.md
+++ b/content/docs/ai/mcp-server.md
@@ -1,17 +1,16 @@
 ---
 title: Railway MCP Server
-description: Connect AI coding agents to Railway through Remote MCP or Local MCP.
+description: Connect AI coding agents to the Railway MCP server.
 ---
 
 The Railway MCP Server implements the <a href="https://modelcontextprotocol.org" target="_blank">Model Context Protocol (MCP)</a>. It lets AI assistants create projects, deploy templates, manage environments, pull variables, and redeploy services.
 
-Railway offers two MCP servers:
+The server runs at `mcp.railway.com`. Connect to it in one of two ways:
 
-* **Remote MCP** runs at `mcp.railway.com` and is the default. The `railway mcp` command connects your editor to it through the [Railway CLI](/cli), reusing your `railway login` credentials so no second authentication is required. Editors that support OAuth can also connect directly.
-* **Local MCP** runs in-process through the Railway CLI on your machine. Start it with `railway mcp local` when your machine can't reach `mcp.railway.com`.
+* **Through the CLI** (default). The `railway mcp` command connects your editor to `mcp.railway.com` through the [Railway CLI](/cli), reusing your `railway login` credentials so no second authentication is required.
+* **With OAuth.** Editors that support OAuth connect directly to `https://mcp.railway.com` without the CLI.
 
-**Note:** Connecting to Remote MCP by default and the `railway mcp local`
-command require CLI version 5.44.0 or later.
+**Note:** Connecting through the CLI requires CLI version 5.44.0 or later.
 
 ## Quick start
 
@@ -23,9 +22,8 @@ one command. Select the options to generate the setup command:
 If the CLI is already installed, skip the bootstrap and run:
 
 ```bash
-railway setup agent          # Remote MCP through the CLI proxy (default)
-railway setup agent --oauth  # Remote MCP with OAuth
-railway setup agent --local  # Local MCP
+railway setup agent          # connect through the CLI (default)
+railway setup agent --oauth  # connect with OAuth
 ```
 
 Read on for per-editor manual configuration, the available tool list, and security considerations.
@@ -33,8 +31,8 @@ Read on for per-editor manual configuration, the available tool list, and securi
 ## Per-editor configuration
 
 If you'd rather configure an editor manually, or want to inspect what
-`railway mcp install` writes, use the selector to switch between Remote MCP
-through the CLI proxy, Remote MCP with OAuth, and local stdio:
+`railway mcp install` writes, use the selector to switch between the CLI
+connection, OAuth, and [running the server locally](#run-the-server-locally):
 
 <McpInstallGuide />
 
@@ -48,14 +46,11 @@ The **Model Context Protocol (MCP)** defines a standard for how AI applications 
 * **Clients**: The layer within hosts that maintains one-to-one connections with individual MCP servers.
 * **Servers**: Standalone programs (like the Railway MCP Server) that expose tools and workflows for managing external systems.
 
-Remote MCP runs on Railway's infrastructure. The `railway mcp` command connects to it over stdio and attaches credentials from your `railway login` session to each request, and editors that support OAuth can connect directly instead. The Local MCP server (`railway mcp local`) translates natural language requests into CLI workflows powered by the [Railway CLI](/cli) without reaching `mcp.railway.com`.
+The Railway MCP server runs on Railway's infrastructure. The `railway mcp` command connects to it over stdio and attaches credentials from your `railway login` session to each request. Editors that support OAuth connect directly instead.
 
 ## Prerequisites
 
-The server and authentication method determine which local tools and credentials you need.
-
-* **Remote MCP** requires a <a href="https://railway.com/login" target="_blank">Railway account</a>. The default `railway mcp` connection requires an installed CLI and a `railway login` session so it can reuse those credentials. Direct OAuth doesn't require the CLI.
-* **Local MCP** requires an installed and authenticated [Railway CLI](/cli).
+Connecting to the Railway MCP server requires a <a href="https://railway.com/login" target="_blank">Railway account</a>. The default CLI connection also requires an installed [Railway CLI](/cli) and a `railway login` session so it can reuse those credentials. OAuth doesn't require the CLI.
 
 ## Example usage
 
@@ -80,7 +75,7 @@ Use prompts that describe the Railway outcome you want the agent to produce.
   Pull environment variables for my project and save them to a .env file
   ```
 
-* **Debug a failing deployment** (remote-only `railway-agent` tool)
+* **Debug a failing deployment** (uses the `railway-agent` tool)
 
   ```text
   Use the railway agent to figure out why my backend service is
@@ -105,12 +100,8 @@ Use prompts that describe the Railway outcome you want the agent to produce.
 
 ## Available MCP tools
 
-The Railway MCP Server exposes the following tools. Your AI assistant selects tools based on your request.
-
-### Remote MCP
-
-Remote MCP exposes the following tools. Use `railway-agent` for multi-step
-operations.
+The Railway MCP Server exposes the following tools. Your AI assistant selects
+tools based on your request. Use `railway-agent` for multi-step operations.
 
 * **Account**
   * `whoami`
@@ -125,9 +116,18 @@ operations.
 * **Agent**
   * `railway-agent`: hand a natural-language request to Railway's AI agent for multi-step operations like log analysis, debugging, and service configuration
 
-### Local MCP
+## Run the server locally
 
-Local MCP runs through the Railway CLI and exposes these tools:
+The CLI also ships an in-process MCP server for machines that can't reach
+`mcp.railway.com`, for example on egress-restricted networks. Start it with
+`railway mcp local`, or write the configuration for supported editors with
+`railway mcp install --local`. It talks directly to the Railway API using your
+CLI credentials, marks destructive tools with protocol-level hints, and
+returns a preview before requiring `confirm: true`.
+
+The local server exposes a different tool set from `mcp.railway.com`:
+
+<Collapse title="Local server tools">
 
 * **Account:** `whoami`
 * **Projects and services:** `list_workspaces`, `list_projects`,
@@ -149,25 +149,26 @@ Local MCP runs through the Railway CLI and exposes these tools:
   `http_error_rate`, and `http_response_time`
 * **Documentation:** `docs_search` and `docs_fetch`
 
+</Collapse>
+
 ## Security considerations
 
-The Railway MCP Server runs CLI commands or invokes Railway APIs on your
-behalf. Local MCP marks destructive tools with protocol-level hints and returns
-a preview before requiring `confirm: true`. You should still:
+The Railway MCP Server invokes Railway APIs on your behalf. Keep these points
+in mind:
+
+* **CLI authentication.** The `railway mcp` command reads and refreshes your `railway login` credentials. Editor configuration doesn't contain a long-lived Railway credential.
+* **OAuth scoping.** With OAuth, you choose which workspaces and projects the client can access. Tokens are short-lived and can be revoked from your Railway account settings.
+* **Destructive actions** are marked at the protocol level. Clients that respect these hints will prompt for confirmation.
+* **Project tokens are not accepted.** The server requires a user identity for billing and audit trails.
+
+You should still:
 
 * **Review actions** requested by the LLM before approving them, especially
-  destructive ones (`remove_service`, `delete_domain`, `remove_tcp_proxy`,
-  `remove_bucket`, `remove_volume`, `redeploy`, `accept-deploy`, and
-  `railway-agent`).
+  destructive ones (`redeploy`, `accept-deploy`, `railway-agent`, and the
+  local server's `remove_service`, `delete_domain`, `remove_tcp_proxy`,
+  `remove_bucket`, and `remove_volume`).
 * **Restrict access** to ensure only trusted users can invoke the MCP server.
 * **Avoid production risks** by limiting usage to non-critical environments where possible.
-
-For Remote MCP:
-
-* **CLI proxy authentication.** The proxy reads and refreshes your `railway login` credentials. Editor configuration doesn't contain a long-lived Railway credential.
-* **OAuth scoping.** With direct OAuth, you choose which workspaces and projects the client can access. Tokens are short-lived and can be revoked from your Railway account settings.
-* **Destructive actions** are marked at the protocol level. Clients that respect these hints will prompt for confirmation.
-* **Project tokens are not accepted.** Remote MCP requires a user identity for billing and audit trails.
 
 ## Feature requests
 

--- a/content/docs/ai/mcp-server.md
+++ b/content/docs/ai/mcp-server.md
@@ -1,14 +1,17 @@
 ---
 title: Railway MCP Server
-description: Connect AI coding agents to Railway through Local MCP or Remote MCP.
+description: Connect AI coding agents to Railway through Remote MCP or Local MCP.
 ---
 
 The Railway MCP Server implements the <a href="https://modelcontextprotocol.org" target="_blank">Model Context Protocol (MCP)</a>. It lets AI assistants create projects, deploy templates, manage environments, pull variables, and redeploy services.
 
 Railway offers two MCP servers:
 
-* **Local MCP** runs through the [Railway CLI](/cli) on your machine and uses local CLI context.
-* **Remote MCP** runs at `mcp.railway.com`. Connect directly using OAuth, or run `railway mcp proxy` to reuse credentials from your `railway login` session.
+* **Remote MCP** runs at `mcp.railway.com` and is the default. The `railway mcp` command connects your editor to it through the [Railway CLI](/cli), reusing your `railway login` credentials so no second authentication is required. Editors that support OAuth can also connect directly.
+* **Local MCP** runs in-process through the Railway CLI on your machine. Start it with `railway mcp local` when your machine can't reach `mcp.railway.com`.
+
+**Note:** Connecting to Remote MCP by default and the `railway mcp local`
+command require CLI version 5.44.0 or later.
 
 ## Quick start
 
@@ -20,9 +23,9 @@ one command. Select the options to generate the setup command:
 If the CLI is already installed, skip the bootstrap and run:
 
 ```bash
-railway setup agent                  # Local MCP
-railway setup agent --remote         # Remote MCP through the CLI proxy
-railway setup agent --remote --oauth # Remote MCP with OAuth
+railway setup agent          # Remote MCP through the CLI proxy (default)
+railway setup agent --oauth  # Remote MCP with OAuth
+railway setup agent --local  # Local MCP
 ```
 
 Read on for per-editor manual configuration, the available tool list, and security considerations.
@@ -30,8 +33,8 @@ Read on for per-editor manual configuration, the available tool list, and securi
 ## Per-editor configuration
 
 If you'd rather configure an editor manually, or want to inspect what
-`railway mcp install` writes, use the selector to switch between local stdio,
-Remote MCP through the CLI proxy, and Remote MCP with OAuth:
+`railway mcp install` writes, use the selector to switch between Remote MCP
+through the CLI proxy, Remote MCP with OAuth, and local stdio:
 
 <McpInstallGuide />
 
@@ -45,14 +48,14 @@ The **Model Context Protocol (MCP)** defines a standard for how AI applications 
 * **Clients**: The layer within hosts that maintains one-to-one connections with individual MCP servers.
 * **Servers**: Standalone programs (like the Railway MCP Server) that expose tools and workflows for managing external systems.
 
-The Local MCP server translates natural language requests into CLI workflows powered by the [Railway CLI](/cli). Remote MCP runs on Railway's infrastructure and supports OAuth. The CLI proxy provides another connection path by passing credentials from your `railway login` session to Remote MCP.
+Remote MCP runs on Railway's infrastructure. The `railway mcp` command connects to it over stdio and attaches credentials from your `railway login` session to each request, and editors that support OAuth can connect directly instead. The Local MCP server (`railway mcp local`) translates natural language requests into CLI workflows powered by the [Railway CLI](/cli) without reaching `mcp.railway.com`.
 
 ## Prerequisites
 
 The server and authentication method determine which local tools and credentials you need.
 
+* **Remote MCP** requires a <a href="https://railway.com/login" target="_blank">Railway account</a>. The default `railway mcp` connection requires an installed CLI and a `railway login` session so it can reuse those credentials. Direct OAuth doesn't require the CLI.
 * **Local MCP** requires an installed and authenticated [Railway CLI](/cli).
-* **Remote MCP** requires a <a href="https://railway.com/login" target="_blank">Railway account</a>. Direct OAuth doesn't require the CLI. The CLI proxy requires an installed CLI and a `railway login` session so it can reuse those credentials.
 
 ## Example usage
 
@@ -104,6 +107,24 @@ Use prompts that describe the Railway outcome you want the agent to produce.
 
 The Railway MCP Server exposes the following tools. Your AI assistant selects tools based on your request.
 
+### Remote MCP
+
+Remote MCP exposes the following tools. Use `railway-agent` for multi-step
+operations.
+
+* **Account**
+  * `whoami`
+* **Projects**
+  * `list-projects`, `create-project`, `list-services`
+* **Feature flags**
+  * `list-feature-flags`, `get-feature-flag`
+  * `set-feature-flag`, `delete-feature-flag` (admin; destructive delete is marked at the protocol level)
+* **Deployments**
+  * `redeploy`
+  * `accept-deploy`: commit staged changes and deploy (destructive; clients prompt for confirmation)
+* **Agent**
+  * `railway-agent`: hand a natural-language request to Railway's AI agent for multi-step operations like log analysis, debugging, and service configuration
+
 ### Local MCP
 
 Local MCP runs through the Railway CLI and exposes these tools:
@@ -127,24 +148,6 @@ Local MCP runs through the Railway CLI and exposes these tools:
 * **Observability:** `get_logs`, `service_metrics`, `http_requests`,
   `http_error_rate`, and `http_response_time`
 * **Documentation:** `docs_search` and `docs_fetch`
-
-### Remote MCP
-
-Remote MCP exposes the following tools. Use `railway-agent` for multi-step
-operations.
-
-* **Account**
-  * `whoami`
-* **Projects**
-  * `list-projects`, `create-project`, `list-services`
-* **Feature flags**
-  * `list-feature-flags`, `get-feature-flag`
-  * `set-feature-flag`, `delete-feature-flag` (admin; destructive delete is marked at the protocol level)
-* **Deployments**
-  * `redeploy`
-  * `accept-deploy`: commit staged changes and deploy (destructive; clients prompt for confirmation)
-* **Agent**
-  * `railway-agent`: hand a natural-language request to Railway's AI agent for multi-step operations like log analysis, debugging, and service configuration
 
 ## Security considerations
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -1,65 +1,63 @@
 ---
 title: railway mcp
-description: Connect to Remote MCP, run Local MCP, or install the Railway MCP server into AI coding tools.
+description: Connect AI coding tools to the Railway MCP server.
 ---
 
-Connect AI coding tools to Remote MCP at `mcp.railway.com`, run Local MCP, or
-install either configuration into supported tools.
+Connect AI coding tools to the Railway MCP server at `mcp.railway.com`, or
+install the configuration into supported tools.
 
 ## Usage
 
-Run the command without a subcommand to connect to Remote MCP, or choose a
-subcommand to run the local server or install MCP configuration.
+Run the command without a subcommand to connect to the MCP server, or use the
+`install` subcommand to write editor configuration.
 
 ```bash
 railway mcp [COMMAND] [OPTIONS]
 ```
 
-Running `railway mcp` with no subcommand proxies Remote MCP over stdio. The
-proxy authenticates every request with your `railway login` credentials, so
-connecting doesn't require a second authentication. This is the command used
-by the MCP client configurations that `railway mcp install` writes.
+Running `railway mcp` with no subcommand connects to `mcp.railway.com` over
+stdio. The command authenticates every request with your `railway login`
+credentials, so connecting doesn't require a second authentication. This is
+the command used by the MCP client configurations that `railway mcp install`
+writes.
 
-**Note:** Connecting to Remote MCP by default and the `local` subcommand
-require CLI version 5.44.0 or later. On earlier versions, `railway mcp` starts
-the local server.
+**Note:** Connecting to `mcp.railway.com` by default requires CLI version
+5.44.0 or later. On earlier versions, `railway mcp` starts the in-process
+server described in [Run the server locally](#run-the-server-locally).
 
 ## Subcommands
-
-Use a subcommand to run Local MCP or write editor configuration.
 
 | Subcommand | Description |
 |------------|-------------|
 | `install` | Install Railway's MCP server config into AI coding tools |
-| `local` | Serve Local MCP over stdio, without reaching `mcp.railway.com` |
-| `proxy` | Proxy `mcp.railway.com` over stdio. Behaves the same as running `railway mcp` with no subcommand, and is kept so configurations written before the proxy became the default keep working |
+| `local` | Serve an in-process MCP server over stdio, without reaching `mcp.railway.com`. See [Run the server locally](#run-the-server-locally) |
+| `proxy` | Behaves the same as running `railway mcp` with no subcommand. Kept so configurations written before it became the default keep working |
 
 ## Options for `install`
 
-The install command can target specific tools and select which server and
-authentication method to configure.
+The install command can target specific tools and select how the connection
+authenticates.
 
 | Flag | Description |
 |------|-------------|
 | `--agent <AGENT>` | Target a specific tool instead of all detected tools. Can be used more than once |
 | `--oauth` | Configure the direct `https://mcp.railway.com` endpoint so the MCP client handles OAuth. Takes precedence over `--remote` |
-| `--local` | Configure Local MCP (`railway mcp local`) instead of the Remote MCP default |
-| `--remote` | Configure Remote MCP through the CLI proxy. This is the default, and the flag is kept as a compatibility alias |
+| `--local` | Configure the in-process local server (`railway mcp local`) instead of the default connection |
+| `--remote` | Configure the default CLI connection to `mcp.railway.com`. This is already the default, and the flag is kept as a compatibility alias |
 
-## Choose a server
+## Choose a connection
 
-Railway provides Remote MCP and Local MCP. Remote MCP supports CLI credential
-reuse through a local proxy or direct OAuth through the MCP client.
+The MCP server supports credential reuse through the CLI or direct OAuth
+through the MCP client.
 
-| Server | Install command | Authentication |
-|--------|-----------------|----------------|
-| Remote MCP (default) | `railway mcp install` | Reuses your `railway login` credentials through the CLI proxy |
-| Remote MCP with OAuth | `railway mcp install --oauth` | OAuth managed by the MCP client |
-| Local MCP | `railway mcp install --local` | Railway credentials available to the local CLI |
+| Connection | Install command | Authentication |
+|------------|-----------------|----------------|
+| CLI (default) | `railway mcp install` | Reuses your `railway login` credentials |
+| OAuth | `railway mcp install --oauth` | OAuth managed by the MCP client |
 
-The CLI proxy keeps credentials out of editor configuration. It refreshes your
-Railway access token when needed and forwards requests to `mcp.railway.com`.
-Run `railway login` if a proxied tool call reports that you aren't
+The CLI connection keeps credentials out of editor configuration. It refreshes
+your Railway access token when needed and forwards requests to
+`mcp.railway.com`. Run `railway login` if a tool call reports that you aren't
 authenticated. The next tool call uses the new login without restarting the
 editor.
 
@@ -78,10 +76,10 @@ Pass one or more of these values to `--agent`.
 
 ## Installed MCP entries
 
-The installed entry depends on the target tool and transport.
+The installed entry depends on the target tool and connection.
 
-| Agent | Remote MCP through CLI proxy | Remote MCP with OAuth | Local MCP |
-|-------|------------------------------|-----------------------|-----------|
+| Agent | CLI (default) | OAuth | Local server (`--local`) |
+|-------|---------------|-------|--------------------------|
 | Claude Code | `command: "railway"`, `args: ["mcp"]` | `type: "http"`, `url: "https://mcp.railway.com"` | `command: "railway"`, `args: ["mcp", "local"]` |
 | Cursor | `command: "railway"`, `args: ["mcp"]` | `url: "https://mcp.railway.com"` | `command: "railway"`, `args: ["mcp", "local"]` |
 | Factory Droid | `type: "stdio"`, `command: "railway"`, `args: ["mcp"]`, `disabled: false` | `type: "http"`, `url: "https://mcp.railway.com"`, `disabled: false` | `type: "stdio"`, `command: "railway"`, `args: ["mcp", "local"]`, `disabled: false` |
@@ -92,18 +90,17 @@ The installed entry depends on the target tool and transport.
 `railway mcp install` merges the Railway server entry into existing configs without removing other MCP servers.
 
 **Note:** Configurations that run `railway mcp proxy` continue to work and
-connect to Remote MCP. Re-run `railway mcp install` to update them to the
-bare `railway mcp` form.
+connect to `mcp.railway.com`. Re-run `railway mcp install` to update them to
+the bare `railway mcp` form.
 
 ## Examples
 
-These examples cover detected tools, targeted installs, Remote MCP, and Local
-MCP.
+These examples cover detected tools, targeted installs, and OAuth.
 
-### Install Remote MCP for detected tools
+### Install MCP for detected tools
 
 Run the install command without selectors to configure detected tools with
-Remote MCP through the CLI proxy.
+the default CLI connection.
 
 ```bash
 railway mcp install
@@ -125,7 +122,7 @@ Repeat `--agent` to update more than one tool in the same command.
 railway mcp install --agent claude-code --agent copilot
 ```
 
-### Install Remote MCP with OAuth
+### Install MCP with OAuth
 
 Use direct OAuth when your editor can authenticate an HTTP MCP server without
 the CLI.
@@ -134,17 +131,9 @@ the CLI.
 railway mcp install --oauth
 ```
 
-### Install Local MCP
+## Connect through the CLI
 
-Pass `--local` to configure the local stdio server instead of Remote MCP.
-
-```bash
-railway mcp install --local
-```
-
-## Connect to Remote MCP through the CLI proxy
-
-MCP clients connect to Remote MCP through the CLI by running:
+MCP clients connect to the Railway MCP server through the CLI by running:
 
 ```bash
 railway mcp
@@ -155,24 +144,30 @@ The process communicates with the editor over stdio and forwards requests to
 each request. The `railway mcp install` command writes this configuration for
 supported tools automatically.
 
-## Run Local MCP
+## Connect with OAuth
 
-MCP clients that use the local stdio server should run:
+MCP clients that support OAuth can connect directly to
+`https://mcp.railway.com`. The client manages OAuth without using the Railway
+CLI. Run `railway mcp install --oauth` to write this configuration for
+supported tools.
+
+## Run the server locally
+
+The CLI also ships an in-process MCP server for machines that can't reach
+`mcp.railway.com`, for example on egress-restricted networks. It talks
+directly to the Railway API using your CLI credentials and exposes a
+different tool set from `mcp.railway.com`. MCP clients start it by running:
 
 ```bash
 railway mcp local
 ```
 
-Local MCP talks directly to the Railway API using your CLI credentials and
-never reaches `mcp.railway.com`. Choose it when your machine can't reach
-`mcp.railway.com`, for example on egress-restricted networks.
+Pass `--local` to the install command to write this configuration for
+supported tools:
 
-## Connect directly to Remote MCP
-
-MCP clients that support OAuth can connect directly to Remote MCP at
-`https://mcp.railway.com`. The client manages OAuth without using the Railway
-CLI proxy. Run `railway mcp install --oauth` to write this configuration for
-supported tools.
+```bash
+railway mcp install --local
+```
 
 ## Related
 

--- a/content/docs/cli/mcp.md
+++ b/content/docs/cli/mcp.md
@@ -1,53 +1,61 @@
 ---
 title: railway mcp
-description: Start, proxy, or install the Railway MCP server for AI coding tools.
+description: Connect to Remote MCP, run Local MCP, or install the Railway MCP server into AI coding tools.
 ---
 
-Start Local MCP, connect to Remote MCP, or install either configuration into
-supported AI coding tools.
+Connect AI coding tools to Remote MCP at `mcp.railway.com`, run Local MCP, or
+install either configuration into supported tools.
 
 ## Usage
 
-Run the command without a subcommand to start the local server, or choose a
-subcommand to install or proxy MCP.
+Run the command without a subcommand to connect to Remote MCP, or choose a
+subcommand to run the local server or install MCP configuration.
 
 ```bash
 railway mcp [COMMAND] [OPTIONS]
 ```
 
-Running `railway mcp` with no subcommand starts the local stdio MCP server. This is the command used by local MCP client configurations.
+Running `railway mcp` with no subcommand proxies Remote MCP over stdio. The
+proxy authenticates every request with your `railway login` credentials, so
+connecting doesn't require a second authentication. This is the command used
+by the MCP client configurations that `railway mcp install` writes.
+
+**Note:** Connecting to Remote MCP by default and the `local` subcommand
+require CLI version 5.44.0 or later. On earlier versions, `railway mcp` starts
+the local server.
 
 ## Subcommands
 
-Use a subcommand to write editor configuration or connect Remote MCP to an
-editor over stdio.
+Use a subcommand to run Local MCP or write editor configuration.
 
 | Subcommand | Description |
 |------------|-------------|
 | `install` | Install Railway's MCP server config into AI coding tools |
-| `proxy` | Proxy `mcp.railway.com` over stdio using your `railway login` credentials |
+| `local` | Serve Local MCP over stdio, without reaching `mcp.railway.com` |
+| `proxy` | Proxy `mcp.railway.com` over stdio. Behaves the same as running `railway mcp` with no subcommand, and is kept so configurations written before the proxy became the default keep working |
 
 ## Options for `install`
 
-The install command can target specific tools and select how Remote MCP
-authenticates.
+The install command can target specific tools and select which server and
+authentication method to configure.
 
 | Flag | Description |
 |------|-------------|
 | `--agent <AGENT>` | Target a specific tool instead of all detected tools. Can be used more than once |
-| `--remote` | Configure `mcp.railway.com` through `railway mcp proxy`, authenticated by your CLI login |
-| `--oauth` | With `--remote`, configure the direct HTTP endpoint so the MCP client handles OAuth |
+| `--oauth` | Configure the direct `https://mcp.railway.com` endpoint so the MCP client handles OAuth. Takes precedence over `--remote` |
+| `--local` | Configure Local MCP (`railway mcp local`) instead of the Remote MCP default |
+| `--remote` | Configure Remote MCP through the CLI proxy. This is the default, and the flag is kept as a compatibility alias |
 
 ## Choose a server
 
-Railway provides Local MCP and Remote MCP. Remote MCP supports CLI credential
+Railway provides Remote MCP and Local MCP. Remote MCP supports CLI credential
 reuse through a local proxy or direct OAuth through the MCP client.
 
 | Server | Install command | Authentication |
 |--------|-----------------|----------------|
-| Local MCP | `railway mcp install` | Railway credentials available to the local CLI |
-| Remote MCP | `railway mcp install --remote` | Reuses your `railway login` credentials through the CLI proxy |
-| Remote MCP | `railway mcp install --remote --oauth` | OAuth managed by the MCP client |
+| Remote MCP (default) | `railway mcp install` | Reuses your `railway login` credentials through the CLI proxy |
+| Remote MCP with OAuth | `railway mcp install --oauth` | OAuth managed by the MCP client |
+| Local MCP | `railway mcp install --local` | Railway credentials available to the local CLI |
 
 The CLI proxy keeps credentials out of editor configuration. It refreshes your
 Railway access token when needed and forwards requests to `mcp.railway.com`.
@@ -72,25 +80,30 @@ Pass one or more of these values to `--agent`.
 
 The installed entry depends on the target tool and transport.
 
-| Agent | Local MCP | Remote MCP through CLI proxy | Remote MCP with OAuth |
-|-------|-----------|------------------------------|-----------------------|
-| Claude Code | `command: "railway"`, `args: ["mcp"]` | `command: "railway"`, `args: ["mcp", "proxy"]` | `type: "http"`, `url: "https://mcp.railway.com"` |
-| Cursor | `command: "railway"`, `args: ["mcp"]` | `command: "railway"`, `args: ["mcp", "proxy"]` | `url: "https://mcp.railway.com"` |
-| Factory Droid | `type: "stdio"`, `command: "railway"`, `args: ["mcp"]`, `disabled: false` | `type: "stdio"`, `command: "railway"`, `args: ["mcp", "proxy"]`, `disabled: false` | `type: "http"`, `url: "https://mcp.railway.com"`, `disabled: false` |
-| GitHub Copilot | `type: "local"`, `command: "railway"`, `args: ["mcp"]`, `tools: ["*"]` | `type: "local"`, `command: "railway"`, `args: ["mcp", "proxy"]`, `tools: ["*"]` | `type: "http"`, `url: "https://mcp.railway.com"`, `tools: ["*"]` |
-| OpenCode | `type: "local"`, `command: ["railway", "mcp"]`, `enabled: true` | `type: "local"`, `command: ["railway", "mcp", "proxy"]`, `enabled: true` | `type: "remote"`, `url: "https://mcp.railway.com"`, `enabled: true` |
-| OpenAI Codex | `command = "railway"`, `args = ["mcp"]` | `command = "railway"`, `args = ["mcp", "proxy"]` | `url = "https://mcp.railway.com"` |
+| Agent | Remote MCP through CLI proxy | Remote MCP with OAuth | Local MCP |
+|-------|------------------------------|-----------------------|-----------|
+| Claude Code | `command: "railway"`, `args: ["mcp"]` | `type: "http"`, `url: "https://mcp.railway.com"` | `command: "railway"`, `args: ["mcp", "local"]` |
+| Cursor | `command: "railway"`, `args: ["mcp"]` | `url: "https://mcp.railway.com"` | `command: "railway"`, `args: ["mcp", "local"]` |
+| Factory Droid | `type: "stdio"`, `command: "railway"`, `args: ["mcp"]`, `disabled: false` | `type: "http"`, `url: "https://mcp.railway.com"`, `disabled: false` | `type: "stdio"`, `command: "railway"`, `args: ["mcp", "local"]`, `disabled: false` |
+| GitHub Copilot | `type: "local"`, `command: "railway"`, `args: ["mcp"]`, `tools: ["*"]` | `type: "http"`, `url: "https://mcp.railway.com"`, `tools: ["*"]` | `type: "local"`, `command: "railway"`, `args: ["mcp", "local"]`, `tools: ["*"]` |
+| OpenCode | `type: "local"`, `command: ["railway", "mcp"]`, `enabled: true` | `type: "remote"`, `url: "https://mcp.railway.com"`, `enabled: true` | `type: "local"`, `command: ["railway", "mcp", "local"]`, `enabled: true` |
+| OpenAI Codex | `command = "railway"`, `args = ["mcp"]` | `url = "https://mcp.railway.com"` | `command = "railway"`, `args = ["mcp", "local"]` |
 
 `railway mcp install` merges the Railway server entry into existing configs without removing other MCP servers.
 
+**Note:** Configurations that run `railway mcp proxy` continue to work and
+connect to Remote MCP. Re-run `railway mcp install` to update them to the
+bare `railway mcp` form.
+
 ## Examples
 
-These examples cover detected tools, targeted installs, Local MCP, and Remote
+These examples cover detected tools, targeted installs, Remote MCP, and Local
 MCP.
 
-### Install MCP for detected tools
+### Install Remote MCP for detected tools
 
-Run the install command without selectors to configure detected tools.
+Run the install command without selectors to configure detected tools with
+Remote MCP through the CLI proxy.
 
 ```bash
 railway mcp install
@@ -112,50 +125,54 @@ Repeat `--agent` to update more than one tool in the same command.
 railway mcp install --agent claude-code --agent copilot
 ```
 
-### Install Remote MCP through the CLI proxy
-
-Use `--remote` to install the CLI proxy configuration. The proxy reuses your
-`railway login` credentials when it connects to Remote MCP.
-
-```bash
-railway mcp install --remote
-```
-
 ### Install Remote MCP with OAuth
 
-Use direct OAuth when your editor can authenticate an HTTP MCP server.
+Use direct OAuth when your editor can authenticate an HTTP MCP server without
+the CLI.
 
 ```bash
-railway mcp install --remote --oauth
+railway mcp install --oauth
 ```
 
-## Run Local MCP
+### Install Local MCP
 
-MCP clients that use a local stdio server should run:
+Pass `--local` to configure the local stdio server instead of Remote MCP.
+
+```bash
+railway mcp install --local
+```
+
+## Connect to Remote MCP through the CLI proxy
+
+MCP clients connect to Remote MCP through the CLI by running:
 
 ```bash
 railway mcp
 ```
 
-The `railway mcp install` command writes this configuration for supported tools automatically.
+The process communicates with the editor over stdio and forwards requests to
+`mcp.railway.com` over HTTPS, attaching your `railway login` credentials to
+each request. The `railway mcp install` command writes this configuration for
+supported tools automatically.
 
-## Connect to Remote MCP through the CLI proxy
+## Run Local MCP
 
-To reuse Railway CLI credentials when connecting to Remote MCP, run:
+MCP clients that use the local stdio server should run:
 
 ```bash
-railway mcp proxy
+railway mcp local
 ```
 
-The process communicates with the editor over stdio and forwards requests to
-`mcp.railway.com` over HTTPS.
+Local MCP talks directly to the Railway API using your CLI credentials and
+never reaches `mcp.railway.com`. Choose it when your machine can't reach
+`mcp.railway.com`, for example on egress-restricted networks.
 
 ## Connect directly to Remote MCP
 
 MCP clients that support OAuth can connect directly to Remote MCP at
 `https://mcp.railway.com`. The client manages OAuth without using the Railway
-CLI proxy. Run `railway mcp install --remote --oauth` to write this
-configuration for supported tools.
+CLI proxy. Run `railway mcp install --oauth` to write this configuration for
+supported tools.
 
 ## Related
 

--- a/content/docs/cli/setup.md
+++ b/content/docs/cli/setup.md
@@ -23,14 +23,14 @@ The setup command includes the `agent` subcommand.
 
 ## Options for `agent`
 
-Use these flags to skip prompts or select how Remote MCP authenticates.
+Use these flags to skip prompts or select how the MCP connection authenticates.
 
 | Flag | Description |
 |------|-------------|
 | `-y, --yes` | Skip prompts and accept defaults. Also used automatically when stdout is not a terminal |
 | `--oauth` | Configure the direct `https://mcp.railway.com` endpoint so the MCP client handles OAuth. Takes precedence over `--remote` |
-| `--local` | Configure Local MCP (`railway mcp local`) instead of the Remote MCP default |
-| `--remote` | Configure `mcp.railway.com` through the CLI proxy using your `railway login` session. This is the default, and the flag is kept as a compatibility alias |
+| `--local` | Configure the in-process local server (`railway mcp local`) instead of connecting to `mcp.railway.com` |
+| `--remote` | Connect to `mcp.railway.com` through the CLI using your `railway login` session. This is already the default, and the flag is kept as a compatibility alias |
 
 ## Examples
 
@@ -45,8 +45,9 @@ railway setup agent
 ```
 
 This prompts for which supported coding tools to configure and lets you choose
-Remote MCP through the CLI proxy (the default), Local MCP, Remote MCP with
-OAuth, or no MCP configuration. It starts the Railway login flow when needed.
+the CLI connection to `mcp.railway.com` (the default), OAuth, a local
+in-process server, or no MCP configuration. It starts the Railway login flow
+when needed.
 
 ### Non-interactive setup
 
@@ -56,20 +57,9 @@ Pass `--yes` to accept the detected defaults.
 railway setup agent -y
 ```
 
-This configures detected coding tools with Remote MCP through the CLI proxy and skips the interactive login flow. The editors run `railway mcp`, which reuses your `railway login` credentials when it connects to Remote MCP. If you are not already authenticated, run `railway login` after setup.
+This configures detected coding tools and skips the interactive login flow. The editors run `railway mcp`, which reuses your `railway login` credentials when it connects to `mcp.railway.com`. If you are not already authenticated, run `railway login` after setup.
 
-### Use Local MCP
-
-Pass `--local` to configure the local stdio server instead of Remote MCP.
-
-```bash
-railway setup agent --local
-```
-
-This configures supported editors to run `railway mcp local`, which talks
-directly to the Railway API without reaching `mcp.railway.com`.
-
-### Use Remote MCP with OAuth
+### Connect with OAuth
 
 Pass `--oauth` when the MCP client must connect directly and manage OAuth.
 

--- a/content/docs/cli/setup.md
+++ b/content/docs/cli/setup.md
@@ -28,8 +28,9 @@ Use these flags to skip prompts or select how Remote MCP authenticates.
 | Flag | Description |
 |------|-------------|
 | `-y, --yes` | Skip prompts and accept defaults. Also used automatically when stdout is not a terminal |
-| `--remote` | Configure `mcp.railway.com` through the CLI proxy using your `railway login` session |
-| `--oauth` | With `--remote`, configure the direct HTTP endpoint so the MCP client handles OAuth |
+| `--oauth` | Configure the direct `https://mcp.railway.com` endpoint so the MCP client handles OAuth. Takes precedence over `--remote` |
+| `--local` | Configure Local MCP (`railway mcp local`) instead of the Remote MCP default |
+| `--remote` | Configure `mcp.railway.com` through the CLI proxy using your `railway login` session. This is the default, and the flag is kept as a compatibility alias |
 
 ## Examples
 
@@ -44,8 +45,8 @@ railway setup agent
 ```
 
 This prompts for which supported coding tools to configure and lets you choose
-Local MCP, Remote MCP through the CLI proxy, Remote MCP with OAuth, or no
-MCP configuration. It starts the Railway login flow when needed.
+Remote MCP through the CLI proxy (the default), Local MCP, Remote MCP with
+OAuth, or no MCP configuration. It starts the Railway login flow when needed.
 
 ### Non-interactive setup
 
@@ -55,26 +56,25 @@ Pass `--yes` to accept the detected defaults.
 railway setup agent -y
 ```
 
-This configures detected coding tools with default settings and skips the interactive login flow. If you are not already authenticated, run `railway login` after setup.
+This configures detected coding tools with Remote MCP through the CLI proxy and skips the interactive login flow. The editors run `railway mcp`, which reuses your `railway login` credentials when it connects to Remote MCP. If you are not already authenticated, run `railway login` after setup.
 
-### Use Remote MCP through the CLI proxy
+### Use Local MCP
 
-Pass `--remote` to connect to Remote MCP through the CLI proxy and reuse your
-Railway CLI credentials.
+Pass `--local` to configure the local stdio server instead of Remote MCP.
 
 ```bash
-railway setup agent --remote
+railway setup agent --local
 ```
 
-This configures supported editors to run `railway mcp proxy`. The proxy reuses
-your `railway login` credentials when it connects to Remote MCP.
+This configures supported editors to run `railway mcp local`, which talks
+directly to the Railway API without reaching `mcp.railway.com`.
 
 ### Use Remote MCP with OAuth
 
-Add `--oauth` when the MCP client must connect directly and manage OAuth.
+Pass `--oauth` when the MCP client must connect directly and manage OAuth.
 
 ```bash
-railway setup agent --remote --oauth
+railway setup agent --oauth
 ```
 
 This writes `https://mcp.railway.com` directly into supported editor

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -211,8 +211,9 @@ List feature flags for my Railway project
 Set the checkout-v2 feature flag default to true on project <projectId>
 ```
 
-Install agent tooling through the CLI-authenticated proxy with
-`railway setup agent --remote`. For direct editor OAuth, add `--oauth`. See
+Install agent tooling with `railway setup agent`, which connects to Remote MCP
+through the CLI-authenticated proxy by default. For direct editor OAuth, add
+`--oauth`. See
 [Railway MCP Server](/ai/mcp-server) and [Agent Skills](/ai/agent-skills).
 
 ## Related

--- a/content/docs/feature-flags.md
+++ b/content/docs/feature-flags.md
@@ -192,7 +192,7 @@ When you authenticate through `railway login` instead, the CLI uses the project 
 
 ## AI agents and MCP
 
-Remote MCP (`https://mcp.railway.com`) exposes feature flag tools:
+The Railway MCP server (`mcp.railway.com`) exposes feature flag tools:
 
 | Tool | Role | Description |
 |---|---|---|
@@ -211,8 +211,8 @@ List feature flags for my Railway project
 Set the checkout-v2 feature flag default to true on project <projectId>
 ```
 
-Install agent tooling with `railway setup agent`, which connects to Remote MCP
-through the CLI-authenticated proxy by default. For direct editor OAuth, add
+Install agent tooling with `railway setup agent`, which connects to the
+Railway MCP server through the CLI by default. For direct editor OAuth, add
 `--oauth`. See
 [Railway MCP Server](/ai/mcp-server) and [Agent Skills](/ai/agent-skills).
 

--- a/content/docs/platform/compare-to-northflank.md
+++ b/content/docs/platform/compare-to-northflank.md
@@ -159,7 +159,7 @@ Railway also includes sandboxes for running untrusted code at scale, and it uses
 
 The Railway agent is a chat-based assistant that lives inside your project, with all the context and tools it needs to diagnose errors, fix bugs, build new features, and ship them to users.
 
-The same underlying agent powers Railway's Slack and Discord notifications, where you can tag `@railway` and have it get to work without switching contexts. Railway's local and remote MCP servers also bring Railway context and tools into the agent harnesses you already use.
+The same underlying agent powers Railway's Slack and Discord notifications, where you can tag `@railway` and have it get to work without switching contexts. Railway's MCP server also brings Railway context and tools into the agent harnesses you already use.
 
 ## When to pick each
 

--- a/content/guides/best-mcp-servers-coding-agents.md
+++ b/content/guides/best-mcp-servers-coding-agents.md
@@ -199,8 +199,8 @@ The [Railway MCP server](/ai/mcp-server) connects your agent to your Railway pro
 If you have the [Railway CLI](/cli) installed, one command configures your detected clients:
 
 ```bash
-railway setup agent          # local MCP through the CLI
-railway setup agent --remote # hosted remote MCP
+railway setup agent         # remote MCP through the CLI (default)
+railway setup agent --local # local MCP
 ```
 
 Or wire it manually. The remote endpoint authenticates via OAuth:
@@ -219,7 +219,7 @@ claude mcp add --transport http railway https://mcp.railway.com
 }
 ```
 
-The local variant runs through the CLI (`command: "railway"`, `args: ["mcp"]`) and shares the CLI's authentication and linked-project context, which is convenient when your agent works inside a repo already linked to a Railway project. The remote endpoint, by contrast, needs no local install and includes the `railway-agent` tool for multi-step operations like log analysis and failure diagnosis. Full tool lists and per-editor tables for both are in the [MCP server docs](/ai/mcp-server).
+The default CLI configuration (`command: "railway"`, `args: ["mcp"]`) connects to the remote server while sharing the CLI's authentication and linked-project context, which is convenient when your agent works inside a repo already linked to a Railway project. A fully local variant (`args: ["mcp", "local"]`) runs the server in-process without reaching `mcp.railway.com`. The OAuth endpoint, by contrast, needs no local install. Both remote paths include the `railway-agent` tool for multi-step operations like log analysis and failure diagnosis. Full tool lists and per-editor tables are in the [MCP server docs](/ai/mcp-server).
 
 ## 7. Context7
 

--- a/content/guides/best-mcp-servers-coding-agents.md
+++ b/content/guides/best-mcp-servers-coding-agents.md
@@ -199,8 +199,7 @@ The [Railway MCP server](/ai/mcp-server) connects your agent to your Railway pro
 If you have the [Railway CLI](/cli) installed, one command configures your detected clients:
 
 ```bash
-railway setup agent         # remote MCP through the CLI (default)
-railway setup agent --local # local MCP
+railway setup agent
 ```
 
 Or wire it manually. The remote endpoint authenticates via OAuth:
@@ -219,7 +218,7 @@ claude mcp add --transport http railway https://mcp.railway.com
 }
 ```
 
-The default CLI configuration (`command: "railway"`, `args: ["mcp"]`) connects to the remote server while sharing the CLI's authentication and linked-project context, which is convenient when your agent works inside a repo already linked to a Railway project. A fully local variant (`args: ["mcp", "local"]`) runs the server in-process without reaching `mcp.railway.com`. The OAuth endpoint, by contrast, needs no local install. Both remote paths include the `railway-agent` tool for multi-step operations like log analysis and failure diagnosis. Full tool lists and per-editor tables are in the [MCP server docs](/ai/mcp-server).
+The default CLI configuration (`command: "railway"`, `args: ["mcp"]`) shares the CLI's authentication and linked-project context, which is convenient when your agent works inside a repo already linked to a Railway project. The OAuth endpoint, by contrast, needs no local install. Both paths include the `railway-agent` tool for multi-step operations like log analysis and failure diagnosis. Full tool lists and per-editor tables are in the [MCP server docs](/ai/mcp-server).
 
 ## 7. Context7
 

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/pages/api-reference/config/typescript for more information.

--- a/src/components/agent-install-command.tsx
+++ b/src/components/agent-install-command.tsx
@@ -18,13 +18,14 @@ interface CommandInputs {
 
 function buildCommand({ agents, mcp, autoAccept }: CommandInputs): string {
   // agents.railway.com bakes in `--agents -y` (CLI install + `railway setup
-  // agent`, which configures skills + local MCP + login) and forwards extra
-  // args after `-- `. Use it for the canonical full agent setup.
-  if (agents && autoAccept && mcp === "local") {
+  // agent`, which configures skills + Remote MCP through the CLI proxy +
+  // login) and forwards extra args after `-- `. Use it for the canonical
+  // full agent setup.
+  if (agents && autoAccept && mcp === "proxy") {
     return "curl -fsSL agents.railway.com | sh";
   }
-  if (agents && autoAccept && mcp === "proxy") {
-    return "curl -fsSL agents.railway.com | sh -s -- --remote";
+  if (agents && autoAccept && mcp === "local") {
+    return "curl -fsSL agents.railway.com | sh -s -- --local";
   }
   // Standard CLI install path (non-agent) stays on cli.new.
   const base = "bash <(curl -fsSL cli.new)";
@@ -32,29 +33,29 @@ function buildCommand({ agents, mcp, autoAccept }: CommandInputs): string {
 
   // Explicit forms for combos the baked one-liner can't express (no auto-accept,
   // or skills-only without MCP). --agents runs `railway setup agent`.
-  if (agents && mcp === "local") {
+  if (agents && mcp === "proxy") {
     return `${base} --agents${yesFlag}`;
   }
-  if (agents && mcp === "proxy") {
-    return `${base} --agents --remote${yesFlag}`;
+  if (agents && mcp === "local") {
+    return `${base} --agents --local${yesFlag}`;
   }
   if (agents && mcp === "oauth") {
-    return `${base}${yesFlag} && railway setup agent --remote --oauth${yesFlag}`;
+    return `${base}${yesFlag} && railway setup agent --oauth${yesFlag}`;
   }
 
   // Compose CLI install + targeted follow-ups when only one of skills/MCP is wanted.
   const parts = [`${base}${yesFlag}`];
   if (agents) parts.push("railway skills install");
-  if (mcp === "local") parts.push("railway mcp install");
-  if (mcp === "proxy") parts.push("railway mcp install --remote");
-  if (mcp === "oauth") parts.push("railway mcp install --remote --oauth");
+  if (mcp === "proxy") parts.push("railway mcp install");
+  if (mcp === "local") parts.push("railway mcp install --local");
+  if (mcp === "oauth") parts.push("railway mcp install --oauth");
 
   return parts.join(" && ");
 }
 
 export function AgentInstallCommand({ className }: AgentInstallCommandProps) {
   const [agents, setAgents] = React.useState(true);
-  const [mcp, setMcp] = React.useState<McpChoice>("local");
+  const [mcp, setMcp] = React.useState<McpChoice>("proxy");
   const [autoAccept, setAutoAccept] = React.useState(true);
 
   const command = React.useMemo(
@@ -98,11 +99,6 @@ export function AgentInstallCommand({ className }: AgentInstallCommandProps) {
           onCheckedChange={setAgents}
         />
         <OptionToggle
-          label="Local MCP"
-          checked={mcp === "local"}
-          onCheckedChange={next => setMcp(next ? "local" : null)}
-        />
-        <OptionToggle
           label="Remote MCP (CLI proxy)"
           checked={mcp === "proxy"}
           onCheckedChange={next => setMcp(next ? "proxy" : null)}
@@ -111,6 +107,11 @@ export function AgentInstallCommand({ className }: AgentInstallCommandProps) {
           label="Remote MCP (OAuth)"
           checked={mcp === "oauth"}
           onCheckedChange={next => setMcp(next ? "oauth" : null)}
+        />
+        <OptionToggle
+          label="Local MCP"
+          checked={mcp === "local"}
+          onCheckedChange={next => setMcp(next ? "local" : null)}
         />
         <OptionToggle
           label="Auto-accept"

--- a/src/components/agent-install-command.tsx
+++ b/src/components/agent-install-command.tsx
@@ -18,7 +18,7 @@ interface CommandInputs {
 
 function buildCommand({ agents, mcp, autoAccept }: CommandInputs): string {
   // agents.railway.com bakes in `--agents -y` (CLI install + `railway setup
-  // agent`, which configures skills + Remote MCP through the CLI proxy +
+  // agent`, which configures skills + the MCP connection through the CLI +
   // login) and forwards extra args after `-- `. Use it for the canonical
   // full agent setup.
   if (agents && autoAccept && mcp === "proxy") {
@@ -99,17 +99,17 @@ export function AgentInstallCommand({ className }: AgentInstallCommandProps) {
           onCheckedChange={setAgents}
         />
         <OptionToggle
-          label="Remote MCP (CLI proxy)"
+          label="MCP (CLI)"
           checked={mcp === "proxy"}
           onCheckedChange={next => setMcp(next ? "proxy" : null)}
         />
         <OptionToggle
-          label="Remote MCP (OAuth)"
+          label="MCP (OAuth)"
           checked={mcp === "oauth"}
           onCheckedChange={next => setMcp(next ? "oauth" : null)}
         />
         <OptionToggle
-          label="Local MCP"
+          label="MCP (local server)"
           checked={mcp === "local"}
           onCheckedChange={next => setMcp(next ? "local" : null)}
         />

--- a/src/components/mcp-install-guide.tsx
+++ b/src/components/mcp-install-guide.tsx
@@ -471,10 +471,10 @@ function QuickInstall({
       </div>
       <p className="border-t border-muted bg-muted-element/30 px-4 py-2 text-xs text-muted-base">
         {mode === "proxy"
-          ? "Connects to Remote MCP through the CLI, reusing your Railway CLI login. This is the default."
+          ? "Connects to the Railway MCP server through the CLI, reusing your Railway CLI login. This is the default."
           : mode === "oauth"
-            ? "Connects directly to Remote MCP using OAuth."
-            : "Runs the Railway MCP server locally through the Railway CLI, without reaching mcp.railway.com."}
+            ? "Connects directly to mcp.railway.com using OAuth."
+            : "Runs an in-process MCP server through the Railway CLI, without reaching mcp.railway.com."}
       </p>
     </div>
   );
@@ -487,44 +487,27 @@ function ModeToggle({
   mode: Mode;
   onModeChange: (next: Mode) => void;
 }) {
-  const isRemote = mode !== "local";
-
   return (
-    <div className="flex flex-wrap items-center gap-2">
-      <div
-        role="radiogroup"
-        aria-label="MCP server"
-        className="inline-flex items-center rounded-md border border-muted bg-muted-element/40 p-0.5"
-      >
-        <ToggleOption
-          active={isRemote}
-          onClick={() => onModeChange(isRemote ? mode : "proxy")}
-          label="Remote MCP"
-        />
-        <ToggleOption
-          active={!isRemote}
-          onClick={() => onModeChange("local")}
-          label="Local MCP"
-        />
-      </div>
-      {isRemote ? (
-        <div
-          role="radiogroup"
-          aria-label="Remote MCP authentication"
-          className="inline-flex items-center rounded-md border border-muted bg-muted-element/40 p-0.5"
-        >
-          <ToggleOption
-            active={mode === "proxy"}
-            onClick={() => onModeChange("proxy")}
-            label="CLI credentials"
-          />
-          <ToggleOption
-            active={mode === "oauth"}
-            onClick={() => onModeChange("oauth")}
-            label="OAuth"
-          />
-        </div>
-      ) : null}
+    <div
+      role="radiogroup"
+      aria-label="MCP connection"
+      className="inline-flex items-center rounded-md border border-muted bg-muted-element/40 p-0.5"
+    >
+      <ToggleOption
+        active={mode === "proxy"}
+        onClick={() => onModeChange("proxy")}
+        label="CLI"
+      />
+      <ToggleOption
+        active={mode === "oauth"}
+        onClick={() => onModeChange("oauth")}
+        label="OAuth"
+      />
+      <ToggleOption
+        active={mode === "local"}
+        onClick={() => onModeChange("local")}
+        label="Local server"
+      />
     </div>
   );
 }
@@ -631,16 +614,16 @@ function UnsupportedNotice({
 }) {
   const supportedLabel =
     supportedMode === "local"
-      ? "Local"
+      ? "Local server"
       : supportedMode === "proxy"
-        ? "Remote MCP (CLI proxy)"
-        : "Remote MCP (OAuth)";
+        ? "CLI"
+        : "OAuth";
   const supportedDescription =
     supportedMode === "local"
-      ? "local MCP"
+      ? "the local in-process server"
       : supportedMode === "proxy"
-        ? "Remote MCP through the CLI proxy"
-        : "Remote MCP with OAuth";
+        ? "connecting through the CLI"
+        : "connecting with OAuth";
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-2 rounded-md border border-dashed border-muted bg-muted-element/20 px-4 py-3 text-sm text-muted-base">
       <span>

--- a/src/components/mcp-install-guide.tsx
+++ b/src/components/mcp-install-guide.tsx
@@ -36,8 +36,8 @@ const EDITORS: EditorSection[] = [
     id: "cursor",
     name: "Cursor",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description:
           "Run `railway mcp install --agent cursor`, or add the following to `.cursor/mcp.json`:",
         filename: ".cursor/mcp.json",
@@ -51,17 +51,17 @@ const EDITORS: EditorSection[] = [
   }
 }`,
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent cursor --remote`, or add the following to `.cursor/mcp.json`:",
+          "Run `railway mcp install --agent cursor --local`, or add the following to `.cursor/mcp.json`:",
         filename: ".cursor/mcp.json",
         lang: "json",
         code: `{
   "mcpServers": {
     "railway": {
       "command": "railway",
-      "args": ["mcp", "proxy"]
+      "args": ["mcp", "local"]
     }
   }
 }`,
@@ -90,9 +90,10 @@ const EDITORS: EditorSection[] = [
     id: "vs-code",
     name: "VS Code",
     configs: {
-      local: {
-        mode: "local",
-        description: "Add the following to `.vscode/mcp.json`:",
+      proxy: {
+        mode: "proxy",
+        description:
+          "Add the following to `.vscode/mcp.json` and authenticate with `railway login`:",
         filename: ".vscode/mcp.json",
         lang: "json",
         code: `{
@@ -105,10 +106,9 @@ const EDITORS: EditorSection[] = [
   }
 }`,
       },
-      proxy: {
-        mode: "proxy",
-        description:
-          "Add the following to `.vscode/mcp.json` and authenticate with `railway login`:",
+      local: {
+        mode: "local",
+        description: "Add the following to `.vscode/mcp.json`:",
         filename: ".vscode/mcp.json",
         lang: "json",
         code: `{
@@ -116,7 +116,7 @@ const EDITORS: EditorSection[] = [
     "railway": {
       "type": "stdio",
       "command": "railway",
-      "args": ["mcp", "proxy"]
+      "args": ["mcp", "local"]
     }
   }
 }`,
@@ -141,18 +141,18 @@ const EDITORS: EditorSection[] = [
     id: "claude-code",
     name: "Claude Code",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description: "Run `railway mcp install --agent claude-code`, or:",
         lang: "bash",
         code: "claude mcp add railway railway mcp",
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent claude-code --remote`, or:",
+          "Run `railway mcp install --agent claude-code --local`, or:",
         lang: "bash",
-        code: "claude mcp add railway -- railway mcp proxy",
+        code: "claude mcp add railway -- railway mcp local",
       },
       oauth: {
         mode: "oauth",
@@ -167,19 +167,19 @@ const EDITORS: EditorSection[] = [
     id: "codex",
     name: "Codex",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description:
           "Run `railway mcp install --agent codex`, or use the [OpenAI Codex CLI](https://developers.openai.com/codex/cli):",
         lang: "bash",
         code: "codex mcp add railway -- railway mcp",
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent codex --remote`, or use the OpenAI Codex CLI:",
+          "Run `railway mcp install --agent codex --local`, or use the OpenAI Codex CLI:",
         lang: "bash",
-        code: "codex mcp add railway -- railway mcp proxy",
+        code: "codex mcp add railway -- railway mcp local",
       },
       oauth: {
         mode: "oauth",
@@ -194,8 +194,8 @@ url = "https://mcp.railway.com"`,
     id: "copilot",
     name: "GitHub Copilot CLI",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description:
           "Run `railway mcp install --agent copilot`, or add the following to `~/.copilot/mcp-config.json`:",
         filename: "~/.copilot/mcp-config.json",
@@ -211,10 +211,10 @@ url = "https://mcp.railway.com"`,
   }
 }`,
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent copilot --remote`, or add the following to `~/.copilot/mcp-config.json`:",
+          "Run `railway mcp install --agent copilot --local`, or add the following to `~/.copilot/mcp-config.json`:",
         filename: "~/.copilot/mcp-config.json",
         lang: "json",
         code: `{
@@ -222,7 +222,7 @@ url = "https://mcp.railway.com"`,
     "railway": {
       "type": "local",
       "command": "railway",
-      "args": ["mcp", "proxy"],
+      "args": ["mcp", "local"],
       "tools": ["*"]
     }
   }
@@ -231,7 +231,7 @@ url = "https://mcp.railway.com"`,
       oauth: {
         mode: "oauth",
         description:
-          "Run `railway mcp install --agent copilot --remote --oauth`, or add the following to `~/.copilot/mcp-config.json`:",
+          "Run `railway mcp install --agent copilot --oauth`, or add the following to `~/.copilot/mcp-config.json`:",
         filename: "~/.copilot/mcp-config.json",
         lang: "json",
         code: `{
@@ -250,19 +250,19 @@ url = "https://mcp.railway.com"`,
     id: "factory-droid",
     name: "Factory Droid",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description:
           "Run `railway mcp install --agent factory-droid`, or install in [Factory](https://docs.factory.ai/cli/configuration/mcp):",
         lang: "bash",
         code: 'droid mcp add railway "railway mcp"',
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent factory-droid --remote`, or install in Factory:",
+          "Run `railway mcp install --agent factory-droid --local`, or install in Factory:",
         lang: "bash",
-        code: 'droid mcp add railway "railway mcp proxy"',
+        code: 'droid mcp add railway "railway mcp local"',
       },
       oauth: {
         mode: "oauth",
@@ -276,8 +276,8 @@ url = "https://mcp.railway.com"`,
     id: "opencode",
     name: "OpenCode",
     configs: {
-      local: {
-        mode: "local",
+      proxy: {
+        mode: "proxy",
         description:
           "Run `railway mcp install --agent opencode`, or add the following to `opencode.json`:",
         filename: "opencode.json",
@@ -291,17 +291,17 @@ url = "https://mcp.railway.com"`,
   }
 }`,
       },
-      proxy: {
-        mode: "proxy",
+      local: {
+        mode: "local",
         description:
-          "Run `railway mcp install --agent opencode --remote`, or add the following to `opencode.json`:",
+          "Run `railway mcp install --agent opencode --local`, or add the following to `opencode.json`:",
         filename: "opencode.json",
         lang: "json",
         code: `{
   "mcp": {
     "railway": {
       "type": "local",
-      "command": ["railway", "mcp", "proxy"]
+      "command": ["railway", "mcp", "local"]
     }
   }
 }`,
@@ -381,7 +381,7 @@ url = "https://mcp.railway.com"`,
 ];
 
 export function McpInstallGuide() {
-  const [mode, setMode] = React.useState<Mode>("local");
+  const [mode, setMode] = React.useState<Mode>("proxy");
 
   return (
     <div className="space-y-8">
@@ -408,11 +408,11 @@ function QuickInstall({
   onModeChange: (next: Mode) => void;
 }) {
   const command =
-    mode === "local"
+    mode === "proxy"
       ? "railway mcp install"
-      : mode === "proxy"
-        ? "railway mcp install --remote"
-        : "railway mcp install --remote --oauth";
+      : mode === "oauth"
+        ? "railway mcp install --oauth"
+        : "railway mcp install --local";
 
   const { copied, copy: copyRaw } = useCopyToClipboard();
   const [shimmerKey, setShimmerKey] = React.useState(0);
@@ -470,11 +470,11 @@ function QuickInstall({
         <CopyShimmer shimmerKey={shimmerKey} />
       </div>
       <p className="border-t border-muted bg-muted-element/30 px-4 py-2 text-xs text-muted-base">
-        {mode === "local"
-          ? "Runs the Railway MCP server locally through the Railway CLI."
-          : mode === "proxy"
-            ? "Connects to Remote MCP through a local proxy that reuses your Railway CLI login."
-            : "Connects directly to Remote MCP using OAuth."}
+        {mode === "proxy"
+          ? "Connects to Remote MCP through the CLI, reusing your Railway CLI login. This is the default."
+          : mode === "oauth"
+            ? "Connects directly to Remote MCP using OAuth."
+            : "Runs the Railway MCP server locally through the Railway CLI, without reaching mcp.railway.com."}
       </p>
     </div>
   );
@@ -497,14 +497,14 @@ function ModeToggle({
         className="inline-flex items-center rounded-md border border-muted bg-muted-element/40 p-0.5"
       >
         <ToggleOption
-          active={!isRemote}
-          onClick={() => onModeChange("local")}
-          label="Local MCP"
-        />
-        <ToggleOption
           active={isRemote}
           onClick={() => onModeChange(isRemote ? mode : "proxy")}
           label="Remote MCP"
+        />
+        <ToggleOption
+          active={!isRemote}
+          onClick={() => onModeChange("local")}
+          label="Local MCP"
         />
       </div>
       {isRemote ? (
@@ -565,7 +565,7 @@ function EditorBlock({
   mode: Mode;
   onSwitchMode: (next: Mode) => void;
 }) {
-  const supports = editor.supports ?? ["local", "proxy", "oauth"];
+  const supports = editor.supports ?? ["proxy", "oauth", "local"];
   const config = editor.configs[mode];
 
   return (

--- a/src/generated/page-urls.json
+++ b/src/generated/page-urls.json
@@ -101,6 +101,7 @@
   "/databases/database-view",
   "/databases/mongodb",
   "/databases/mysql",
+  "/databases/mysql-ha",
   "/databases/postgresql",
   "/databases/postgresql-ha",
   "/databases/postgresql-pgbouncer",


### PR DESCRIPTION
## What

Updates the MCP docs for CLI v5.44.0 (railwayapp/cli#1125), where bare `railway mcp` now proxies Remote MCP at `mcp.railway.com` using existing `railway login` credentials, and the in-process server moved to `railway mcp local`.

## Changes

**Remote-by-default everywhere**
- `cli/mcp`: bare `railway mcp` connects to Remote MCP with no second authentication; new `local` subcommand documented; `proxy` kept as a compat alias; install writes `["mcp"]` for remote and `["mcp", "local"]` with `--local`
- `McpInstallGuide` / `AgentInstallCommand`: default to the remote CLI proxy; snippets updated to `["mcp"]` / `["mcp", "local"]`; `--oauth` without `--remote`
- `cli/setup`, `ai`, `agents`, `feature-flags`, best-MCP-servers guide: reflect remote-by-default flags (`--local` opt-out, `--remote` as alias)

**One MCP server, not two**
- Drops the "two MCP servers (Remote/Local)" framing. The Railway MCP server is `mcp.railway.com`, reached through the CLI (`railway mcp`, default) or OAuth
- `ai/mcp-server`: single-server intro, prerequisites and security merged, local tool list moved into a Collapse
- `cli/mcp`: "Choose a connection" (CLI/OAuth) section, with the in-process server demoted to a trailing "Run the server locally" section for egress-restricted machines
- `McpInstallGuide`: single CLI/OAuth/Local server selector

## Verification

Ran the dev server locally — all touched pages render correctly (`/cli/mcp`, `/cli/setup`, `/feature-flags`, `/guides/best-mcp-servers-coding-agents`, `/ai/mcp-server`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)