### PR TITLE
docs: cover sandbox domains and infinite idle lifetime

### DIFF
--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -192,6 +192,7 @@ railway sandbox destroy sbx_abc123
 | `--template <NAME_OR_ID>` | Create from a built template, by local name or template ID. Can't be combined with `--checkpoint`. See [Templates](#templates) |
 | `--checkpoint <NAME>` | Create from a named checkpoint. Can't be combined with `--template`. See [Checkpoints](#checkpoints) |
 | `--private-network` | Join the environment's private network instead of the default isolated mode |
+| `--domain [PREFIX:]PORT` | Publish an HTTP domain on a port, with an optional prefix. Repeatable. Requires `--private-network`. See [Public domains](#public-domains) |
 | `--json` | Output the created sandbox as JSON |
 
 ## Options for `fork`
@@ -204,6 +205,7 @@ railway sandbox destroy sbx_abc123
 | `--variable <KEY=VALUE>` | Set a variable on the fork. Repeatable and comma-separable. The fork doesn't inherit the source's variables |
 | `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
 | `--private-network` | Join the environment's private network. The fork doesn't inherit the source's network mode |
+| `--domain [PREFIX:]PORT` | Publish an HTTP domain on a port, with an optional prefix. Repeatable. Requires `--private-network`. See [Public domains](#public-domains) |
 | `--json` | Output the created sandbox as JSON |
 
 The source sandbox must be running. The fork clones its filesystem into a new sandbox in the same environment and boots fresh, so files are preserved but running processes are not.
@@ -390,7 +392,39 @@ By default a sandbox is isolated: it has outbound internet access but can't reac
 
 ## Public domains
 
-Use the [TypeScript SDK or GraphQL API](/sandboxes#public-domains) to publish a sandbox's HTTP servers on Railway-provided HTTPS domains. The CLI has no sandbox domain creation flag. `--private-network` enables private networking but doesn't publish a public domain by itself.
+Pass `--domain [PREFIX:]PORT` when creating a sandbox to publish an HTTP server on a Railway-provided HTTPS domain. Domains require `--private-network`; that flag alone doesn't publish a domain.
+
+```bash
+railway sandbox create --private-network --domain app:8080
+railway sandbox list
+```
+
+Start your HTTP server in the sandbox, listening on `0.0.0.0` and the requested port. Publishing a domain doesn't start a server. Railway generates the hostname and handles HTTPS.
+
+Omit the prefix to generate one from the project name. Repeat the flag to publish multiple ports:
+
+```bash
+railway sandbox create --private-network --domain 8080 --domain api:3000
+```
+
+You can request up to 10 domains. Each port and explicit prefix must be unique. Ports range from 1 to 65535. Explicit prefixes contain 1 to 46 lowercase letters, digits, or hyphens, with no leading or trailing hyphen.
+
+Creation can return `CREATING` while routes are still publishing. The command prints available URLs or a publishing message. Run `railway sandbox list` to see the URLs once ready. The `--json` output of `create`, `fork`, and `list` includes `domains` entries with `prefix`, `port`, and `domain` fields; the array can be empty until routes are published.
+
+Domains are configured only at creation. The flag also works with `create --template` and `create --checkpoint`. Forks don't inherit source domains; request routes for the fork explicitly:
+
+```bash
+railway sandbox fork --private-network --domain preview:8080
+```
+
+For a public server that must not idle out, also disable the idle timeout on Hobby or Pro:
+
+```bash
+railway sandbox create \
+  --private-network --domain app:8080 --idle-timeout-minutes 0
+```
+
+The sandbox consumes billable resources until you destroy it with `railway sandbox destroy`, which also removes its routes. See [Public domains](/sandboxes#public-domains) for SDK and API usage.
 
 To reach a sandbox's port from your own machine, use [`railway sandbox forward`](#forward-a-port-into-the-active-sandbox).
 

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -54,6 +54,18 @@ railway sandbox create --idle-timeout-minutes 30
 
 Railway auto-destroys the sandbox after it sits [idle](/sandboxes#idle-timeout) for the given number of minutes. The default and allowed range depend on your plan, so see [Idle timeout](/sandboxes#idle-timeout) for the per-plan values.
 
+### Create a sandbox without an idle timeout
+
+On Hobby and Pro, pass `0` to disable idle destruction:
+
+```bash
+railway sandbox create --idle-timeout-minutes 0
+```
+
+The sandbox continues consuming billable resources until you destroy it with `railway sandbox destroy`. Trial and Free plans reject this option. Omit the flag to use your plan's default timeout.
+
+`fork` also accepts `--idle-timeout-minutes 0`. A fork doesn't inherit the source's idle timeout, so pass the flag again to keep it from idling out. See [Disable the idle timeout](/sandboxes#disable-the-idle-timeout) for the SDK and API behavior.
+
 ### Create a sandbox on the private network
 
 ```bash
@@ -174,7 +186,7 @@ railway sandbox destroy sbx_abc123
 
 | Flag | Description |
 |------|-------------|
-| `--idle-timeout-minutes <N>` | Minutes the sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed. The default and range depend on your plan |
+| `--idle-timeout-minutes <N>` | Minutes the sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed. `0` disables idle destruction on Hobby and Pro. Omit for the plan default |
 | `--variable <KEY=VALUE>` | Set a variable on the sandbox. Repeatable and comma-separable. See [Variables](#variables) |
 | `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
 | `--template <NAME_OR_ID>` | Create from a built template, by local name or template ID. Can't be combined with `--checkpoint`. See [Templates](#templates) |
@@ -188,7 +200,7 @@ railway sandbox destroy sbx_abc123
 |------------------|-------------|
 | `[ID]` | Source sandbox ID to fork. Defaults to the active sandbox |
 | `--id <ID>` | Source sandbox ID, as an alternative to the positional argument |
-| `--idle-timeout-minutes <N>` | Minutes the new sandbox can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed. The default and range depend on your plan |
+| `--idle-timeout-minutes <N>` | Minutes the fork can sit [idle](/sandboxes#idle-timeout) before it is auto-destroyed. `0` disables idle destruction on Hobby and Pro. Omit for the plan default, not the source's setting |
 | `--variable <KEY=VALUE>` | Set a variable on the fork. Repeatable and comma-separable. The fork doesn't inherit the source's variables |
 | `--env-file <PATH>` | Load variables from a `.env` file. Repeatable. `--variable` overrides matching keys |
 | `--private-network` | Join the environment's private network. The fork doesn't inherit the source's network mode |
@@ -375,6 +387,12 @@ Resolving a reference to a service's internal address requires the private netwo
 ## Private networking
 
 By default a sandbox is isolated: it has outbound internet access but can't reach other services in your environment over private networking. Pass `--private-network` to `create` or `fork` to place the sandbox on the environment's private network, so it can reach services like `postgres.railway.internal` and they can reach it. See [Networking](/sandboxes#networking) for the full description of both modes.
+
+## Public domains
+
+Use the [TypeScript SDK or GraphQL API](/sandboxes#public-domains) to publish a sandbox's HTTP servers on Railway-provided HTTPS domains. The CLI has no sandbox domain creation flag. `--private-network` enables private networking but doesn't publish a public domain by itself.
+
+To reach a sandbox's port from your own machine, use [`railway sandbox forward`](#forward-a-port-into-the-active-sandbox).
 
 ## Common options
 

--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -62,9 +62,7 @@ On Hobby and Pro, pass `0` to disable idle destruction:
 railway sandbox create --idle-timeout-minutes 0
 ```
 
-The sandbox continues consuming billable resources until you destroy it with `railway sandbox destroy`. Trial and Free plans reject this option. Omit the flag to use your plan's default timeout.
-
-`fork` also accepts `--idle-timeout-minutes 0`. A fork doesn't inherit the source's idle timeout, so pass the flag again to keep it from idling out. See [Disable the idle timeout](/sandboxes#disable-the-idle-timeout) for the SDK and API behavior.
+The sandbox remains billable until you run `railway sandbox destroy`. Pass `0` again when forking; forks don't inherit the source's timeout. See [Idle timeout](/sandboxes#idle-timeout) for plan defaults and limits.
 
 ### Create a sandbox on the private network
 
@@ -392,41 +390,18 @@ By default a sandbox is isolated: it has outbound internet access but can't reac
 
 ## Public domains
 
-Pass `--domain [PREFIX:]PORT` when creating a sandbox to publish an HTTP server on a Railway-provided HTTPS domain. Domains require `--private-network`; that flag alone doesn't publish a domain.
-
-```bash
-railway sandbox create --private-network --domain app:8080
-railway sandbox list
-```
-
-Start your HTTP server in the sandbox, listening on `0.0.0.0` and the requested port. Publishing a domain doesn't start a server. Railway generates the hostname and handles HTTPS.
-
-Omit the prefix to generate one from the project name. Repeat the flag to publish multiple ports:
+Pass `--domain [PREFIX:]PORT` with `--private-network` to publish an HTTP server on a Railway-provided HTTPS domain. Omit the prefix to generate one from the project name, or repeat the flag for multiple ports:
 
 ```bash
 railway sandbox create --private-network --domain 8080 --domain api:3000
+railway sandbox list
 ```
 
-You can request up to 10 domains. Each port and explicit prefix must be unique. Ports range from 1 to 65535. Explicit prefixes contain 1 to 46 lowercase letters, digits, or hyphens, with no leading or trailing hyphen.
+Start your server on `0.0.0.0` and the requested port. Creation can return before routes are published; `list` shows the URLs once ready. With `--json`, `create`, `fork`, and `list` include `domains` entries with `prefix`, `port`, and `domain` fields.
 
-Creation can return `CREATING` while routes are still publishing. The command prints available URLs or a publishing message. Run `railway sandbox list` to see the URLs once ready. The `--json` output of `create`, `fork`, and `list` includes `domains` entries with `prefix`, `port`, and `domain` fields; the array can be empty until routes are published.
+The flag also works with `create --template`, `create --checkpoint`, and `fork`. Domains can't be changed after creation, and forks don't inherit them, so pass `--domain` and `--private-network` again.
 
-Domains are configured only at creation. The flag also works with `create --template` and `create --checkpoint`. Forks don't inherit source domains; request routes for the fork explicitly:
-
-```bash
-railway sandbox fork --private-network --domain preview:8080
-```
-
-For a public server that must not idle out, also disable the idle timeout on Hobby or Pro:
-
-```bash
-railway sandbox create \
-  --private-network --domain app:8080 --idle-timeout-minutes 0
-```
-
-The sandbox consumes billable resources until you destroy it with `railway sandbox destroy`, which also removes its routes. See [Public domains](/sandboxes#public-domains) for SDK and API usage.
-
-To reach a sandbox's port from your own machine, use [`railway sandbox forward`](#forward-a-port-into-the-active-sandbox).
+See [Public domains](/sandboxes#public-domains) for limits. For a long-running server, add [`--idle-timeout-minutes 0`](#create-a-sandbox-without-an-idle-timeout). To access a port locally without publishing a domain, use [`railway sandbox forward`](#forward-a-port-into-the-active-sandbox).
 
 ## Common options
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -471,7 +471,16 @@ You can request up to 10 domains per sandbox. Ports must be integers from 1 to 6
 
 `sandbox.domains` contains `{ prefix, port, domain }` for each published route, or an empty array when there are none. `Sandbox.connect()`, `Sandbox.list()`, and `sandbox.refresh()` read back this metadata. The dashboard also shows the domains on the sandbox's detail page. Destroying a sandbox removes its routes.
 
-In the GraphQL API, pass the same domain entries as `SandboxCreateInput.publicDomains`, and select `domains { prefix port domain }` on the result. The CLI has no sandbox domain creation flag, so use the SDK or API to publish routes.
+In the CLI, pass `--domain [PREFIX:]PORT` with `--private-network` when creating or forking a sandbox:
+
+```bash
+railway sandbox create --private-network --domain 8080 --domain api:3000
+railway sandbox list
+```
+
+Creation can return before routes are published. Use `railway sandbox list` to read the URLs once ready. See [CLI public domains](/cli/sandbox#public-domains) for flags, output, and fork examples.
+
+In the GraphQL API, pass the same domain entries as `SandboxCreateInput.publicDomains`, and select `domains { prefix port domain }` on the result.
 
 For a long-running public server, also [disable the idle timeout](#disable-the-idle-timeout) on a supported plan. Public domains require private networking, so the sandbox can also reach your environment's internal services.
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -5,7 +5,7 @@ description: Provision ephemeral, isolated Linux environments on Railway. Create
 
 <Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
 
-Sandboxes are short-lived Linux environments you can provision on demand, run commands in, and destroy.
+Sandboxes are isolated Linux environments you can provision on demand, run commands in, and destroy. Use an idle timeout for short-lived work, or disable it for a [long-running sandbox](#disable-the-idle-timeout).
 
 Each sandbox is scoped to a Railway [environment](/environments) and runs on Railway's virtual machine primitive, giving you isolated, on-demand compute for anything you'd run on a VM.
 
@@ -15,7 +15,7 @@ Each sandbox is a programmatically controllable, fully isolated virtual machine.
 
 ## Dashboard
 
-Navigate to the **Sandboxes** tab in your project to view, create, and destroy sandboxes.
+Navigate to the **Sandboxes** tab in your project to view, create, and destroy sandboxes. A sandbox's detail page shows its [public domains](#public-domains), with a link and target port for each published route.
 
 You can SSH into a running sandbox directly without leaving the dashboard. If you have SSH keys configured in your Railway account, you can also copy the SSH command from the dashboard to use in your terminal of choice.
 
@@ -301,7 +301,7 @@ const fork = await base.fork();
 await fork.exec("npm test"); // sees the installed dependencies, isolated from base
 ```
 
-`Sandbox.create(source)` is equivalent to `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes` or `networkIsolation` to set them on the fork, which doesn't inherit them from the source.
+`Sandbox.create(source)` is equivalent to `source.fork()`. The source must be `RUNNING`, and the fork is created in the same environment. Pass `idleTimeoutMinutes`, `networkIsolation`, or `domains` to configure the fork. It doesn't inherit these settings from the source, including a disabled idle timeout or published domains.
 
 ### Checkpoints
 
@@ -359,7 +359,7 @@ const sandbox = await Sandbox.create({
 
 `region` places the sandbox in one of Railway's [regions](/deployments/regions), using the region identifier listed there, for example `us-east4-eqdc4a`. Without it, the sandbox runs in US West (`us-west2`), regardless of your account's preferred region. Read the placement back from `sandbox.region`. `create` and `fork` both accept `region`. A fork doesn't inherit the source's region, so pass `region` explicitly to place a fork alongside its source. The CLI has no region flag, so use the SDK or the API to choose a region.
 
-`idleTimeoutMinutes` sets how long a sandbox can sit [idle](#idle-timeout) before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses the plan default. The default and allowed range depend on your plan, so see [Idle timeout](#idle-timeout) for the per-plan values.
+`idleTimeoutMinutes` sets how long a sandbox can sit [idle](#idle-timeout) before Railway automatically destroys it. Set it high enough to cover the gaps between steps in reconnect workflows, and low enough to avoid paying for idle compute. Without it, the sandbox uses the plan default. Set it to `0` to [disable idle destruction](#disable-the-idle-timeout) on Hobby and Pro. See [Idle timeout](#idle-timeout) for the per-plan defaults and finite ranges.
 
 `env` bakes environment variables into the sandbox, available to every command over both `exec` and SSH for the sandbox's lifetime. Use it for values a command needs at runtime, including secrets. Values can reference other Railway variables, for example `${{shared.NPM_TOKEN}}`, resolved when the sandbox is created. `create` and `fork` both accept `env`, and a fork doesn't inherit the source's variables.
 
@@ -388,14 +388,12 @@ Only sandboxes in the `CREATING` or `RUNNING` state count toward the cap. Destro
 
 ## Timeouts and output
 
-A sandbox enforces an idle timeout: how long it can sit idle before Railway destroys it. Commands have a separate, optional timeout.
+By default, Railway destroys a sandbox after its idle timeout expires. Hobby and Pro workspaces can disable this timeout. Commands have a separate, optional timeout.
 
-| Limit | Default | Maximum |
-|-------|---------|---------|
-| Idle timeout (Hobby and Pro) | 30 minutes | 120 minutes |
-| Idle timeout (Trial and Free) | 5 minutes | 5 minutes |
-
-The idle timeout default and maximum depend on your plan, as shown above.
+| Plan           | Default idle timeout | Finite idle timeout range | Disable idle timeout        |
+| -------------- | -------------------- | ------------------------- | --------------------------- |
+| Hobby and Pro  | 30 minutes           | 1 to 120 minutes          | Set `idleTimeoutMinutes: 0` |
+| Trial and Free | 5 minutes            | 1 to 5 minutes            | Not available               |
 
 In the CLI, `railway sandbox exec` streams output live and runs the command until it exits, unless you pass `--timeout <SECONDS>`, a client-side deadline. When the deadline expires, the command receives `SIGTERM` and `exec` exits with code 124. Use `--detach` to start a command in the background and get a session name back, then `--session <name>` to reattach later. In the SDK, a command has no timeout unless you set `timeoutSec`, so [long-running commands](#long-running-commands) keep going until they exit. The `truncated` field on an exec result reports when captured output was cut short.
 
@@ -403,9 +401,28 @@ In the CLI, `railway sandbox exec` streams output live and runs the command unti
 
 A sandbox is considered idle when you haven't interacted with it for longer than its idle timeout. Interacting means running a command (`exec`) or sending a command over an SSH session. Every interaction resets the timer, so the countdown always starts from your most recent interaction.
 
-The idle timeout only counts your interactions with the sandbox, not anything running inside it. A process, server, or job running in the sandbox doesn't keep it alive on its own. Once a sandbox stays idle past its timeout, Railway shuts it down automatically.
+With a finite idle timeout, a process, server, or job running in the sandbox doesn't keep it alive on its own. Once a sandbox stays idle past its timeout, Railway destroys it automatically. Publishing a domain doesn't disable the idle timeout.
 
 Set the idle timeout with `idleTimeoutMinutes` in the SDK or `--idle-timeout-minutes` in the CLI. On the Hobby and Pro plans it defaults to 30 minutes and can be set from 1 to 120 minutes. On the Trial and Free plans it defaults to 5 minutes and can be set from 1 to 5 minutes. Setting a value above your plan's maximum returns an error.
+
+### Disable the idle timeout
+
+On Hobby and Pro, set `idleTimeoutMinutes: 0` to disable automatic destruction due to inactivity. This is the infinite TTL option. Omit the value to use the plan default instead.
+
+```ts
+const sandbox = await Sandbox.create({ idleTimeoutMinutes: 0 });
+
+// Later, when the sandbox is no longer needed:
+await sandbox.destroy();
+```
+
+In the CLI, use `railway sandbox create --idle-timeout-minutes 0`. You can also pass this option when forking or creating from a template or checkpoint. Forks and checkpoint restores don't inherit the source's idle timeout, so pass `0` again if they must not idle out.
+
+The API accepts any `idleTimeoutMinutes` value less than or equal to `0` and normalizes it to `0`. Trial and Free plans reject these values. Positive values must stay within your plan's finite range.
+
+Read the setting from `sandbox.idleTimeoutMinutes`. A value of `0` means idle destruction is disabled. `null` means the setting is unknown, including for a destroyed sandbox.
+
+A sandbox with idle destruction disabled continues consuming billable resources until you destroy it. `destroy()` and `await using` still tear it down, and `timeoutSec` deadlines on exec commands remain separate from the sandbox's lifetime.
 
 ## Networking
 
@@ -429,9 +446,38 @@ In the CLI, pass `--private-network` to `railway sandbox create` or `railway san
 
 Neither mode changes how you drive a sandbox. To run commands, use `exec` or SSH, and to move files in and out, use the [files API](#files).
 
+### Public domains
+
+Publish Railway-provided HTTP domains when you create a sandbox to make its servers reachable over HTTPS. You must explicitly set `networkIsolation: "PRIVATE"`. Omitting the network mode or selecting `ISOLATED` rejects a request with domains.
+
+```ts
+const sandbox = await Sandbox.create({
+  networkIsolation: "PRIVATE",
+  domains: [{ port: 8080 }, { prefix: "api", port: 3000 }],
+});
+
+for (const { prefix, port, domain } of sandbox.domains) {
+  console.log(`${prefix}: https://${domain} -> port ${port}`);
+}
+```
+
+Configure each HTTP server to listen on `0.0.0.0` and its requested port. Publishing a route doesn't start a server for you. Railway generates the hostname and handles HTTPS at the public endpoint.
+
+Each domain needs a target `port`. If you omit `prefix`, Railway generates a DNS-safe prefix from the project name and makes it unique within the request. Explicit prefixes must contain 1 to 46 lowercase letters, digits, or hyphens, with no leading or trailing hyphen.
+
+You can request up to 10 domains per sandbox. Ports must be integers from 1 to 65535, and both ports and prefixes must be unique within a sandbox's request.
+
+`domains` is a creation-time option for `Sandbox.create()`, including template and checkpoint creation, and `fork()`. Forks don't inherit the source's domains. Pass `domains` and `networkIsolation: "PRIVATE"` again to publish routes on a fork. You can't add or change domains on an existing sandbox.
+
+`sandbox.domains` contains `{ prefix, port, domain }` for each published route, or an empty array when there are none. `Sandbox.connect()`, `Sandbox.list()`, and `sandbox.refresh()` read back this metadata. The dashboard also shows the domains on the sandbox's detail page. Destroying a sandbox removes its routes.
+
+In the GraphQL API, pass the same domain entries as `SandboxCreateInput.publicDomains`, and select `domains { prefix port domain }` on the result. The CLI has no sandbox domain creation flag, so use the SDK or API to publish routes.
+
+For a long-running public server, also [disable the idle timeout](#disable-the-idle-timeout) on a supported plan. Public domains require private networking, so the sandbox can also reach your environment's internal services.
+
 ### Reaching a port in a sandbox
 
-A sandbox has no public endpoint. Railway doesn't assign it a domain or a TCP proxy, so a server inside a sandbox isn't reachable from the internet.
+Use SSH port forwarding to reach a sandbox from your machine without publishing a domain. It works with either network mode.
 
 To reach that server from your machine, forward its port with [`railway sandbox forward`](/cli/sandbox#forward-a-port-into-the-active-sandbox), which maps `localhost:3000` to port 3000 in the sandbox:
 
@@ -441,7 +487,7 @@ railway sandbox forward 3000
 
 Forwarding runs over SSH, so it needs an SSH key on your Railway account. Add one at [Account Settings -> SSH Keys](https://railway.com/account/ssh-keys).
 
-To serve traffic on a public URL, deploy a [service](/services) and give it a [public domain](/networking/public-networking).
+For a public HTTP URL, configure [public domains](#public-domains) when you create the sandbox.
 
 ## Pricing
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -407,22 +407,15 @@ Set the idle timeout with `idleTimeoutMinutes` in the SDK or `--idle-timeout-min
 
 ### Disable the idle timeout
 
-On Hobby and Pro, set `idleTimeoutMinutes: 0` to disable automatic destruction due to inactivity. This is the infinite TTL option. Omit the value to use the plan default instead.
+On Hobby and Pro, set `idleTimeoutMinutes: 0` for an infinite TTL:
 
 ```ts
 const sandbox = await Sandbox.create({ idleTimeoutMinutes: 0 });
-
-// Later, when the sandbox is no longer needed:
-await sandbox.destroy();
 ```
 
-In the CLI, use `railway sandbox create --idle-timeout-minutes 0`. You can also pass this option when forking or creating from a template or checkpoint. Forks and checkpoint restores don't inherit the source's idle timeout, so pass `0` again if they must not idle out.
+In the CLI, pass `--idle-timeout-minutes 0` to `create` or `fork`. This also works with templates and checkpoints. Forks and checkpoint restores don't inherit the source's timeout, so pass `0` again when needed.
 
-The API accepts any `idleTimeoutMinutes` value less than or equal to `0` and normalizes it to `0`. Trial and Free plans reject these values. Positive values must stay within your plan's finite range.
-
-Read the setting from `sandbox.idleTimeoutMinutes`. A value of `0` means idle destruction is disabled. `null` means the setting is unknown, including for a destroyed sandbox.
-
-A sandbox with idle destruction disabled continues consuming billable resources until you destroy it. `destroy()` and `await using` still tear it down, and `timeoutSec` deadlines on exec commands remain separate from the sandbox's lifetime.
+The sandbox remains billable until you destroy it with `destroy()`, `await using`, or `railway sandbox destroy`. Exec timeouts remain separate. Omit the idle timeout to use your plan's default.
 
 ## Networking
 
@@ -448,7 +441,7 @@ Neither mode changes how you drive a sandbox. To run commands, use `exec` or SSH
 
 ### Public domains
 
-Publish Railway-provided HTTP domains when you create a sandbox to make its servers reachable over HTTPS. You must explicitly set `networkIsolation: "PRIVATE"`. Omitting the network mode or selecting `ISOLATED` rejects a request with domains.
+Pass `domains` with `networkIsolation: "PRIVATE"` when creating a sandbox to publish its HTTP servers on Railway-provided HTTPS domains:
 
 ```ts
 const sandbox = await Sandbox.create({
@@ -456,33 +449,18 @@ const sandbox = await Sandbox.create({
   domains: [{ port: 8080 }, { prefix: "api", port: 3000 }],
 });
 
-for (const { prefix, port, domain } of sandbox.domains) {
-  console.log(`${prefix}: https://${domain} -> port ${port}`);
-}
+console.log(sandbox.domains); // [{ prefix, port, domain }, ...]
 ```
 
-Configure each HTTP server to listen on `0.0.0.0` and its requested port. Publishing a route doesn't start a server for you. Railway generates the hostname and handles HTTPS at the public endpoint.
+Start each server on `0.0.0.0` and its requested port. Railway handles HTTPS; publishing a domain doesn't start a server or disable the [idle timeout](#disable-the-idle-timeout). Destroying the sandbox removes its routes.
 
-Each domain needs a target `port`. If you omit `prefix`, Railway generates a DNS-safe prefix from the project name and makes it unique within the request. Explicit prefixes must contain 1 to 46 lowercase letters, digits, or hyphens, with no leading or trailing hyphen.
+You can request up to 10 domains, with unique ports from 1 to 65535. Omitted prefixes are generated from the project name. Explicit prefixes must be unique and contain 1 to 46 lowercase letters, digits, or hyphens, with no leading or trailing hyphen.
 
-You can request up to 10 domains per sandbox. Ports must be integers from 1 to 65535, and both ports and prefixes must be unique within a sandbox's request.
+Domains are set only at creation, including templates, checkpoints, and forks. Forks don't inherit them; pass `domains` and `networkIsolation: "PRIVATE"` again. You can't change domains on an existing sandbox.
 
-`domains` is a creation-time option for `Sandbox.create()`, including template and checkpoint creation, and `fork()`. Forks don't inherit the source's domains. Pass `domains` and `networkIsolation: "PRIVATE"` again to publish routes on a fork. You can't add or change domains on an existing sandbox.
+`sandbox.domains` contains `{ prefix, port, domain }` for each published route. Read it through `Sandbox.connect()`, `Sandbox.list()`, or `sandbox.refresh()`, or view the URLs in the dashboard.
 
-`sandbox.domains` contains `{ prefix, port, domain }` for each published route, or an empty array when there are none. `Sandbox.connect()`, `Sandbox.list()`, and `sandbox.refresh()` read back this metadata. The dashboard also shows the domains on the sandbox's detail page. Destroying a sandbox removes its routes.
-
-In the CLI, pass `--domain [PREFIX:]PORT` with `--private-network` when creating or forking a sandbox:
-
-```bash
-railway sandbox create --private-network --domain 8080 --domain api:3000
-railway sandbox list
-```
-
-Creation can return before routes are published. Use `railway sandbox list` to read the URLs once ready. See [CLI public domains](/cli/sandbox#public-domains) for flags, output, and fork examples.
-
-In the GraphQL API, pass the same domain entries as `SandboxCreateInput.publicDomains`, and select `domains { prefix port domain }` on the result.
-
-For a long-running public server, also [disable the idle timeout](#disable-the-idle-timeout) on a supported plan. Public domains require private networking, so the sandbox can also reach your environment's internal services.
+In the CLI, use [`--domain [PREFIX:]PORT` with `--private-network`](/cli/sandbox#public-domains). In GraphQL, pass `SandboxCreateInput.publicDomains` and select `domains { prefix port domain }`. The array is empty until routes are published.
 
 ### Reaching a port in a sandbox
 


### PR DESCRIPTION
Documents sandbox public domains and disabled idle timeouts across the sandbox and CLI references. Covers SDK/API configuration, CLI create/fork flags and output, domain limits, dashboard links, plan eligibility, billing, and cleanup.

Includes commands from [CLI #1197](https://github.com/railwayapp/cli/pull/1197). Merge after that CLI change is released.

Verified against [mono #37884](https://github.com/railwayapp/mono/pull/37884), [#37389](https://github.com/railwayapp/mono/pull/37389), [#38075](https://github.com/railwayapp/mono/pull/38075), and live CLI tests covering HTTPS routing, fork isolation, infinite idle timeout, and cleanup. The docs production build passed with 399 generated pages.
