### PR TITLE
docs(guides): update TanStack guide

### DIFF
--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a TanStack Start App
-description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and Vinxi server configuration.
-date: "2026-04-14"
+description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and choosing a production server.
+date: "2026-09-03"
 tags:
   - deployment
   - frontend
@@ -10,7 +10,9 @@ tags:
 topic: frameworks
 ---
 
-[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, SSR, and streaming out of the box. TanStack Start uses Vinxi as its server runtime, which builds on Nitro.
+[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, server routes, SSR, and streaming out of the box. TanStack Start is a Vite plugin, so a TanStack Start app builds and deploys as a standard Node service on Railway.
+
+Railway is an [official TanStack Start hosting partner](https://tanstack.com/start/latest/docs/framework/react/guide/hosting), and the TanStack scaffolder ships a Railway option that configures your app to deploy here with no extra setup.
 
 This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
@@ -20,15 +22,15 @@ This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
 ## Create a TanStack Start app
 
-**Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Deploy the TanStack Start app to Railway](#deploy-the-tanstack-start-app-to-railway).
+**Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Choose a production server](#choose-a-production-server).
 
 Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project:
 
 ```bash
-npx @tanstack/create-start@latest my-app
+npx @tanstack/cli@latest create
 ```
 
-Follow the prompts to choose your preferred options.
+Follow the prompts to choose your preferred options. When you reach the deployment options, **select `railway`**. This adds a Nitro server, a `start` script, and everything else Railway needs to build and run your app — see [Choose a production server](#choose-a-production-server) below for what it does and why it matters.
 
 ### Run the app locally
 
@@ -40,9 +42,52 @@ npm run dev
 
 Open `http://localhost:3000` to see your app.
 
+## Choose a production server
+
+This is the one decision that determines whether your deploy works, so it is worth understanding before you push.
+
+`vite build` compiles your app, but it does not produce a server that runs on its own. TanStack Start needs a server runtime on top of the build, and which one you use changes both the build output path and the command that starts it:
+
+| Setup | Build output | Start command |
+| --- | --- | --- |
+| **Nitro** (recommended) | `.output/server/index.mjs` | `node .output/server/index.mjs` |
+| No server runtime | `dist/server/server.js` + `dist/client/` | `srvx --prod -s ../client dist/server/server.js` |
+
+**Use Nitro.** It is what the Railway option in the scaffolder sets up, and it is the configuration this guide documents from here on.
+
+If you picked `railway` when scaffolding, you already have it and there is nothing to do. To add it to an existing app, install Nitro and register its Vite plugin:
+
+```bash
+npm install nitro
+```
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { nitro } from 'nitro/vite';
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import viteReact from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [nitro(), tanstackStart(), viteReact()],
+});
+```
+
+Then add a `start` script, which Railway uses to run your app:
+
+```json
+{
+  "scripts": {
+    "start": "node .output/server/index.mjs"
+  }
+}
+```
+
+That `start` script matters more than it looks. A freshly scaffolded TanStack Start app has **no `start` script at all** unless you add one or pick a deployment option that adds it for you. Without one, Railway has no obvious way to run your app after the build — it will fall back to serving the build with [`srvx`](https://srvx.h3.dev), which works but is not what most production apps want. If your build succeeds and the container exits immediately or serves a 502, a missing `start` script is the first thing to check.
+
 ## Deploy the TanStack Start app to Railway
 
-TanStack Start builds a Node.js server that handles SSR, server functions, and static asset serving. It deploys as a standard Node service on Railway.
+TanStack Start builds a Node.js server that handles SSR, server functions, server routes, and static asset serving. It deploys as a standard Node service on Railway.
 
 ### Deploy from the CLI
 
@@ -84,7 +129,7 @@ TanStack Start builds a Node.js server that handles SSR, server functions, and s
 
 ### Use a Dockerfile
 
-If Railpack does not detect the start command correctly, use a Dockerfile:
+If you'd rather control the build yourself, use a Dockerfile. This one assumes [Nitro](#choose-a-production-server), which builds to `.output`:
 
 ```dockerfile
 FROM node:lts-alpine AS build
@@ -99,54 +144,56 @@ FROM node:lts-alpine
 
 WORKDIR /app
 COPY --from=build /app/.output ./.output
-COPY --from=build /app/package*.json ./
 
 EXPOSE 3000
 CMD ["node", ".output/server/index.mjs"]
 ```
 
-TanStack Start (via Vinxi/Nitro) builds into a `.output` directory. The server entry point is `.output/server/index.mjs`.
+The Nitro build bundles its own dependencies into `.output`, so the runtime stage does not need `node_modules` or your `package.json`.
 
 Deploy via the CLI or from GitHub. Railway automatically detects the `Dockerfile` and [uses it to build and deploy the app](/builds/dockerfiles).
 
 ## Port configuration
 
-TanStack Start's Vinxi server listens on port 3000 by default. To make it respect Railway's `PORT` variable, check your `app.config.ts`:
+You don't need any. Both Nitro and srvx read the `PORT` environment variable that Railway sets, and both bind all interfaces by default, so your app is reachable as soon as it starts.
 
-```typescript
-// app.config.ts
-import { defineConfig } from '@tanstack/react-start/config';
-
-export default defineConfig({
-  server: {
-    port: Number(process.env.PORT) || 3000,
-  },
-});
-```
-
-If the server does not bind to the correct port, set a [custom start command](/deployments/start-command):
-
-```bash
-PORT=$PORT node .output/server/index.mjs
-```
+If you have an older app with an `app.config.ts` that sets a port, you can delete that file. It was part of the Vinxi-based setup that TanStack Start no longer uses, and it has no effect on current versions.
 
 ## Server functions
 
-TanStack Start server functions run on the Node.js server, not in the browser. They can access environment variables, databases, and other server-side resources:
+Server functions run on the server, never in the browser. Use them to reach environment variables, databases, and other server-side resources from your loaders and components:
 
 ```typescript
-// app/routes/api/hello.ts
-import { createAPIFileRoute } from '@tanstack/react-start/api';
+// src/fns.ts
+import { createServerFn } from '@tanstack/react-start';
 
-export const Route = createAPIFileRoute('/api/hello')({
-  GET: async () => {
-    const dbUrl = process.env.DATABASE_URL; // server-only
-    return Response.json({ message: 'Hello from Railway' });
+export const getMessage = createServerFn().handler(async () => {
+  const dbUrl = process.env.DATABASE_URL; // server-only
+  return { message: 'Hello from Railway' };
+});
+```
+
+## Server routes
+
+To expose an HTTP endpoint, add a `server` property to a file route:
+
+```typescript
+// src/routes/api.hello.ts
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/hello')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const dbUrl = process.env.DATABASE_URL; // server-only
+        return Response.json({ message: 'Hello from Railway' });
+      },
+    },
   },
 });
 ```
 
-Server functions have access to all Railway [service variables](/variables). Only variables with the `VITE_` prefix are available in client-side code, since TanStack Start uses Vite. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
+Both server functions and server routes have access to all Railway [service variables](/variables). Only variables prefixed with `VITE_` are available in client-side code, since TanStack Start is built on Vite. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
 
 ## Add a Postgres database
 
@@ -158,6 +205,20 @@ DATABASE_URL=${{Postgres.DATABASE_URL}}
 ```
 
 Use an ORM like Prisma or Drizzle to query the database from server functions and loaders.
