### PR TITLE
docs: remove duplicated words in enterprise, CLI, and guide pages

### DIFF
--- a/content/docs/cli/login.md
+++ b/content/docs/cli/login.md
@@ -66,7 +66,7 @@ See [Tokens](/cli#tokens) for how to generate each token type.
 
 ## Related
 
-- [railway up](/cli/up) — deploy and sign up/in in one step
+- [railway up](/cli/up) — deploy and sign up or sign in, all in one step
 - [railway logout](/cli/logout)
 - [railway whoami](/cli/whoami)
 - [Global Options](/cli/global-options)

--- a/content/docs/enterprise.md
+++ b/content/docs/enterprise.md
@@ -50,7 +50,7 @@ Railway can be deployed globally, with availability across the Americas, EMEA, a
 
 ## Support SLOs
 
-Enterprise support for reliable uptime and and performance, with:
+Enterprise support for reliable uptime and performance, with:
 
 - 24/7 support coverage
 - +80 NPS enterprise support rating

--- a/content/guides/add-a-cdn-using-cloudfront.md
+++ b/content/guides/add-a-cdn-using-cloudfront.md
@@ -326,7 +326,7 @@ First generate an SSL certificate -
 
 Now, add the certificate in the CloudFront distribution settings and finish setting up the custom domain -
 
-- Return the the CloudFront distribution settings
+- Return the CloudFront distribution settings
 - Under _Custom SSL certificate_, choose the certificate you just created from the drop down menu
 - Under _Alternate domain name (CNAME)_, add your custom domain.
   - If you want both www and apex domain, be sure to add both


### PR DESCRIPTION
## Summary

Remove duplicated words in documentation pages.

| File | Fix |
|------|-----|
| content/docs/enterprise.md | "and and" → "and" |
| content/docs/cli/login.md | "sign up/in in" → "sign up or sign in, all in" |
| content/guides/add-a-cdn-using-cloudfront.md | "the the" → "the" |

## Test plan

- [x] Verified each duplicated word was present before editing
- [x] Residual scan clean on changed files
- [ ] CI checks pass
