### PR TITLE
docs: Dockerfile ARG note, healthcheck 2xx accuracy, IaC preDeploy

### DIFF
--- a/content/docs/deployments/healthchecks.md
+++ b/content/docs/deployments/healthchecks.md
@@ -7,7 +7,7 @@ Healthchecks can be used to guarantee zero-downtime [deployments](/deployments/r
 
 ## How it works
 
-When a new deployment is triggered for a service, if a healthcheck endpoint is configured, Railway will query the endpoint until it receives an HTTP `200` response. Only then will the new deployment be made active and the previous deployment inactive.
+When a new deployment is triggered for a service, if a healthcheck endpoint is configured, Railway will query the endpoint until it receives a successful response (any `2xx` status code). Only then will the new deployment be made active and the previous deployment inactive.
 
 **Note:** Railway does not monitor the healthcheck endpoint after the deployment has gone live.
 
@@ -15,9 +15,9 @@ When a new deployment is triggered for a service, if a healthcheck endpoint is c
 
 To configure a healthcheck:
 
-1. Ensure your webserver has an endpoint (e.g. `/health`) that will return an HTTP status code of 200 when the application is live and ready.
+1. Ensure your webserver has an endpoint (for example, `/health`) that returns a `2xx` status code when the application is live and ready.
 
-2. Under your service settings, input your health endpoint. Railway will wait for this endpoint to serve a `200` status code before switching traffic to your new endpoint.
+2. Under your service settings, input your health endpoint. Railway will wait for this endpoint to serve a `2xx` status code before switching traffic to your new endpoint.
 
 ## Configure the healthcheck port
 
@@ -37,7 +37,7 @@ Not listening on the `PORT` variable or omitting it when using target ports can 
 
 ## Healthcheck timeout
 
-The default timeout on healthchecks is 300 seconds (5 minutes). If your application fails to serve a `200` status code during this allotted time, the deploy will be marked as failed.
+The default timeout on healthchecks is 300 seconds (5 minutes). If your application fails to serve a `2xx` status code during this allotted time, the deploy will be marked as failed.
 
 <Image 
 src="https://res.cloudinary.com/railway/image/upload/v1664564544/docs/healthcheck-timeout_lozkiv.png"

--- a/content/docs/infrastructure-as-code/reference.md
+++ b/content/docs/infrastructure-as-code/reference.md
@@ -135,6 +135,21 @@ const api = service("api", {
 });
 ```
 
+### Pre-deploy command
+
+Run a command, such as a database migration, between the build and the deploy:
+
+```ts
+const web = service("web", {
+  start: "node .output/server/index.mjs",
+  preDeploy: "npx drizzle-kit migrate",
+});
+```
+
+The command runs with access to your service variables and the private network, and a failing command stops the deployment. See [Pre-deploy command](/deployments/pre-deploy-command) for the runtime behavior.
+
+`railway config pull` renders this field as `deploy: { preDeployCommand: ["..."] }`, which is equivalent.
+
 ### Replicas
 
 Use `replicas` for scaling intent:

--- a/content/guides/tanstack-start.md
+++ b/content/guides/tanstack-start.md
@@ -157,6 +157,8 @@ CMD ["node", ".output/server/index.mjs"]
 
 The Nitro build bundles its own dependencies into `.output`, so the runtime stage does not need `node_modules` or your `package.json`.
 
+**Note:** With a Dockerfile, service variables aren't available during the build unless you [declare them as build arguments](/builds/dockerfiles#using-variables-at-build-time). To bake a `VITE_` variable into the client bundle, add `ARG VITE_MY_VAR` to the build stage before `RUN npm run build`. Committing a Dockerfile also switches your service to the Dockerfile builder on the next deploy, even if it previously built with Railpack.
+
 Deploy via the CLI or from GitHub. Railway automatically detects the `Dockerfile` and [uses it to build and deploy the app](/builds/dockerfiles).
 
 ## Port configuration


### PR DESCRIPTION
Three small accuracy fixes, each verified against real behavior:

- **TanStack guide, Dockerfile section:** service variables don't reach Dockerfile builds unless declared with `ARG`, so `VITE_` values silently vanish — plus a warning that committing a Dockerfile switches the service off Railpack on the next deploy. Both behaviors observed on live deploys (this exact combination cost us an afternoon chasing a phantom platform bug).
- **Healthchecks doc:** the probe accepts any `2xx` response, not exactly `200` (`stacker/gateways/workload_healthcheck/main.go` grades `>= 200 && < 300`). The doc said `200` in four places.
- **IaC reference:** documents the `preDeploy` service field, which already works end to end but appears nowhere in the docs. Verified today with a real `railway config apply`: `preDeploy: "node migrate.js"` landed as `serviceInstance.preDeployCommand`. Includes a note that `config pull` currently renders it in the raw `deploy:` block (a CLI fix for first-class rendering is in flight separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)