+
+## Troubleshooting
+
+**The build succeeds, but the container exits right away or the domain returns a 502.**
+Your app most likely has no `start` script and no server runtime. See [Choose a production server](#choose-a-production-server).
+
+**Pages render, but CSS and JavaScript assets 404.**
+Your server isn't serving the client build. With Nitro this is handled for you. Without it, check that the `-s` path in your srvx command points at the client output directory.
+
+**The deploy works but the app serves the dev server.**
+Never use `vite dev` as a production start command. It is not a production server, and it will not behave correctly behind Railway's edge. Build the app and run the built server instead.
+
+**A deploy healthcheck fails even though the app starts cleanly.**
+Railway's healthcheck does not follow redirects, so a healthcheck path that answers a 3xx fails every deploy. Point it at a path that returns a 200 directly, or remove the healthcheck.
 
 ## Next steps
 

--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -1,6 +1,6 @@
 ---
-title: Deploy a TanStack Start App
-description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and choosing a production server.
+title: Build a TanStack App
+description: Deploy a TanStack app to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and choosing a production server.
 date: "2026-09-03"
 tags:
   - deployment
@@ -12,25 +12,25 @@ topic: frameworks
 
 [TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, server routes, SSR, and streaming out of the box. TanStack Start is a Vite plugin, so a TanStack Start app builds and deploys as a standard Node service on Railway.
 
-Railway is an [official TanStack Start hosting partner](https://tanstack.com/start/latest/docs/framework/react/guide/hosting), and the TanStack scaffolder ships a Railway option that configures your app to deploy here with no extra setup.
+Railway is an [official TanStack hosting partner](https://tanstack.com/start/latest/docs/framework/react/guide/hosting), and the TanStack scaffolder ships a Railway option that configures your app to deploy here with no extra setup.
 
-This guide covers how to deploy a TanStack Start app to Railway in three ways:
+This guide covers how to deploy a TanStack app to Railway in three ways:
 
 1. [From a GitHub repository](#deploy-from-a-github-repo).
 2. [Using the CLI](#deploy-from-the-cli).
 3. [Using a Dockerfile](#use-a-dockerfile).
 
-## Create a TanStack Start app
+## Create a TanStack app
 
-**Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Choose a production server](#choose-a-production-server).
+**Note:** If you already have a TanStack app locally or on GitHub, skip to [Choose a production server](#choose-a-production-server).
 
 Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project:
 
 ```bash
-npx @tanstack/cli@latest create
+npx @tanstack/cli@latest create my-app --deployment railway
 ```
 
-Follow the prompts to choose your preferred options. When you reach the deployment options, **select `railway`**. This adds a Nitro server, a `start` script, and everything else Railway needs to build and run your app — see [Choose a production server](#choose-a-production-server) below for what it does and why it matters.
+The `--deployment railway` flag adds a Nitro server, a `start` script, and everything else Railway needs to build and run your app — see [Choose a production server](#choose-a-production-server) below for what it does and why it matters. You can also omit the flag and pick `railway` from the deployment prompts instead.
 
 ### Run the app locally
 
@@ -83,9 +83,9 @@ Then add a `start` script, which Railway uses to run your app:
 }
 ```
 
-That `start` script matters more than it looks. A freshly scaffolded TanStack Start app has **no `start` script at all** unless you add one or pick a deployment option that adds it for you. Without one, Railway has no obvious way to run your app after the build — it will fall back to serving the build with [`srvx`](https://srvx.h3.dev), which works but is not what most production apps want. If your build succeeds and the container exits immediately or serves a 502, a missing `start` script is the first thing to check.
+A freshly scaffolded TanStack Start app has **no `start` script at all** unless you add one or pick a deployment option that adds it for you. If Railway doesn't find one, it falls back to serving your build with [`srvx`](https://srvx.h3.dev). That does work, so a missing `start` script won't necessarily break your deploy — but it means the server you run in production is chosen for you rather than by you. Adding the script keeps that decision explicit.
 
-## Deploy the TanStack Start app to Railway
+## Deploy the TanStack app to Railway
 
 TanStack Start builds a Node.js server that handles SSR, server functions, server routes, and static asset serving. It deploys as a standard Node service on Railway.
 
@@ -94,7 +94,7 @@ TanStack Start builds a Node.js server that handles SSR, server functions, serve
 1. **Install the Railway CLI**:
    - <a href="/guides/cli#installing-the-cli" target="_blank">Install the CLI</a> and <a href="/guides/cli#authenticating-with-the-cli" target="_blank">authenticate it</a> using your Railway account.
 2. **Initialize a Railway Project**:
-   - Run the command below in your TanStack Start app directory.
+   - Run the command below in your TanStack app directory.
      ```bash
      railway init
      ```
@@ -198,7 +198,7 @@ Both server functions and server routes have access to all Railway [service vari
 ## Add a Postgres database
 
 1. In your Railway project, click **+ New**, then **Database**, then **PostgreSQL**.
-2. Add the connection string to your TanStack Start service:
+2. Add the connection string to your TanStack app's service:
 
 ```
 DATABASE_URL=${{Postgres.DATABASE_URL}}
@@ -209,7 +209,7 @@ Use an ORM like Prisma or Drizzle to query the database from server functions an
 ## Troubleshooting
 
 **The build succeeds, but the container exits right away or the domain returns a 502.**
-Your app most likely has no `start` script and no server runtime. See [Choose a production server](#choose-a-production-server).
+Check the deploy logs for the command Railway actually ran. If your app has no `start` script, Railway starts it with `srvx` against `dist/`, which fails if your build produced something else. See [Choose a production server](#choose-a-production-server).
 
 **Pages render, but CSS and JavaScript assets 404.**
 Your server isn't serving the client build. With Nitro this is handled for you. Without it, check that the `-s` path in your srvx command points at the client output directory.
@@ -224,5 +224,5 @@ Railway's healthcheck does not follow redirects, so a healthcheck path that answ
 
 - [Manage environment variables](/guides/frontend-environment-variables) - Handle `VITE_` prefixed variables in TanStack Start.
 - [Choose between SSR, SSG, and ISR](/guides/ssr-ssg-isr) - Understand rendering strategies.
-- [Add a Database Service](/databases/build-a-database-service)
-- [Monitor your app](/observability)
+- [Add a Database Service](/databases/build-a-database-service) - Connect Postgres, MySQL, Redis, and more.
+- [Monitor your app](/observability) - Track logs, metrics, and deployment health.


### PR DESCRIPTION
Updates the TanStack guide for the current version of the framework.

- Refreshes the server setup and build output paths
- Updates the Dockerfile and code samples
- Retitles the guide and tidies the Next steps list
- Adds a troubleshooting section

Verified by scaffolding a fresh app and deploying it to Railway — CLI, Dockerfile, and the no-start-script path were each checked against a live service.

🤖 Generated with [Claude Code](https://claude.com/claude-code)