### PR TITLE
docs(guides): rewrite TanStack Start guide, validated end to end on Railway

### DIFF
--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -1,6 +1,6 @@
 ---
 title: Deploy a TanStack Start App
-description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and choosing a production server.
+description: Deploy a TanStack Start full-stack React application to Railway. Covers scaffolding with the Railway option, GitHub and CLI deploys, environment variables, database migrations, and troubleshooting.
 date: "2026-09-03"
 tags:
   - deployment
@@ -12,31 +12,32 @@ topic: frameworks
 
 [TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, server routes, SSR, and streaming out of the box. TanStack Start is a Vite plugin, so a TanStack Start app builds and deploys as a standard Node service on Railway.
 
-Railway is an [official TanStack Start hosting partner](https://tanstack.com/start/latest/docs/framework/react/guide/hosting), and the TanStack scaffolder ships a Railway option that configures your app to deploy here with no extra setup.
+Railway is an <a href="https://tanstack.com/start/latest/docs/framework/react/guide/hosting" target="_blank">official TanStack Start hosting partner</a>, and the TanStack scaffolder ships a Railway deployment option that configures your app to deploy here with no extra setup.
 
 This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
-1. [From a GitHub repository](#deploy-from-a-github-repo).
-2. [Using the CLI](#deploy-from-the-cli).
+1. [Using the CLI](#deploy-from-the-cli).
+2. [From a GitHub repository](#deploy-from-a-github-repo).
 3. [Using a Dockerfile](#use-a-dockerfile).
 
 ## Create a TanStack Start app
 
 **Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Choose a production server](#choose-a-production-server).
 
-Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project:
+Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project with the Railway deployment option:
 
 ```bash
-npx @tanstack/cli@latest create
+npx @tanstack/cli@latest create my-app --deployment railway
 ```
 
-Follow the prompts to choose your preferred options. When you reach the deployment options, **select `railway`**. This adds a Nitro server, a `start` script, and everything else Railway needs to build and run your app — see [Choose a production server](#choose-a-production-server) below for what it does and why it matters.
+Follow the prompts to choose your remaining options. The `railway` option adds a Nitro server and a `start` script, which is everything Railway needs to build and run your app.
+
+If you run the command without the `--deployment` flag, select `Railway` at the **Deploy** prompt. Don't accept the default `Nitro (agnostic)` choice for an app headed to Railway: it adds the Nitro server but not the `start` script, and that combination fails at runtime. See [Choose a production server](#choose-a-production-server).
 
 ### Run the app locally
 
 ```bash
 cd my-app
-npm install
 npm run dev
 ```
 
@@ -44,18 +45,20 @@ Open `http://localhost:3000` to see your app.
 
 ## Choose a production server
 
-This is the one decision that determines whether your deploy works, so it is worth understanding before you push.
-
-`vite build` compiles your app, but it does not produce a server that runs on its own. TanStack Start needs a server runtime on top of the build, and which one you use changes both the build output path and the command that starts it:
+`vite build` compiles your app, but TanStack Start needs a server runtime on top of the build. Which one you use changes both the build output and the command that starts it:
 
 | Setup | Build output | Start command |
 | --- | --- | --- |
-| **Nitro** (recommended) | `.output/server/index.mjs` | `node .output/server/index.mjs` |
-| No server runtime | `dist/server/server.js` + `dist/client/` | `srvx --prod -s ../client dist/server/server.js` |
+| Nitro (recommended) | `.output/server/index.mjs` | `node .output/server/index.mjs` |
+| No server runtime | `dist/server/` and `dist/client/` | `npx srvx --prod -s ../client dist/server/server.js` |
 
-**Use Nitro.** It is what the Railway option in the scaffolder sets up, and it is the configuration this guide documents from here on.
+**Use Nitro with a `start` script.** It is what the Railway option in the scaffolder sets up, it produces a self-contained server bundle, and it is the configuration this guide documents from here on.
 
-If you picked `railway` when scaffolding, you already have it and there is nothing to do. To add it to an existing app, install Nitro and register its Vite plugin:
+If your app has no server runtime at all, Railway's builder ([Railpack](/builds) v0.36 and later) detects TanStack Start and serves the default Vite build with [srvx](https://srvx.h3.dev), so that layout deploys without configuration too. The build logs recommend Nitro when this fallback is used.
+
+The combination to avoid is Nitro without a `start` script, which is what the scaffolder's default `Nitro (agnostic)` deploy option produces. Railway falls back to srvx pointed at `dist/`, but Nitro builds to `.output/`, so the server crashes on startup and the domain returns a 502. If you have the `nitro()` plugin in `vite.config.ts`, the `start` script is required.
+
+To add Nitro to an existing app, install it and register its Vite plugin:
 
 ```bash
 npm install nitro
@@ -83,8 +86,6 @@ Then add a `start` script, which Railway uses to run your app:
 }
 ```
 
-That `start` script matters more than it looks. A freshly scaffolded TanStack Start app has **no `start` script at all** unless you add one or pick a deployment option that adds it for you. Without one, Railway has no obvious way to run your app after the build — it will fall back to serving the build with [`srvx`](https://srvx.h3.dev), which works but is not what most production apps want. If your build succeeds and the container exits immediately or serves a 502, a missing `start` script is the first thing to check.
-
 ## Deploy the TanStack Start app to Railway
 
 TanStack Start builds a Node.js server that handles SSR, server functions, server routes, and static asset serving. It deploys as a standard Node service on Railway.
@@ -108,8 +109,11 @@ TanStack Start builds a Node.js server that handles SSR, server functions, serve
    - This command will scan, compress and upload your app's files to Railway. You'll see real-time deployment logs in your terminal.
    - Once the deployment completes, go to **View logs** to check if the service is running successfully.
 4. **Set Up a Public URL**:
-   - Navigate to the **Networking** section under the [Settings](/overview/the-basics#service-settings) tab of your new service.
-   - Click [Generate Domain](/networking/public-networking#railway-provided-domain) to create a public URL for your app.
+   - Generate a domain for your service:
+     ```bash
+     railway domain
+     ```
+   - You can also generate one from the **Networking** section under the [Settings](/overview/the-basics#service-settings) tab of your service.
 
 ### Deploy from a GitHub repo
 
@@ -122,7 +126,7 @@ TanStack Start builds a Node.js server that handles SSR, server functions, serve
    - Click **Deploy** to start the deployment process.
    - Once deployed, a Railway [service](/services) will be created for your app, but it won't be publicly accessible by default.
 4. **Verify the Deployment**:
-   - Once the deployment completes, go to **View logs** to check if the server is running successfully.
+   - Once the deployment completes, go to [**View logs**](/observability/logs#build--deploy-panel) to check if the server is running successfully.
 5. **Set Up a Public URL**:
    - Navigate to the **Networking** section under the [Settings](/overview/the-basics#service-settings) tab of your new service.
    - Click [Generate Domain](/networking/public-networking#railway-provided-domain) to create a public URL for your app.
@@ -145,6 +149,7 @@ FROM node:lts-alpine
 WORKDIR /app
 COPY --from=build /app/.output ./.output
 
+ENV NODE_ENV=production
 EXPOSE 3000
 CMD ["node", ".output/server/index.mjs"]
 ```
@@ -159,7 +164,7 @@ You don't need any. Both Nitro and srvx read the `PORT` environment variable tha
 
 If you have an older app with an `app.config.ts` that sets a port, you can delete that file. It was part of the Vinxi-based setup that TanStack Start no longer uses, and it has no effect on current versions.
 
-## Server functions
+## Server functions and server routes
 
 Server functions run on the server, never in the browser. Use them to reach environment variables, databases, and other server-side resources from your loaders and components:
 
@@ -173,8 +178,6 @@ export const getMessage = createServerFn().handler(async () => {
 });
 ```
 
-## Server routes
-
 To expose an HTTP endpoint, add a `server` property to a file route:
 
 ```typescript
@@ -185,7 +188,6 @@ export const Route = createFileRoute('/api/hello')({
   server: {
     handlers: {
       GET: async () => {
-        const dbUrl = process.env.DATABASE_URL; // server-only
         return Response.json({ message: 'Hello from Railway' });
       },
     },
@@ -193,34 +195,87 @@ export const Route = createFileRoute('/api/hello')({
 });
 ```
 
-Both server functions and server routes have access to all Railway [service variables](/variables). Only variables prefixed with `VITE_` are available in client-side code, since TanStack Start is built on Vite. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
+## Environment variables
+
+TanStack Start apps use two kinds of variables, and they behave differently on Railway.
+
+**Server variables** are read at runtime with `process.env` in server functions, server routes, and loaders. They are available on the next deploy after you change them, and they never reach the browser. Use them for secrets.
+
+**Client variables** must be prefixed with `VITE_`, are read with `import.meta.env.VITE_*`, and are baked into the JavaScript bundle when `npm run build` runs. Never put secrets in a `VITE_` variable, since anyone can read them in the shipped bundle.
+
+Set both kinds as [service variables](/variables) on your Railway service. Variables are available during the build and at runtime, so `VITE_` values are baked in correctly.
+
+Changing a `VITE_` variable takes effect on the next build. Updating a variable in the dashboard prompts a redeploy, and a redeploy of a Railpack-built service rebuilds it, so the new value is picked up. A plain container restart does not rebuild, so it keeps the old value. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
 
 ## Add a Postgres database
 
 1. In your Railway project, click **+ New**, then **Database**, then **PostgreSQL**.
-2. Add the connection string to your TanStack Start service:
+2. Add the connection string to your TanStack Start service as a [reference variable](/variables#reference-variables):
 
-```
+```plaintext
 DATABASE_URL=${{Postgres.DATABASE_URL}}
 ```
 
-Use an ORM like Prisma or Drizzle to query the database from server functions and loaders.
+This connects over Railway's [private network](/networking/private-networking), so it works at runtime with no extra configuration. Query the database from server functions and loaders with an ORM like Drizzle or Prisma:
+
+```typescript
+import { createServerFn } from '@tanstack/react-start';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { visits } from '../db/schema';
+
+export const recordVisit = createServerFn().handler(async () => {
+  const db = drizzle(process.env.DATABASE_URL!);
+  await db.insert(visits).values({});
+  const rows = await db.select().from(visits);
+  return { visitCount: rows.length };
+});
+```
+
+### Run migrations with a pre-deploy command
+
+Run schema migrations in a [pre-deploy command](/deployments/pre-deploy-command), which executes between the build and the deploy with access to your service variables and the private network:
+
+1. Navigate to your service **Settings** on Railway.
+2. In the **Deploy** section, set **Pre-deploy Command** to your ORM's migration command. For Drizzle:
+   ```bash
+   npx drizzle-kit migrate
+   ```
+
+Keep the migration tool in `dependencies` rather than `devDependencies` so it is present in the deployed image, and generate migration files locally (`npx drizzle-kit generate` for Drizzle) so the pre-deploy step only applies them. The deploy logs show the migration output, and a failed migration stops the deploy before your app starts.
+
+## Use Bun instead of Node
+
+Railpack detects a `bun.lock` file and switches the whole pipeline to Bun: it installs with `bun install`, builds with `bun run build`, and runs the production server with Bun. Scaffold with `npx @tanstack/cli@latest create my-app --package-manager bun` and deploy the same way as a Node app. No extra configuration is needed.
 
 ## Troubleshooting
 
-**The build succeeds, but the container exits right away or the domain returns a 502.**
-Your app most likely has no `start` script and no server runtime. See [Choose a production server](#choose-a-production-server).
+**The build succeeds, but the domain returns a 502 and the deployment flips to `CRASHED`.**
+Your app uses the `nitro()` plugin but has no `start` script, so Railway's srvx fallback looks for `dist/server/server.js` while Nitro built `.output/`. The runtime logs show srvx exiting with `ENOENT ... dist/server/server.js`. Add the `start` script from [Choose a production server](#choose-a-production-server). This is what the scaffolder's default `Nitro (agnostic)` deploy option produces, so freshly scaffolded apps hit it unless they picked `Railway`.
+
+**The app deploys as a static site, and every page 404s.**
+`@tanstack/react-start` is in `devDependencies`, so Railway's TanStack Start detection misses it and the build logs show `Deploying as vite static site`. Move it to `dependencies` and redeploy.
+
+**A `VITE_` variable is undefined in the browser, or shows a stale value.**
+Check the prefix first, since only `VITE_`-prefixed variables reach client code. If the variable is set and still shows an old value, it was baked in by an earlier build. Trigger a redeploy so the app rebuilds with the current value.
+
+**A deploy healthcheck fails even though the app starts cleanly.**
+Railway's [healthcheck](/deployments/healthchecks) requires an HTTP `200` response and does not follow redirects, so a healthcheck path that answers a `3xx` fails every deploy. Point it at a path that returns a `200` directly.
+
+**The build logs recommend setting up Nitro.**
+Your app has no server runtime, so Railway is serving the default Vite build with srvx. This works, but Nitro is the recommended production server. See [Choose a production server](#choose-a-production-server).
 
 **Pages render, but CSS and JavaScript assets 404.**
-Your server isn't serving the client build. With Nitro this is handled for you. Without it, check that the `-s` path in your srvx command points at the client output directory.
+Your server isn't serving the client build. With Nitro this is handled for you. Without it, check that a [custom start command](/deployments/start-command) points srvx's `-s` flag at the client output directory.
 
 **The deploy works but the app serves the dev server.**
 Never use `vite dev` as a production start command. It is not a production server, and it will not behave correctly behind Railway's edge. Build the app and run the built server instead.
 
-**A deploy healthcheck fails even though the app starts cleanly.**
-Railway's healthcheck does not follow redirects, so a healthcheck path that answers a 3xx fails every deploy. Point it at a path that returns a 200 directly, or remove the healthcheck.
+**A custom server entry or start command isn't detected.**
+Autodetection covers the standard layouts. If you run a custom server file, set a [custom start command](/deployments/start-command) in your service settings, or use a [Dockerfile](#use-a-dockerfile) for full control.
 
 ## Next steps
+
+Explore these resources to learn how you can maximize your experience with Railway:
 
 - [Manage environment variables](/guides/frontend-environment-variables) - Handle `VITE_` prefixed variables in TanStack Start.
 - [Choose between SSR, SSG, and ISR](/guides/ssr-ssg-isr) - Understand rendering strategies.

--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -1,7 +1,7 @@
 ---
 title: Deploy a TanStack Start App
-description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and Vinxi server configuration.
-date: "2026-04-14"
+description: Deploy a TanStack Start full-stack React application to Railway. Covers GitHub deploys, CLI deploys, Dockerfile setup, and choosing a production server.
+date: "2026-09-03"
 tags:
   - deployment
   - frontend
@@ -10,7 +10,9 @@ tags:
 topic: frameworks
 ---
 
-[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, SSR, and streaming out of the box. TanStack Start uses Vinxi as its server runtime, which builds on Nitro.
+[TanStack Start](https://tanstack.com/start) is a full-stack React framework built on TanStack Router. It provides file-based routing, server functions, server routes, SSR, and streaming out of the box. TanStack Start is a Vite plugin, so a TanStack Start app builds and deploys as a standard Node service on Railway.
+
+Railway is an [official TanStack Start hosting partner](https://tanstack.com/start/latest/docs/framework/react/guide/hosting), and the TanStack scaffolder ships a Railway option that configures your app to deploy here with no extra setup.
 
 This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
@@ -20,15 +22,15 @@ This guide covers how to deploy a TanStack Start app to Railway in three ways:
 
 ## Create a TanStack Start app
 
-**Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Deploy the TanStack Start app to Railway](#deploy-the-tanstack-start-app-to-railway).
+**Note:** If you already have a TanStack Start app locally or on GitHub, skip to [Choose a production server](#choose-a-production-server).
 
 Ensure [Node](https://nodejs.org/en/download) is installed, then create a new project:
 
 ```bash
-npx @tanstack/create-start@latest my-app
+npx @tanstack/cli@latest create
 ```
 
-Follow the prompts to choose your preferred options.
+Follow the prompts to choose your preferred options. When you reach the deployment options, **select `railway`**. This adds a Nitro server, a `start` script, and everything else Railway needs to build and run your app — see [Choose a production server](#choose-a-production-server) below for what it does and why it matters.
 
 ### Run the app locally
 
@@ -40,9 +42,52 @@ npm run dev
 
 Open `http://localhost:3000` to see your app.
 
+## Choose a production server
+
+This is the one decision that determines whether your deploy works, so it is worth understanding before you push.
+
+`vite build` compiles your app, but it does not produce a server that runs on its own. TanStack Start needs a server runtime on top of the build, and which one you use changes both the build output path and the command that starts it:
+
+| Setup | Build output | Start command |
+| --- | --- | --- |
+| **Nitro** (recommended) | `.output/server/index.mjs` | `node .output/server/index.mjs` |
+| No server runtime | `dist/server/server.js` + `dist/client/` | `srvx --prod -s ../client dist/server/server.js` |
+
+**Use Nitro.** It is what the Railway option in the scaffolder sets up, and it is the configuration this guide documents from here on.
+
+If you picked `railway` when scaffolding, you already have it and there is nothing to do. To add it to an existing app, install Nitro and register its Vite plugin:
+
+```bash
+npm install nitro
+```
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { nitro } from 'nitro/vite';
+import { tanstackStart } from '@tanstack/react-start/plugin/vite';
+import viteReact from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [nitro(), tanstackStart(), viteReact()],
+});
+```
+
+Then add a `start` script, which Railway uses to run your app:
+
+```json
+{
+  "scripts": {
+    "start": "node .output/server/index.mjs"
+  }
+}
+```
+
+That `start` script matters more than it looks. A freshly scaffolded TanStack Start app has **no `start` script at all** unless you add one or pick a deployment option that adds it for you. Without one, Railway has no obvious way to run your app after the build — it will fall back to serving the build with [`srvx`](https://srvx.h3.dev), which works but is not what most production apps want. If your build succeeds and the container exits immediately or serves a 502, a missing `start` script is the first thing to check.
+
 ## Deploy the TanStack Start app to Railway
 
-TanStack Start builds a Node.js server that handles SSR, server functions, and static asset serving. It deploys as a standard Node service on Railway.
+TanStack Start builds a Node.js server that handles SSR, server functions, server routes, and static asset serving. It deploys as a standard Node service on Railway.
 
 ### Deploy from the CLI
 
@@ -84,7 +129,7 @@ TanStack Start builds a Node.js server that handles SSR, server functions, and s
 
 ### Use a Dockerfile
 
-If Railpack does not detect the start command correctly, use a Dockerfile:
+If you'd rather control the build yourself, use a Dockerfile. This one assumes [Nitro](#choose-a-production-server), which builds to `.output`:
 
 ```dockerfile
 FROM node:lts-alpine AS build
@@ -99,54 +144,56 @@ FROM node:lts-alpine
 
 WORKDIR /app
 COPY --from=build /app/.output ./.output
-COPY --from=build /app/package*.json ./
 
 EXPOSE 3000
 CMD ["node", ".output/server/index.mjs"]
 ```
 
-TanStack Start (via Vinxi/Nitro) builds into a `.output` directory. The server entry point is `.output/server/index.mjs`.
+The Nitro build bundles its own dependencies into `.output`, so the runtime stage does not need `node_modules` or your `package.json`.
 
 Deploy via the CLI or from GitHub. Railway automatically detects the `Dockerfile` and [uses it to build and deploy the app](/builds/dockerfiles).
 
 ## Port configuration
 
-TanStack Start's Vinxi server listens on port 3000 by default. To make it respect Railway's `PORT` variable, check your `app.config.ts`:
+You don't need any. Both Nitro and srvx read the `PORT` environment variable that Railway sets, and both bind all interfaces by default, so your app is reachable as soon as it starts.
 
-```typescript
-// app.config.ts
-import { defineConfig } from '@tanstack/react-start/config';
-
-export default defineConfig({
-  server: {
-    port: Number(process.env.PORT) || 3000,
-  },
-});
-```
-
-If the server does not bind to the correct port, set a [custom start command](/deployments/start-command):
-
-```bash
-PORT=$PORT node .output/server/index.mjs
-```
+If you have an older app with an `app.config.ts` that sets a port, you can delete that file. It was part of the Vinxi-based setup that TanStack Start no longer uses, and it has no effect on current versions.
 
 ## Server functions
 
-TanStack Start server functions run on the Node.js server, not in the browser. They can access environment variables, databases, and other server-side resources:
+Server functions run on the server, never in the browser. Use them to reach environment variables, databases, and other server-side resources from your loaders and components:
 
 ```typescript
-// app/routes/api/hello.ts
-import { createAPIFileRoute } from '@tanstack/react-start/api';
+// src/fns.ts
+import { createServerFn } from '@tanstack/react-start';
 
-export const Route = createAPIFileRoute('/api/hello')({
-  GET: async () => {
-    const dbUrl = process.env.DATABASE_URL; // server-only
-    return Response.json({ message: 'Hello from Railway' });
+export const getMessage = createServerFn().handler(async () => {
+  const dbUrl = process.env.DATABASE_URL; // server-only
+  return { message: 'Hello from Railway' };
+});
+```
+
+## Server routes
+
+To expose an HTTP endpoint, add a `server` property to a file route:
+
+```typescript
+// src/routes/api.hello.ts
+import { createFileRoute } from '@tanstack/react-router';
+
+export const Route = createFileRoute('/api/hello')({
+  server: {
+    handlers: {
+      GET: async () => {
+        const dbUrl = process.env.DATABASE_URL; // server-only
+        return Response.json({ message: 'Hello from Railway' });
+      },
+    },
   },
 });
 ```
 
-Server functions have access to all Railway [service variables](/variables). Only variables with the `VITE_` prefix are available in client-side code, since TanStack Start uses Vite. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
+Both server functions and server routes have access to all Railway [service variables](/variables). Only variables prefixed with `VITE_` are available in client-side code, since TanStack Start is built on Vite. See [Manage environment variables in frontend builds](/guides/frontend-environment-variables) for details.
 
 ## Add a Postgres database
 
@@ -158,6 +205,20 @@ DATABASE_URL=${{Postgres.DATABASE_URL}}
 ```
 
 Use an ORM like Prisma or Drizzle to query the database from server functions and loaders.
+
+## Troubleshooting
+
+**The build succeeds, but the container exits right away or the domain returns a 502.**
+Your app most likely has no `start` script and no server runtime. See [Choose a production server](#choose-a-production-server).
+
+**Pages render, but CSS and JavaScript assets 404.**
+Your server isn't serving the client build. With Nitro this is handled for you. Without it, check that the `-s` path in your srvx command points at the client output directory.
+
+**The deploy works but the app serves the dev server.**
+Never use `vite dev` as a production start command. It is not a production server, and it will not behave correctly behind Railway's edge. Build the app and run the built server instead.
+
+**A deploy healthcheck fails even though the app starts cleanly.**
+Railway's healthcheck does not follow redirects, so a healthcheck path that answers a 3xx fails every deploy. Point it at a path that returns a 200 directly, or remove the healthcheck.
 
 ## Next steps
 


### PR DESCRIPTION
Builds directly on @sarahkb125's refresh in #1331 (her commit is the base of this branch) and extends it with Railway-deploy-validated coverage. Every command and technical claim was verified by actually running it: three scaffolds (default, `--deployment railway`, Bun), real Railway deploys of each, env-var behavior tests against live services, a Drizzle pre-deploy migration against a Railway Postgres, and a local Docker build/run of the published Dockerfile.

On top of the #1331 refresh, this adds:
- **Environment variables**: server vars are runtime `process.env`; `VITE_` vars bake at build; a redeploy rebuilds a Railpack service so changed `VITE_` values apply (verified v1→v2 on live deploys).
- **Database migrations**: `DATABASE_URL` reference variable over private networking, Drizzle from a server function, and `npx drizzle-kit migrate` as a pre-deploy command (ran between build and deploy, applied migrations, logged success).
- **Bun**: `bun.lock` switches the whole Railpack pipeline; deployed and serving.
- **CLI domain generation** (`railway domain`) in the deploy steps.

And deploy-tested corrections:
- The srvx fallback serves the no-nitro layout correctly (deployed, SSR responds), but **nitro without a `start` script crashes**: srvx targets `dist/` while Nitro builds `.output/`, so the container exits with `ENOENT`, the domain 502s, and the deployment flips to `CRASHED`. That combination is what the scaffolder's default `Nitro (agnostic)` deploy option produces, so the guide warns about that prompt choice by name.
- `@tanstack/react-start` in `devDependencies` makes detection miss: the app deploys as `vite static site` and 404s (new troubleshooting entry).
- The healthcheck-3xx troubleshooting entry from #1331 verified correct (a 302 healthcheck path failed the deploy) and kept.

Supersedes #1331/#1333 if merged; a Railpack fix for the nitro-without-start-script crash is drafted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)