### PR TITLE
docs(databases): say what Regenerate does and does not cover

### DIFF
--- a/content/docs/databases/database-view.md
+++ b/content/docs/databases/database-view.md
@@ -78,6 +78,15 @@ The Connection section shows the username and password for the database, and all
 
 Regenerating breaks existing connections until they use the new password, so it's important to manually redeploy any service that depends on the updated password variable (or the derived database URL).
 
+Regenerate is the supported way to change a database password. Use it instead of the two manual routes, which change only one side each:
+
+- Editing the password variable does not change the password inside the database. A database keeps its credentials in its data directory, and only reads the variable when it initializes an empty one — so a running database with a volume ignores the edit, and every redeploy after it keeps ignoring it.
+- Running `ALTER USER` (or its equivalent) against the database does not change the variable, so Railway and everything reading the variable keep presenting the old password.
+
+Either one on its own leaves the database and the variable out of sync, and every connection fails with an authentication error — from your app, the CLI, and this Data tab alike.
+
+<Banner variant="info">If you have already changed one side, set the variable back to the password the database actually holds and redeploy the services that use it. Both sides match again, and Regenerate works from there.</Banner>
+
 <Image src="/images/database-config-connection.png"
 alt="Screenshot of the Connection section in the database Config tab"
 layout="intrinsic"


### PR DESCRIPTION
## Why

The Connection section describes password regeneration as the control that keeps the database and the environment variables synchronized — accurate, but the page never says what happens when they have **already** diverged. That gap is what customers hit.

Regeneration authenticates to the database with the password currently in the service's variables. Once a manual `ALTER USER` or a variable edit has moved one side, the login it needs is refused and the control cannot run.

Two Central Station clusters are people in exactly that state:

| cluster | threads |
|---|---|
| [MySQL Root Password Desync](https://admin.station.railway.com/clusters/clst_01khydzpp5fq9a6cwrc5g7e9e1) | 10 |
| [Postgres Password Desync](https://admin.station.railway.com/clusters/clst_01khnk4vt3e4arcdhncww1gmdm) | 34 |

They change one side by hand, read this page, and find no way back. One thread's subject is literally *"Postgres role password out of sync — cannot authenticate, Config tab won't load"*.

## What changed

Adds to **Databases → Database view → Config tab → Connection**:

- The two manual routes and what each one leaves untouched — a variable edit never reaches the database (it only reads the variable when initializing an empty data directory, so a running database with a volume ignores it, and so does every redeploy after), and `ALTER USER` never reaches the variable.
- That either one alone breaks every connection: the app, the CLI, and the Data tab alike.
- The way back: set the variable to the password the database actually holds, redeploy the services that use it, and Regenerate works from there.

No existing sentence was removed — this is additive.
