### PR TITLE
docs(conductors): add Claude Max 20x to program benefits

### DIFF
--- a/content/docs/community/the-conductor-program.md
+++ b/content/docs/community/the-conductor-program.md
@@ -51,6 +51,8 @@ As part of the program, conductors will receive -
 
 - 100% off discount for the Pro plan's subscription and resource costs.
 
+- A Claude Max 20x subscription, covered by Railway.
+
 - Cash payouts for solving complex issues for users.
 
 - The opportunity to earn payouts for OSS contributions ([CLI](https://github.com/railwayapp/cli), [Railpack](https://github.com/railwayapp/railpack), [Docs](https://github.com/railwayapp/docs), etc).


### PR DESCRIPTION
## Summary

Adds a Claude Max 20x subscription to the Conductor benefits list on the Conductor Program page.

## Context

Conductors now get a Claude Max 20x subscription covered by Railway. The benefits list was missing it, so applicants and current Conductors had no way to see the perk from the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)