### PR TITLE
docs(ssh): document scp, sftp, and port forwarding

### DIFF
--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -108,6 +108,23 @@ Transfers reach the running container's filesystem, including any mounted
 volume. For volume files specifically, [`railway volume browse`](/cli/volume)
 gives you an interactive browser without setting up SSH.
 
+## Forward a port with ssh -L
+
+Railway SSH supports local port forwarding, so you can open an SSH tunnel from
+your own machine to a port inside your container.
+
+```bash
+ssh -N -L 8080:127.0.0.1:8080 myapp.up.railway.app@ssh.railway.com
+```
+
+The connection is dialed from inside the container, so `127.0.0.1` is the
+container's own loopback. `-N` skips the shell, so the command does nothing but
+hold the tunnel open. Keep the session running while you use the tunnel.
+
+Forwarding is limited to the container's loopback and your project's private
+network. Public destinations are refused, so an SSH tunnel can't be used as a
+general internet proxy.
+
 ## Manage SSH config
 
 Use the `config` subcommand to add, preview, or remove a Railway OpenSSH config

--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -72,11 +72,30 @@ railway ssh -i ~/.ssh/railway_ed25519
 
 When set, the CLI skips its local `~/.ssh` scan and forwards the key directly to `ssh`.
 
+## Connect to a service without a public domain
+
+The SSH username is the service's domain, so a service that has no domain needs
+a different target. Use its service instance ID instead.
+
+1. Open the service in the dashboard.
+2. Open the **command palette** with `CMD + K` (Mac) or `Ctrl + K` (Windows).
+3. Choose **Copy Service Instance ID**.
+
+That ID works as the username anywhere a domain does:
+
+```bash
+ssh <service-instance-id>@ssh.railway.com
+scp <service-instance-id>@ssh.railway.com:/app/data.json ./data.json
+```
+
+The palette also offers **Copy Service ID**, which is a different value and is
+not a valid SSH target.
+
 ## Copy files with scp and sftp
 
 Railway SSH supports the SFTP subsystem, so your system `scp` and `sftp` clients
 work against `ssh.railway.com` using the same registered key. Use the service's
-domain as the username.
+domain as the username, or its service instance ID if it has no domain.
 
 ```bash
 # Copy a file out of the container

--- a/content/docs/cli/ssh.md
+++ b/content/docs/cli/ssh.md
@@ -72,6 +72,42 @@ railway ssh -i ~/.ssh/railway_ed25519
 
 When set, the CLI skips its local `~/.ssh` scan and forwards the key directly to `ssh`.
 
+## Copy files with scp and sftp
+
+Railway SSH supports the SFTP subsystem, so your system `scp` and `sftp` clients
+work against `ssh.railway.com` using the same registered key. Use the service's
+domain as the username.
+
+```bash
+# Copy a file out of the container
+scp myapp.up.railway.app@ssh.railway.com:/app/data.json ./data.json
+
+# Copy a file into the container
+scp ./data.json myapp.up.railway.app@ssh.railway.com:/app/data.json
+
+# Copy a directory
+scp -r myapp.up.railway.app@ssh.railway.com:/app/logs ./logs
+
+# Open an interactive SFTP session
+sftp myapp.up.railway.app@ssh.railway.com
+```
+
+A deployment instance ID works as the username too, in place of the domain.
+
+`scp` uses the SFTP protocol on OpenSSH 9.0 and newer. On older clients, pass
+`-s` to select it.
+
+If you added a host alias with [`railway ssh config`](#manage-ssh-config), use
+the alias instead:
+
+```bash
+scp railway-api:/app/data.json ./data.json
+```
+
+Transfers reach the running container's filesystem, including any mounted
+volume. For volume files specifically, [`railway volume browse`](/cli/volume)
+gives you an interactive browser without setting up SSH.
+
 ## Manage SSH config
 
 Use the `config` subcommand to add, preview, or remove a Railway OpenSSH config

--- a/content/docs/volumes/reference.md
+++ b/content/docs/volumes/reference.md
@@ -70,13 +70,12 @@ Here are some limitations of which we are currently aware:
 
 - Each service can only have a single volume
 - Replicas cannot be used with volumes
-- There is no built-in S/FTP support
 - To prevent data corruption, we prevent multiple deployments from being active
   and mounted to the same service. This means that there will be a small amount
   of downtime when re-deploying a service that has a volume attached, even if there is a healthcheck endpoint configured
 - Down-sizing a volume is not currently supported, but increasing size is supported
 - Volume resizing is performed live without downtime. The underlying storage is expanded while your service continues running, and the filesystem automatically extends to utilize the additional space. In certain scenarios, such as when a volume reaches 100% capacity, an offline resize is automatically performed instead to run data integrity checks, which will restart your service
-- Volume files can be managed from the CLI with `railway volume browse` or `railway volume files`
+- Volume files can be managed from the CLI with `railway volume browse` or `railway volume files`, and over `sftp` or `scp` through a service the volume is attached to (see [railway ssh](/cli/ssh))
 - Docker images that run as a non-root UID by default will have permissions issues when performing operations within an attached volume. If you are affected by this, you can set `RAILWAY_RUN_UID=0` environment variable in your service.
 
 ## Support


### PR DESCRIPTION
## Summary

- Adds a **Connect to a service without a public domain** section: copy the service instance ID from the command palette and use it as the SSH username.
- Adds a **Copy files with scp and sftp** section, covering the `ssh.railway.com` target format, directory copies, the OpenSSH 9.0 protocol default, and using a `railway ssh config` host alias.
- Adds a **Forward a port with ssh -L** section for opening an SSH tunnel to a container port, noting that forwarding is limited to loopback and the private network.
- Removes the "There is no built-in S/FTP support" caveat from the volumes reference, and notes on the CLI bullet that volume files are also reachable over `sftp`/`scp` through a service the volume is attached to.

## Context

Railway SSH accepts the SFTP subsystem and direct-tcpip channels, so `scp`, `sftp`, and `ssh -L` already work with a registered SSH key, and a service instance ID is a valid target for a service with no domain. None of it was documented, and the volumes page said the opposite about SFTP. That gap sends people to workarounds (or to support) for things the platform does today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)