### PR TITLE
Fix dead and malicious links. 

### DIFF
--- a/content/docs/databases/mysql.md
+++ b/content/docs/databases/mysql.md
@@ -53,7 +53,7 @@ Especially for production environments, performing regular backups and monitorin
 
 - **Observability**: Implement monitoring for insights into performance and health of your databases. If you're not already running an observability stack, check out these templates to help you get started building one:
   - [Prometheus](https://railway.com/deploy/KmJatA)
-  - [Grafana](https://railway.com/deploy/anURAt)
+  - [Grafana](https://railway.com/deploy/grafana-open-source-observability-platform--grafana-monitoring-dashboard)
 
 ## Additional resources
 

--- a/content/docs/databases/postgresql.md
+++ b/content/docs/databases/postgresql.md
@@ -58,7 +58,7 @@ Especially for production environments, performing regular backups and monitorin
 
 - **Observability**: Implement monitoring for insights into performance and health of your databases. If you're not already running an observability stack, check out these templates to help you get started building one:
   - [Prometheus](https://railway.com/deploy/KmJatA)
-  - [Grafana](https://railway.com/deploy/anURAt)
+  - [Grafana](https://railway.com/deploy/grafana-open-source-observability-platform--grafana-monitoring-dashboard)
   - [PostgreSQL Exporter](https://railway.com/deploy/gDzHrM)
 
 ## Extensions

--- a/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
+++ b/content/guides/deploy-node-express-api-with-auto-scaling-secrets-and-zero-downtime.md
@@ -53,7 +53,7 @@ npm install -D typescript @types/node @types/express tsx
 - [Express](https://expressjs.com/) - Web framework for Node.js
 - [dotenv](https://www.npmjs.com/package/dotenv) - Loads environment variables from `.env` files
 - [TypeScript](https://www.typescriptlang.org/) - Typed superset of JavaScript
-- [tsx](https://tsx.is/) - TypeScript execution engine
+- [tsx](https://tsx.hirok.io/) - TypeScript execution engine
 
 ### Configure TypeScript
 
@@ -172,7 +172,7 @@ Update your `package.json` to include the necessary scripts. Learn more about [n
 
 ### Run the development server
 
-Now you can run your TypeScript application using [tsx](https://tsx.is/), which provides seamless TypeScript execution without worrying about configuration:
+Now you can run your TypeScript application using [tsx](https://tsx.hirok.io/), which provides seamless TypeScript execution without worrying about configuration:
 
 ```bash
 npm run dev


### PR DESCRIPTION
Just three links changed here, 

Moved `https://railway.com/deploy/anURAt` -> `https://railway.com/deploy/grafana-open-source-observability-platform--grafana-monitoring-dashboard`. Not sure why, but the original template was removed at some point. 

Changed `https://tsx.is/` -> `https://tsx.hirok.io/` because tsx.is was compromised. 