### PR TITLE
docs: status/incidents pointer on API page + webhook delivery semantics

### DIFF
--- a/content/docs/integrations/api.md
+++ b/content/docs/integrations/api.md
@@ -241,6 +241,12 @@ To help you get started, we have provided example queries and mutations organize
 - [Manage Domains](/integrations/api/manage-domains) - Add custom domains, configure DNS
 - [Manage Volumes](/integrations/api/manage-volumes) - Create volumes, manage backups
 
+## Status and incidents
+
+Current platform status and incident history are published at [status.railway.com](https://status.railway.com), where you can also subscribe to incident notifications.
+
+For how the API behaves under failure in one place — error format, rate-limit headers, retry guidance, and the deprecation policy — see the [Rate limits](#rate-limits), [Errors](#errors), [Retries](#retries), and [Versioning and deprecation](#versioning-and-deprecation) sections above, or the machine-readable summary at [railway.com/api-reliability.md](https://railway.com/api-reliability.md).
+
 ## Support
 
 If you run into problems using the API or have any suggestions, feel free to reach out on [Central Station](https://station.railway.com) where the team can help you directly.

--- a/content/docs/observability/webhooks.md
+++ b/content/docs/observability/webhooks.md
@@ -61,6 +61,19 @@ When an event occurs, Railway sends a JSON payload to your configured webhook UR
 }
 ```
 
+## Delivery
+
+Railway delivers each event as an HTTP `POST` to your webhook URL:
+
+- **Timeout** - each delivery attempt has a 30-second timeout.
+- **Retries** - a failed delivery is retried up to 3 times with exponential backoff. A delivery counts as successful on any `2xx` or `3xx` response; any other status, a timeout, or a connection error is treated as a failure.
+- **Best-effort** - delivery is not guaranteed and events are not ordered. Treat a webhook as a prompt to act, not a source of truth. When you need certainty, reconcile against the [public API](/integrations/api).
+- **Persistent failures** - if a URL fails repeatedly (currently 100 failures within a 6-hour window), Railway temporarily stops sending to it for 24 hours to avoid wasting retries on a dead endpoint.
+
+### Verifying the sender
+
+Webhook payloads are **not** cryptographically signed. To confirm a request came from Railway, include a secret in the webhook URL you configure — for example a hard-to-guess path segment or query parameter — and reject any request that does not carry it.
+
 ## Testing webhooks
 
 The `Test Webhook` button will send a test payload to the specified webhook URL.


### PR DESCRIPTION
Surfaced by the Ora production-readiness journey: the API page (which the scanner crawls) had no link to the status page, and the webhooks page documented no delivery guarantees.

## Changes
- **`integrations/api`**: add a "Status and incidents" section linking `status.railway.com` and the machine-readable `railway.com/api-reliability.md` summary, with in-page anchors to the existing Rate limits / Errors / Retries / Versioning sections.
- **`observability/webhooks`**: add a "Delivery" section — 30s timeout, up to 3 retries with exponential backoff, 2xx/3xx = success, best-effort/unordered, persistent-failure suspension (100 failures/6h → 24h) — and a note that payloads are **unsigned** with how to verify the sender via a URL secret.

All facts grounded in `notifications/senders/webhook.ts` and the delivery activity retry policy (not inferred).

🤖 Generated with [Claude Code](https://claude.com/claude-code)