### PR TITLE
fix(seo): escape JSON-LD before embedding, align Organization sameAs

### DIFF
--- a/src/components/seo.tsx
+++ b/src/components/seo.tsx
@@ -7,7 +7,7 @@ import {
 } from "next-seo/pages";
 import Head from "next/head";
 import { useRouter } from "next/router";
-import { Header, FAQItem } from "@/utils/seo";
+import { Header, FAQItem, safeJsonLdStringify } from "@/utils/seo";
 import { pageUrlSet } from "@/utils/page-url-set";
 
 export interface Props extends NextSeoProps {
@@ -94,7 +94,15 @@ export const SEO: React.FC<Props> = ({
     name: "Railway",
     url: "https://railway.com",
     logo: "https://railway.com/brand/logo-dark.png",
-    sameAs: ["https://twitter.com/Railway", "https://github.com/railwayapp"],
+    // Kept in step with ORGANIZATION_SCHEMA on railway.com: two different
+    // machine-readable claims about one entity weaken the entity consolidation
+    // that answer engines rely on to resolve "Railway".
+    sameAs: [
+      "https://twitter.com/railway",
+      "https://github.com/railwayapp",
+      "https://discord.gg/railway",
+      "https://www.youtube.com/@railwayapp",
+    ],
   };
   schemas.push(organizationSchema);
 
@@ -238,7 +246,7 @@ export const SEO: React.FC<Props> = ({
           <script
             key={`schema-${index}`}
             type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+            dangerouslySetInnerHTML={{ __html: safeJsonLdStringify(schema) }}
           />
         ))}
       </Head>

--- a/src/utils/seo.ts
+++ b/src/utils/seo.ts
@@ -8,6 +8,34 @@ export interface Header {
   id: string;
 }
 
+/**
+ * Serialises a JSON-LD schema for embedding in a <script> tag.
+ *
+ * Plain JSON.stringify is unsafe here: schema values carry page content —
+ * titles, headings, and (since FAQPage started using real extracted prose)
+ * whole paragraphs of documentation. A literal "</script>" anywhere in that
+ * text closes the JSON-LD block early, so the rest of the schema spills into
+ * the document as markup. That both corrupts the structured data an answer
+ * engine reads and turns page content into executable markup.
+ *
+ * Escaping <, > and & as unicode escapes keeps the JSON semantically identical
+ * (JSON.parse returns the same string) while making an early close impossible.
+ * U+2028/U+2029 are escaped too: both are literal line terminators in JS but
+ * legal raw inside a JSON string, so they can break the surrounding script.
+ *
+ * Mirrors safeJsonLdStringify in the mono repo's @railway/seo package; the two
+ * sites are separate repos and cannot share the module, so the name is kept
+ * identical to make the shared origin obvious.
+ */
+export function safeJsonLdStringify(schema: unknown): string {
+  return JSON.stringify(schema)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
 export function extractHeadersFromMarkdown(markdown: string): Header[] {
   // Remove both triple-backtick and tilde-fenced code blocks
   const codeBlockRegex = /```[\s\S]*?```|~~~[\s\S]*?~~~/g;


### PR DESCRIPTION
## Context

Companion to [railwayapp/mono#36868](https://github.com/railwayapp/mono/pull/36868), which fixed technical-AEO defects on `railway.com`. This is the docs half.

Per Search Console, `docs.railway.com` pages are Railway's highest-impression, lowest-click pages (`docs.railway.com/` — 765k impressions, 0.00 CTR; `/quick-start` — 288k, 0.00). They are the pages most often *summarised* rather than clicked, which makes their structured data the thing that decides whether Railway is the cited source. Both fixes below are in that path.

I audited four suspected defects against live `docs.railway.com` and current `main`. **Two were already fixed upstream** and are not touched here:

- FAQ placeholder answers (`"See the answer in the documentation at…"`) — fixed by #1252, which now extracts real prose. Verified zero occurrences live.
- `/guides/*` markdown twins 404ing — fixed by #1177. Verified `/guides/astro.md`, `/guides/angular.md` and 127 others return 200. (`/guides/cli` is a 308 redirect to `/cli`, correctly canonicalised, and is not in the sitemap — working as intended.)

All 389 sitemap URLs return 200. Two real defects remained.

## 1. JSON-LD was embedded unescaped

`seo.tsx` serialised every schema with a raw `JSON.stringify` inside `dangerouslySetInnerHTML`:

```tsx
dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
```

Schema values carry page content — titles, headings, and **since #1252 whole paragraphs of extracted FAQ prose**. A literal `</script>` anywhere in that text closes the JSON-LD block early: the rest of the schema spills into the document as markup. That corrupts the structured data an answer engine reads *and* turns page content into executable markup.

Demonstrated:

```
<script type="application/ld+json">{…"text":"Close the tag like this: </script><script>alert(1)</script>…
                                                                      ^ block ends here
```

**This is latent, not theoretical.** `content/guides/frontend-environment-variables.md` already contains `</script>`. It is safe today only because that page has no question heading feeding `FAQPage` — one `## …?` heading away from breaking.

`safeJsonLdStringify` escapes `<`, `>`, `&` as unicode escapes, plus `U+2028`/`U+2029` (legal raw inside a JSON string, but literal line terminators in JS, so they can break the surrounding script). The JSON stays semantically identical — `JSON.parse` returns the same string.

It deliberately mirrors the helper of the same name in mono's `@railway/seo`. The two sites are separate repos and can't share a module, so the name is kept identical to make the shared origin obvious.

## 2. `Organization` schema disagreed with railway.com

Docs claimed two profiles where railway.com's canonical `ORGANIZATION_SCHEMA` lists four, and used a different capitalisation of the Twitter URL:

| | before | after |
|---|---|---|
| `sameAs` | twitter.com/**R**ailway, github | twitter.com/railway, github, discord, youtube |

Two divergent machine-readable claims about one entity weaken exactly the entity consolidation answer engines use to resolve "Railway". (The `logo` mismatch I originally flagged was already fixed upstream.)

## Verification

Against a **real production build**, not just unit-level checks:

- `pnpm tsc` → exit 0; `pnpm build` → exit 0
- **1,587 `ld+json` blocks across 388 built pages: all valid JSON, zero containing a raw `<` or `>`**
- Rebuilt unmodified `main` for comparison: the same pages carried **2 unescaped-`&` blocks before, 0 after**
- The escape path is genuinely exercised in production output — breadcrumb names like `Build & deploy`, and OG image query strings
- Adversarial cases (`</script>`, HTML comments, `&`, U+2028, U+2029, plain prose) all escape correctly and round-trip through `JSON.parse`

No tests added: this repo has no test framework (no vitest/jest, no `test` script, no test files), and introducing one is beyond the scope of a two-file fix. Verification was done against build output instead, which for this bug is the stronger signal — it is the emitted HTML that matters.
