### PR TITLE
docs: correct retention, restore, PITR backup type, bucket window, and log retention values

### DIFF
--- a/content/docs/observability/logs.md
+++ b/content/docs/observability/logs.md
@@ -422,11 +422,13 @@ In order to ensure a consistent query format across Railway services, incoming l
 
 Depending on your plan, logs are retained for a certain amount of time.
 
-| Plan          | Retention\*   |
-| ------------- | ------------- |
-| Hobby / Trial | 7 days        |
-| Pro           | 30 days       |
-| Enterprise    | Up to 90 days |
+| Plan       | Retention\*   |
+| ---------- | ------------- |
+| Free       | 3 days        |
+| Trial      | 7 days        |
+| Hobby      | 7 days        |
+| Pro        | 30 days       |
+| Enterprise | Up to 90 days |
 
 _\* Upgrading plans will immediately restore logs that were previously outside of the retention period._
 

--- a/content/docs/storage-buckets.md
+++ b/content/docs/storage-buckets.md
@@ -128,13 +128,13 @@ Not yet supported:
 
 You can delete your bucket by clicking on it in your canvas, going to Settings, and selecting Delete Bucket. This stages the deletion, and nothing happens until you deploy the staged change.
 
-Once deployed, the bucket disappears from your project, but it is not permanently deleted yet. It stays restorable for two days, after which every object in it is destroyed.
+Once deployed, the bucket disappears from your project, but it is not permanently deleted yet. It stays restorable for 52 hours, after which every object in it is destroyed.
 
-<Banner variant="danger">After two days, deletion is permanent and the objects cannot be restored. Download anything you want to keep before the window closes.</Banner>
+<Banner variant="danger">After 52 hours, deletion is permanent and the objects cannot be restored. Download anything you want to keep before the window closes.</Banner>
 
 ### Restoring a deleted bucket
 
-While a deleted bucket is still within its two day window, you can put it back:
+While a deleted bucket is still within its 52-hour window, you can put it back:
 
 1. Open the Activity feed for your project.
 2. Select the change that deleted the bucket.

--- a/content/docs/volumes/backups.md
+++ b/content/docs/volumes/backups.md
@@ -16,8 +16,8 @@ Backups can be scheduled to run on a daily, weekly or monthly basis. They will b
 You can set the schedule in the service settings panel, under the Backups tab.
 
 - **Daily** - Backed up every 24 hours, kept for 6 days
-- **Weekly** - Backed up every 7 days, kept for 1 month
-- **Monthly** - Backed up every 30 days, kept for 3 months
+- **Weekly** - Backed up every 7 days, kept for 27 days
+- **Monthly** - Backed up every 30 days, kept for 89 days
 
 You can select multiple backup schedules for a single volume. These schedules can be modified at any time, and you can also manually trigger backups as needed.
 
@@ -40,7 +40,7 @@ During this process, you will see a new [volume](/overview/the-basics#volumes) m
 
 The previous volume will be retained but has been unmounted from the service, it will have the original volume name such as `silk-volume`.
 
-**Note:** Restoring a backup will remove any newer backups you may have created after the backup you are restoring, you will still have access to backups older than the one you are restoring.
+**Note:** The restored volume carries copies of the backups up to and including the one you restored. Backups newer than that point are not copied to it, but they are not deleted either — they stay on the previous volume, which remains in your project unmounted from the service.
 
 If everything looks good and you're ready to proceed, click the `Deploy` button to complete the restore.
 

--- a/content/docs/volumes/point-in-time-recovery.md
+++ b/content/docs/volumes/point-in-time-recovery.md
@@ -9,7 +9,7 @@ PITR works for both single-node Postgres and [Postgres HA](/databases/postgresql
 
 ## How it works
 
-When PITR is enabled, your Postgres image archives every WAL segment it produces directly to a Railway [storage bucket](/storage-buckets) using [pgBackRest](https://pgbackrest.org/). pgBackRest also takes its own base backups on a rolling schedule — a full backup every week and an incremental backup every day — so the bucket holds everything Postgres needs to rebuild a database at any point in the archive window. The last 4 full backups are retained, giving you a restore window of roughly 4 weeks.
+When PITR is enabled, your Postgres image archives every WAL segment it produces directly to a Railway [storage bucket](/storage-buckets) using [pgBackRest](https://pgbackrest.org/). pgBackRest also takes its own base backups on a rolling schedule — a full backup every week and a differential backup every day — so the bucket holds everything Postgres needs to rebuild a database at any point in the archive window. The last 4 full backups are retained, giving you a restore window of roughly 4 weeks.
 
 Pushes are async: pgBackRest's worker batches WAL segments and ships them to S3 in the background, so a stalled bucket can't block writes on Postgres. Under sustained S3 outages, a 5 GiB queue cap on the leader trips and pgBackRest drops WAL to keep the database running — your PITR window truncates, but Postgres stays up.
 
@@ -89,7 +89,7 @@ Everything is zstd-compressed before it leaves the service, so both egress and s
 For most workloads, expect roughly:
 
 - A few GB of compressed WAL per day under steady write load (idle databases are nearly free). Each segment is billed once as egress when pushed, then as storage while retained.
-- One base backup per cycle (weekly full, daily incremental), compressed and de-duplicated by pgBackRest.
+- One base backup per cycle (weekly full, daily differential), compressed and de-duplicated by pgBackRest.
 
 pgBackRest's `expire` runs after each backup and reclaims old base backups along with their pinned WAL, so the bucket size stabilizes at roughly 4 weeks of write volume.
 


### PR DESCRIPTION
Five statements in the docs no longer match what the platform does. Each line below was checked against the current implementation before editing; only the contradicted wording changed.

- **volumes/backups.md — schedule retention.** Weekly backups are kept for **27 days** and monthly backups for **89 days** (the page said "1 month" / "3 months"). Daily (6 days) was already correct.
- **volumes/backups.md — restore note.** Restoring does not delete newer backups. The restored volume carries copies of the backups up to and including the one you restored; newer backups remain on the previous volume, which stays in the project unmounted from the service.
- **volumes/point-in-time-recovery.md — base backup type.** pgBackRest takes a weekly **full** and a daily **differential** backup (the page said "incremental"), in both the "How it works" and "Cost" sections.
- **storage-buckets.md — deletion window.** A deleted bucket stays restorable for **52 hours** (the page said "two days"), in the paragraph, the danger banner, and the restore steps.
- **observability/logs.md — retention table.** Lists every plan with its actual retention: Free 3 days, Trial 7 days, Hobby 7 days, Pro 30 days, Enterprise up to 90 days (the table had no Free row and merged Hobby/Trial).
