### PR TITLE
docs(databases): reverting an HA cluster keeps the deleted nodes' volumes

### DIFF
--- a/content/docs/databases/mysql-ha.md
+++ b/content/docs/databases/mysql-ha.md
@@ -126,6 +126,8 @@ width={612} height={378} quality={100} />
 
 The reverted service keeps the cluster image (`mysql-ha/mysql`), which detects that it has no cluster peers and runs plain standalone `mysqld` with authentication intact. Don't swap the image back to a bare `mysql` tag by hand — the cluster image runs standalone perfectly well, and it is what keeps a later re-conversion possible without another image change.
 
+**Reverting keeps every deleted node's volume.** Deleting the cluster services does not delete their volumes: the replicas' volumes stay in your project, unattached, and continue to count toward storage billing. This is deliberate — a revert never destroys data. Once you've confirmed the standalone MySQL service is healthy, it is safe to delete the leftover volumes from the project canvas. If you convert to HA again later, the new cluster provisions fresh volumes (with suffixed names, since the kept ones still hold the original names) — it does not reuse them.
+
 **Reverting is only available while the original MySQL service is the cluster primary.** Reverting keeps that service and deletes every other node — if the primary role has moved after a failover, reverting would delete the node holding the latest data. If the original service is not the primary, use **Make Leader** to promote it first; the revert flow offers this when it applies.
 
 Railway will automatically migrate all variable references within your project back to the original MySQL service as part of the staged revert. As with conversion, any hardcoded connection strings outside of Railway will need to be updated manually.

--- a/content/docs/databases/postgresql-ha.md
+++ b/content/docs/databases/postgresql-ha.md
@@ -121,6 +121,8 @@ alt="Revert to Standalone confirmation dialog for a Postgres HA cluster"
 layout="intrinsic"
 width={916} height={542} quality={100} />
 
+**Reverting keeps every deleted node's volume.** Deleting the cluster services does not delete their volumes: the replicas' and etcd nodes' volumes stay in your project, unattached, and continue to count toward storage billing. This is deliberate — a revert never destroys data. Once you've confirmed the standalone Postgres service is healthy, it is safe to delete the leftover volumes from the project canvas. If you convert to HA again later, the new cluster provisions fresh volumes (with suffixed names, since the kept ones still hold the original names) — it does not reuse them.
+
 **Reverting is only available while the original Postgres service is the cluster leader.** Reverting keeps that service and deletes every other node — if the leader role has moved after a failover, reverting would delete the node holding the latest data. If the original service is not the leader, use **Make Leader** to promote it first; the revert flow offers this when it applies.
 
 Railway will automatically migrate all variable references within your project back to the original Postgres service as part of the staged revert. As with conversion, any hardcoded connection strings outside of Railway will need to be updated manually.

--- a/content/docs/databases/redis-ha.md
+++ b/content/docs/databases/redis-ha.md
@@ -116,6 +116,8 @@ Reverting will:
 
 The reverted service stays on the cluster's `redis-sentinel` image rather than returning to `redis:X`. Running standalone, it behaves like a plain Redis with authentication intact — leave the image as is. Swapping it back to `redis:X` by hand drops the `--requirepass` startup wiring the sentinel image provides, so clients that send your password start failing to authenticate.
 
+**Reverting keeps every deleted node's volume.** Deleting the cluster services does not delete their volumes: the replicas' volumes stay in your project, unattached, and continue to count toward storage billing. This is deliberate — a revert never destroys data. Once you've confirmed the standalone Redis service is healthy, it is safe to delete the leftover volumes from the project canvas. If you convert to HA again later, the new cluster provisions fresh volumes (with suffixed names, since the kept ones still hold the original names) — it does not reuse them.
+
 **Reverting is only available while the original Redis service is the cluster primary.** Reverting keeps that service and deletes every other node — if the primary role has moved after a failover, reverting would delete the node holding the latest data. If the original service is not the primary, use **Make Leader** to promote it first; the revert flow offers this when it applies.
 
 Railway will automatically migrate all variable references within your project back to the original Redis service as part of the staged revert. As with conversion, any hardcoded connection strings outside of Railway will need to be updated manually.


### PR DESCRIPTION
Reverting an HA cluster to standalone deletes the member services but deliberately keeps their volumes — a revert never destroys data. The volumes stay in the project, unattached, and keep counting toward storage billing, which undocumented reads as a resource leak (it has generated real support escalations).

Adds a short **Reverting keeps every deleted node's volume** paragraph to the *Reverting to Standalone* section of all three HA pages (Postgres, MySQL, Redis): what is kept and why, that it bills, that deleting the leftovers is safe once the standalone service is confirmed healthy, and that a later re-conversion provisions fresh suffixed volumes rather than reusing them.

Note: the major-version-upgrade revert keeps its swapped-out volume for the same reason, but there is no major-upgrade docs page yet to carry it — worth adding when that page lands.