### PR TITLE
docs(domains): document email forwarding on purchased domains

### DIFF
--- a/content/docs/networking/domains/railway-domains.md
+++ b/content/docs/networking/domains/railway-domains.md
@@ -102,7 +102,7 @@ Open a domain from [railway.com/workspace/domains](https://railway.com/workspace
 2. Enter the address to forward, such as `hello`, and the destination inbox it should reach.
 3. Open the actions menu for the address, then click **Send test email** to confirm it arrives.
 
-Enabling forwarding adds seven DNS records to the domain apex, six mail exchange records and one sender policy record, which appear alongside your other [DNS records](#dns-records). Forwarding depends on the mail exchange records. While forwarding addresses exist, Railway refuses both a mail exchange record for another provider at the domain apex and delegation to [custom nameservers](#nameservers). If you delete the final forwarding mail exchange record, Railway warns you that the forwarding addresses will also be deleted.
+Enabling forwarding adds seven DNS records to the domain apex, several mail exchange records and one sender policy record, which appear alongside your other [DNS records](#dns-records). Forwarding depends on the mail exchange records. While forwarding addresses exist, Railway refuses both a mail exchange record for another provider at the domain apex and delegation to [custom nameservers](#nameservers).
 
 ### Before you rely on forwarding
 
@@ -122,7 +122,7 @@ Each domain can have a limited number of forwarding addresses, set by your works
 | --- | --- | --- | --- | --- |
 | 1 | 1 | 5 | 25 | 25 |
 
-The limit counts per domain and applies when you add an address. A domain that's over its limit keeps forwarding every address it has, and you can still edit and remove them, but Railway refuses new ones. Enterprise limits can be raised on request.
+The limit counts per domain and applies when you add an address.
 
 ### When forwarding isn't available
 

--- a/content/docs/networking/domains/railway-domains.md
+++ b/content/docs/networking/domains/railway-domains.md
@@ -94,15 +94,15 @@ After you start a transfer:
 
 ## Email forwarding
 
-Forward mail sent to an address on your Railway-purchased domain to an inbox you already use. Railway doesn't create a mailbox and doesn't store your mail. It relays each message to the destination you choose.
+Forward mail sent to an address on your Railway-purchased domain to an inbox you already use. Railway doesn't create a mailbox or store your mail. Each message is relayed to the destination you choose.
 
 Open a domain from [railway.com/workspace/domains](https://railway.com/workspace/domains) and find the **Email Forwarding** section, next to **DNS records**. Only workspace admins can add, edit, and remove addresses.
 
 1. Click **Add Address**.
 2. Enter the address to forward, such as `hello`, and the destination inbox it should reach.
-3. Click **Send Test Email** on the address to confirm it arrives.
+3. Open the actions menu for the address, then click **Send test email** to confirm it arrives.
 
-Enabling forwarding adds seven DNS records to the domain apex, six mail exchange records and one sender policy record, which appear alongside your other [DNS records](#dns-records). Forwarding delivers only while those records are in place, so Railway warns you before a DNS change that would break it: a mail exchange record for another provider is refused while forwarding addresses exist, deleting the mail exchange records stops forwarding, and delegating the domain to [custom nameservers](#nameservers) stops delivery.
+Enabling forwarding adds seven DNS records to the domain apex, six mail exchange records and one sender policy record, which appear alongside your other [DNS records](#dns-records). Forwarding depends on the mail exchange records. While forwarding addresses exist, Railway refuses both a mail exchange record for another provider at the domain apex and delegation to [custom nameservers](#nameservers). If you delete the final forwarding mail exchange record, Railway warns you that the forwarding addresses will also be deleted.
 
 ### Before you rely on forwarding
 
@@ -112,7 +112,7 @@ Forwarding hands each message to an inbox you already own, which shapes what it 
 - Spam isn't filtered on the way through. The destination inbox applies its own filtering, so check its spam folder.
 - Messages with attachments over 10 MB may fail to arrive.
 - Each address forwards to one destination. Catch-all and wildcard addresses aren't supported.
-- Mail sent from the destination inbox to the forwarded address isn't forwarded back, so test with **Send Test Email** rather than emailing yourself.
+- Mail sent from the destination inbox to the forwarded address isn't forwarded back, so test with **Send test email** rather than emailing yourself.
 
 ### Address limits
 

--- a/content/docs/networking/domains/railway-domains.md
+++ b/content/docs/networking/domains/railway-domains.md
@@ -92,6 +92,45 @@ After you start a transfer:
 - **If you lose the code**, return to this section and click **Get Transfer Code** again — it returns the same code.
 - **Make sure before you start — transfers are final.** Once started, a transfer won't be undone; the domain moves to your new registrar, where you'll manage it from then on.
 
+## Email forwarding
+
+Forward mail sent to an address on your Railway-purchased domain to an inbox you already use. Railway doesn't create a mailbox and doesn't store your mail. It relays each message to the destination you choose.
+
+Open a domain from [railway.com/workspace/domains](https://railway.com/workspace/domains) and find the **Email Forwarding** section, next to **DNS records**. Only workspace admins can add, edit, and remove addresses.
+
+1. Click **Add Address**.
+2. Enter the address to forward, such as `hello`, and the destination inbox it should reach.
+3. Click **Send Test Email** on the address to confirm it arrives.
+
+Enabling forwarding adds seven DNS records to the domain apex, six mail exchange records and one sender policy record, which appear alongside your other [DNS records](#dns-records). Forwarding delivers only while those records are in place, so Railway warns you before a DNS change that would break it: a mail exchange record for another provider is refused while forwarding addresses exist, deleting the mail exchange records stops forwarding, and delegating the domain to [custom nameservers](#nameservers) stops delivery.
+
+### Before you rely on forwarding
+
+Forwarding hands each message to an inbox you already own, which shapes what it can do:
+
+- Replies come from the destination inbox and show that address, not the address the mail was sent to.
+- Spam isn't filtered on the way through. The destination inbox applies its own filtering, so check its spam folder.
+- Messages with attachments over 10 MB may fail to arrive.
+- Each address forwards to one destination. Catch-all and wildcard addresses aren't supported.
+- Mail sent from the destination inbox to the forwarded address isn't forwarded back, so test with **Send Test Email** rather than emailing yourself.
+
+### Address limits
+
+Each domain can have a limited number of forwarding addresses, set by your workspace plan:
+
+| Trial | Free | Hobby | Pro | Enterprise |
+| --- | --- | --- | --- | --- |
+| 1 | 1 | 5 | 25 | 25 |
+
+The limit counts per domain and applies when you add an address. A domain that's over its limit keeps forwarding every address it has, and you can still edit and remove them, but Railway refuses new ones. Enterprise limits can be raised on request.
+
+### When forwarding isn't available
+
+Railway offers forwarding only on domains whose mail records it can manage. The **Email Forwarding** section shows guidance instead of a form when:
+
+- The domain already sends or receives mail through another provider. Set forwarding up with that provider, because adding it in Railway would break your existing setup.
+- DNS is delegated to [custom nameservers](#nameservers). Set forwarding up at that provider, or reset to Railway's nameservers first.
+
 ## Billing
 
 Domain subscriptions are separate from your workspace subscription.
@@ -120,6 +159,10 @@ No. Railway doesn't support transferring in a domain registered with another reg
 
 <Collapse title="Can I use Cloudflare or another DNS provider with my domain?">
 Yes. Workspace admins can point a Railway-purchased domain at an external DNS provider with [custom nameservers](#nameservers), without transferring the domain out. While custom nameservers are in use, the one-click custom domain flow is disabled and DNS records are managed at your external provider instead of in Railway.
+</Collapse>
+
+<Collapse title="Can I get email on my domain?">
+Railway can forward mail sent to an address on your domain to an inbox you already use. It doesn't host mailboxes, so you can't read mail in Railway or send from the forwarded address. See [Email forwarding](#email-forwarding).
 </Collapse>
 
 <Collapse title="Which TLDs are available?">


### PR DESCRIPTION
**[Read the section on the preview deploy](https://docs-frontend-docs-pr-1327.up.railway.app/networking/domains/railway-domains#email-forwarding)**

The dashboard's forwarding UI links to `railway-domains#email-forwarding`, and that anchor has no target today, so the link lands at the top of the page. This adds the section, placed before Billing.

Backed by the [RFC](https://app.notion.com/p/railwayapp/Email-forwarding-on-purchased-domains-3ce0e4c54563800e892dd00b01a1b032) and the implementation stack (railwayapp/mono#37650, #37651, #37647, #37648, #37652, #37649, #37657).

## What it covers

Forwarding relays mail to an inbox the customer already has: no mailbox, nothing stored on Railway. Then setup, the seven DNS records enabling it adds, and the DNS changes Railway refuses while forwarding is in use.

**Limitations are written as observable consequences, not mechanism.** Each line is held to what the implementation establishes, matching the walk-back in mono#37657: attachments over 10 MB *may fail to arrive* rather than being dropped while the message lands, spam *isn't filtered on the way through* rather than being absent, and mail from the destination inbox *isn't forwarded back* rather than being dropped.

**No registrar is named**, per the RFC. Every limitation reads as Railway behaviour.

Plan caps are a table (Trial 1, Free 1, Hobby 5, Pro 25, Enterprise 25), with the two things that surprise people: the cap counts per domain, and a domain over its limit keeps forwarding and stays editable while new addresses are refused.

## Verification

Full evidence: [validation report](https://gist.github.com/fcx-railway/1d068509f0a664cdae39f4170066af24).

| Check | Result |
| --- | --- |
| `pnpm tsc` | Passes, exit 0 (385 documents built) |
| CI Build, CodeQL, preview deploy | Pass |
| Anchor `id="email-forwarding"` | Renders exactly once, no dedup suffix, confirmed on the preview deploy too |
| Internal links `#dns-records`, `#nameservers` | Both resolve to existing ids |
| Every technical claim | Checked against the RFC and the mono stack, not written from the brief |

A second agent reviewed the page against the implementation and found five medium claim errors, all fixed in the second commit: delegation to custom nameservers is *refused* while addresses exist rather than quietly stopping delivery (`assertNameserverDelegationAllowed`), the third-party MX guard is apex-scoped (`isApexDnsRecordHost`), deleting the final forwarding MX also *deletes the addresses* rather than just stopping delivery, the row action is a menu item labelled **Send test email** (the title-case string is the confirm button), and the opening no longer attributes the relay itself to Railway. Each was verified against mono before being accepted.

## One thing this PR cannot fix

The docs site doesn't scroll to a hash target on cold load, on **production** as well as locally. Verified against two pre-existing anchors on the live page (`#nameservers`, `#billing`, 4s wait): the id resolves, `window.scrollY` stays 0. Clicking a TOC entry behaves the same way. So this PR gives the dashboard link a correct, unique target, but landing the reader at the section needs a site-level scroll-on-hash fix, which is outside a content change.
