### PR TITLE
Document pinned IaC plans for CI apply-on-merge

### DIFF
--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -113,10 +113,9 @@ railway config apply --plan railway-plan.json --yes --confirm-destructive
 
 Apply fails if the live environment etag no longer matches, or if the
 checked-out `.railway/` tree is not the planned tree. In GitHub Actions, use
-[`railwayapp/config-action`](https://github.com/railwayapp/config-action),
-which wraps both commands and comments the plan on the pull request; the
-[example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml)
-shows the two-job setup.
+[`railwayapp/config`](https://github.com/railwayapp/config), which wraps both
+commands, comments the plan on the pull request, and documents the two-job
+workflow.
 
 ## Apply changes
 

--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -112,8 +112,11 @@ railway config apply --plan railway-plan.json --yes --confirm-destructive
 ```
 
 Apply fails if the live environment etag no longer matches, or if the
-checked-out `.railway/` tree is not the planned tree. See the
-[example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
+checked-out `.railway/` tree is not the planned tree. In GitHub Actions, use
+[`railwayapp/config-action`](https://github.com/railwayapp/config-action),
+which wraps both commands and comments the plan on the pull request; the
+[example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml)
+shows the two-job setup.
 
 ## Apply changes
 

--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -98,9 +98,22 @@ railway config plan
 | `--verbose`, `--full` | Show full change details |
 | `--detailed-exit-code` | Exit `2` when changes are pending and `0` when none are pending |
 | `--show-values` | Print variable values instead of redacting them |
+| `--out <PATH>` | Write a pinned plan artifact (change set, `configEtag`, `.railway/` tree) |
+| `--source-tree <SHA>` | Override the tree written into `--out` (defaults to `git rev-parse HEAD:.railway`) |
 
 Plan output redacts variable values by default. Treat output from
 `--show-values` or `--decrypt-variables` as sensitive.
+
+`--out` is the CI pin. Merge should apply that file, not re-plan:
+
+```bash
+railway config plan --out railway-plan.json
+railway config apply --plan railway-plan.json --yes --confirm-destructive
+```
+
+Apply fails if the live environment etag no longer matches, or if the
+checked-out `.railway/` tree is not the planned tree. See the
+[example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
 
 ## Apply changes
 
@@ -118,6 +131,7 @@ accepts these confirmation flags:
 |------|-------------|
 | `--yes` | Skip the confirmation prompt and run non-interactively |
 | `--confirm-destructive` | Permit destructive changes in non-interactive, JSON, or agent sessions |
+| `--plan <PATH>` | Apply a pinned `--out` artifact without re-evaluating the authoring file |
 
 <Banner variant="warning">
 `railway config apply --json` applies non-destructive changes without

--- a/content/docs/cli/config.md
+++ b/content/docs/cli/config.md
@@ -21,6 +21,7 @@ railway config <COMMAND> [OPTIONS]
 | `pull` | Import the selected Railway environment into `.railway/railway.ts` |
 | `plan` | Preview changes without applying them |
 | `apply` | Preview, confirm, and apply changes |
+| `migrate` | Translate `railway.json` / `railway.toml` into `.railway/railway.ts` |
 
 See [Infrastructure as Code](/infrastructure-as-code) for the complete workflow
 and [the IaC reference](/infrastructure-as-code/reference) for the TypeScript
@@ -71,13 +72,42 @@ railway config pull
 | `--json` | Print the imported graph as JSON instead of writing files |
 | `--runner <PATH>` | Use a specific TypeScript configuration runner |
 | `--omit-preserved-variables` | Omit unknown variables instead of rendering `preserve()` |
+| `--include-variables` | Decrypt and inline non-sealed variable values into the file |
 | `--agent` | Print a suggestion to ask an agent to turn imported state into idiomatic TypeScript |
+
+`--include-variables` writes non-sealed values, including secrets that were never sealed, into `.railway/railway.ts`. The CLI prints a warning when you use it. Sealed variables stay as `preserve()`.
+
+The TypeScript file imports `railway/iac`. Install the SDK from the repository root (`npm install railway`, or the equivalent `pnpm` / `yarn` / `bun` command) before `plan` or `apply`.
 
 `--agent` doesn't invoke an agent or change the generated file. The flag has
 no effect with `--json`, which prints only the imported graph.
 
 Review an imported configuration with `railway config plan` before applying
 it.
+
+## Migrate Config as Code
+
+`railway config migrate` finds every `railway.json` and `railway.toml` in the
+repository — including files in monorepo packages — and emits one
+`.railway/railway.ts`. Linked services whose Railway Config File points at
+those paths keep their Railway service names.
+
+```bash
+railway config migrate
+railway config migrate --apply
+railway config migrate --apply --delete-files
+```
+
+| Flag | Description |
+|------|-------------|
+| `--apply` | Write the file and clear Railway Config File settings |
+| `--force` | Overwrite an existing `.railway/railway.ts` |
+| `--delete-files` | Delete the discovered CaC files after a successful apply |
+| `--service <name>` | Migrate only this service |
+| `--lang ts\|py\|go` | Authoring language (default `ts`) |
+
+A single-service migrate still writes a named `partial` export. A merged
+migrate does not.
 
 ## Preview changes
 

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -325,7 +325,7 @@ Infrastructure as Code is experimental. Current limitations include:
 - Services managed by `railway.json` or `railway.toml` must be migrated before IaC can manage them.
 - Volume lifecycle is intentionally conservative to avoid accidental unmounts.
 - Bucket regions are immutable after creation.
-- Persisted ChangeSet history and apply-later workflows are not part of v0.
+- Railway does not store plan history. A saved plan (`railway config plan --out`) is a file you keep yourself, for example as a CI artifact.
 - Generated `.railway/railway.ts` formatting may change while the DSL is experimental.
 
 ## Related pages

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -182,7 +182,16 @@ Destructive changes, such as deleting a service or variable, are marked before c
 railway config apply --yes --confirm-destructive
 ```
 
-Apply is also protected against acting on a stale plan. Railway runs a fresh plan immediately before applying and commits against the exact environment state it just read. If the environment changed in between — for example a concurrent apply or a dashboard edit — the apply is rejected and you are asked to run `railway config plan` again. This prevents an apply from silently overwriting changes it never saw.
+Apply is also protected against acting on a stale plan. A live `railway config apply` runs a fresh plan immediately before applying and commits against the exact environment state it just read. If the environment changed in between — for example a concurrent apply or a dashboard edit — the apply is rejected and you are asked to run `railway config plan` again.
+
+CI should pin that review instead of planning again on merge:
+
+```bash
+railway config plan --out railway-plan.json
+railway config apply --plan railway-plan.json --yes --confirm-destructive
+```
+
+`--plan` applies the saved change set as-is. It fails if the live `configEtag` drifted or the checked-out `.railway/` tree is not the planned tree. See [`railway config`](/cli/config) and the [example GitHub workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
 
 ## Authoring `.railway/railway.ts`
 

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -191,7 +191,7 @@ railway config plan --out railway-plan.json
 railway config apply --plan railway-plan.json --yes --confirm-destructive
 ```
 
-`--plan` applies the saved change set as-is. It fails if the live `configEtag` drifted or the checked-out `.railway/` tree is not the planned tree. See [`railway config`](/cli/config) and the [example GitHub workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
+`--plan` applies the saved change set as-is. It fails if the live `configEtag` drifted or the checked-out `.railway/` tree is not the planned tree. In GitHub Actions, [`railwayapp/config-action`](https://github.com/railwayapp/config-action) wraps both commands and comments the plan on the pull request. See [`railway config`](/cli/config) and the [example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
 
 ## Authoring `.railway/railway.ts`
 

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -325,7 +325,6 @@ Infrastructure as Code is experimental. Current limitations include:
 - Services managed by `railway.json` or `railway.toml` must be migrated before IaC can manage them.
 - Volume lifecycle is intentionally conservative to avoid accidental unmounts.
 - Bucket regions are immutable after creation.
-- Railway does not store plan history. A saved plan (`railway config plan --out`) is a file you keep yourself, for example as a CI artifact.
 - Generated `.railway/railway.ts` formatting may change while the DSL is experimental.
 
 ## Related pages

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -191,7 +191,7 @@ railway config plan --out railway-plan.json
 railway config apply --plan railway-plan.json --yes --confirm-destructive
 ```
 
-`--plan` applies the saved change set as-is. It fails if the live `configEtag` drifted or the checked-out `.railway/` tree is not the planned tree. In GitHub Actions, [`railwayapp/config-action`](https://github.com/railwayapp/config-action) wraps both commands and comments the plan on the pull request. See [`railway config`](/cli/config) and the [example workflow](https://github.com/railwayapp/cli/blob/master/examples/github/railway-config.yml).
+`--plan` applies the saved change set as-is. It fails if the live `configEtag` drifted or the checked-out `.railway/` tree is not the planned tree. In GitHub Actions, [`railwayapp/config`](https://github.com/railwayapp/config) wraps both commands, comments the plan on the pull request, and documents the two-job workflow. See [`railway config`](/cli/config).
 
 ## Authoring `.railway/railway.ts`
 

--- a/content/docs/infrastructure-as-code.md
+++ b/content/docs/infrastructure-as-code.md
@@ -102,7 +102,9 @@ railway config pull
 
 This writes the linked Railway project's current configuration to `.railway/railway.ts`.
 
-The importer generates code intended to be edited by humans. It keeps user-facing names, omits platform defaults, leaves out generated Railway domains, avoids internal IDs, and omits encrypted secrets unless it must include `preserve()` to avoid overwriting an existing value.
+The importer generates code intended to be edited by humans. It keeps user-facing names, omits platform defaults, leaves out generated Railway domains, avoids internal IDs, and renders existing variable values as `preserve()` so they stay on Railway instead of being written into source.
+
+To inline non-sealed variable values into the file, pass `--include-variables`. The CLI warns that non-sealed variables, including secrets, will be decrypted and included in the spec. Sealed variables stay as `preserve()`.
 
 After importing, run a plan to check whether the generated file would change anything in Railway:
 
@@ -195,6 +197,14 @@ railway config apply --plan railway-plan.json --yes --confirm-destructive
 
 ## Authoring `.railway/railway.ts`
 
+The file imports `railway/iac`. Install the Railway TypeScript SDK from the repository root before you plan or apply:
+
+```bash
+npm install railway
+```
+
+`pnpm add railway`, `yarn add railway`, and `bun add railway` work the same way.
+
 A Railway configuration file exports `defineRailway` and returns a `project`.
 
 ```ts
@@ -228,22 +238,24 @@ export default defineRailway(() => {
 
 Python uses `PARTIAL = "api"`. Go uses `const Partial = "api"`.
 
-Do not add a partial export to a monorepo or a file that already describes the whole environment. Do not rename a partial after you apply it. `railway config migrate` writes a named partial because Config as Code was per-service. Drop that export if you later combine those services into one file.
+Do not add a partial export to a monorepo or a file that already describes the whole environment. Do not rename a partial after you apply it. `railway config migrate` writes a named partial only when it migrates a single service. A merged monorepo migrate does not.
 
 ## Migrating from Config as Code
 
-If you currently use `railway.json` or `railway.toml`, migrate with the CLI:
+If you currently use `railway.json` or `railway.toml`, migrate with the CLI. In a monorepo, `migrate` finds every CaC file in the repository and writes them into a single `.railway/railway.ts`.
 
 ```bash
 # Preview the generated .railway/railway.ts
 railway config migrate
 
-# Write the file and clear the service's Railway Config File setting
+# Write the file and clear Railway Config File settings
 railway config migrate --apply
 
-# Optionally delete the old CaC file
+# Optionally delete the old CaC files
 railway config migrate --apply --delete-files
 ```
+
+`--service <name>` migrates only that service. A single-service migrate still writes a named `partial` export because Config as Code was per-service. A merged migrate does not.
 
 Then review and apply:
 


### PR DESCRIPTION
## Summary
- Documents `railway config plan --out` and `railway config apply --plan`.
- CI should apply the reviewed artifact on merge rather than re-planning.
- Links the example GitHub workflow in the CLI repo.

Depends on [railwayapp/cli#1138](https://github.com/railwayapp/cli/pull/1138). Hold merge until that ships, or the flags and workflow URL will 404.