### PR TITLE
fix(storage-buckets): correct the S3 API endpoint

### DIFF
--- a/content/docs/cli/bucket.md
+++ b/content/docs/cli/bucket.md
@@ -212,7 +212,7 @@ railway bucket credentials --reset --yes
 Default output:
 
 ```plaintext
-AWS_ENDPOINT_URL=https://storage.railway.app
+AWS_ENDPOINT_URL=https://t3.storageapi.dev
 AWS_ACCESS_KEY_ID=your-access-key
 AWS_SECRET_ACCESS_KEY=your-secret-key
 AWS_S3_BUCKET_NAME=my-bucket-abc123
@@ -232,7 +232,7 @@ With `--json` (both with and without `--reset`):
 
 ```json
 {
-  "endpoint": "https://storage.railway.app",
+  "endpoint": "https://t3.storageapi.dev",
   "accessKeyId": "your-access-key",
   "secretAccessKey": "your-secret-key",
   "bucketName": "my-bucket-abc123",

--- a/content/docs/storage-buckets.md
+++ b/content/docs/storage-buckets.md
@@ -36,7 +36,7 @@ width={2554} height={1970} quality={80} />
 ### URL style
 
 
-Railway Buckets use <a target="_blank" href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted–style-access">virtual-hosted–style URLs</a>, where the bucket name appears as the subdomain of the S3 endpoint. This is the standard S3 URL format, and most libraries support it out of the box. In most cases you only need to provide the base endpoint (`https://storage.railway.app`) and the client builds the full virtual-hosted URL automatically.
+Railway Buckets use <a target="_blank" href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#virtual-hosted–style-access">virtual-hosted–style URLs</a>, where the bucket name appears as the subdomain of the S3 endpoint. This is the standard S3 URL format, and most libraries support it out of the box. In most cases you only need to provide the base endpoint shown in your bucket's Credentials tab (`https://t3.storageapi.dev`) and the client builds the full virtual-hosted URL automatically.
 
 Buckets that were created before this change might require you to use <a target="_blank" href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html#path-style-access">path-style URLs</a> instead. The Credentials tab of your bucket will tell you which style you should use.
 
@@ -68,7 +68,7 @@ Railway provides the following variables which can be used as [Variable Referenc
 | `SECRET_ACCESS_KEY`        | The secret key for the S3 API.                                                                   |
 | `ACCESS_KEY_ID`            | The key id for the S3 API.                                                                       |
 | `REGION`                   | The region for the S3 API. Example: `auto`                                                       |
-| `ENDPOINT`                 | The S3 API endpoint. Example: `https://storage.railway.app`                                      |
+| `ENDPOINT`                 | The S3 API endpoint. Example: `https://t3.storageapi.dev`                                        |
 | `RAILWAY_PROJECT_NAME`     | The project name the bucket belongs to.                                                          |
 | `RAILWAY_PROJECT_ID`       | The project id the bucket belongs to.                                                            |
 | `RAILWAY_ENVIRONMENT_NAME` | The environment name of the bucket instance.                                                     |

--- a/content/docs/storage-buckets/uploading-serving.md
+++ b/content/docs/storage-buckets/uploading-serving.md
@@ -118,7 +118,7 @@ AWS_ACCESS_KEY_ID=your_access_key_id \
 AWS_SECRET_ACCESS_KEY=your_secret_access_key \
   aws s3api put-bucket-cors \
   --bucket your_bucket_name \
-  --endpoint-url https://storage.railway.app \
+  --endpoint-url https://t3.storageapi.dev \
   --cors-configuration '{
     "CORSRules": [
       {


### PR DESCRIPTION
## Summary

The docs give `https://storage.railway.app` as the S3 API endpoint for Railway Buckets in five places. That is not the value Buckets issue. A bucket's Credentials tab and `railway bucket credentials` both return `https://t3.storageapi.dev`.

The two CLI samples are the most misleading, since they are presented as literal program output for a command that prints something else.

## Changes

- `storage-buckets.md` — the URL style paragraph and the `ENDPOINT` variable row. The paragraph now points at the bucket's Credentials tab as the source of truth, since the endpoint is per-bucket rather than universal.
- `cli/bucket.md` — the default and `--json` sample output for `railway bucket credentials`.
- `storage-buckets/uploading-serving.md` — the `--endpoint-url` flag in the `aws s3api put-bucket-cors` example, which is copy-pasteable and fails as written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)