### PR TITLE
Document sandbox general availability

### DIFF
--- a/content/docs/cli/sandbox.md
+++ b/content/docs/cli/sandbox.md
@@ -5,8 +5,6 @@ description: Manage ephemeral sandboxes.
 
 Create, connect to, run commands in, forward ports into, and destroy ephemeral [sandboxes](/sandboxes) in a Railway environment.
 
-<Banner variant="info">The `sandbox` command requires sandboxes to be enabled for your account through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. It's under active development, and its commands and flags may change in breaking ways.</Banner>
-
 ## Usage
 
 ```bash

--- a/content/docs/cloud-agents.md
+++ b/content/docs/cloud-agents.md
@@ -88,7 +88,7 @@ Deploy a [Railway service](/services) for production traffic.
 
 A running agent bills for compute while it is awake, including when no client is connected. Sleeping stops compute billing and keeps the disk. Coding-provider usage follows your provider's account or API billing separately.
 
-See [VM pricing](/pricing/plans#vm-pricing-beta) for current rates, and [manage agents](/cloud-agents/manage#sleep-wake-and-delete) for lifecycle commands.
+See [VM pricing](/pricing/plans#vm-pricing) for current rates, and [manage agents](/cloud-agents/manage#sleep-wake-and-delete) for lifecycle commands.
 
 ## Specs and limits
 

--- a/content/docs/pricing/plans.md
+++ b/content/docs/pricing/plans.md
@@ -74,8 +74,6 @@ Workloads that run on Railway's virtual machine primitive, such as [sandboxes](/
 | **CPU**            | $50 / vCPU / month ($0.001157 / vCPU / minute) |
 | **Network Egress** | $0.05 / GB                                     |
 
-[Sandboxes](/sandboxes) are generally available. No Priority Boarding opt-in is required.
-
 ## Included usage
 
 The Hobby plan includes $5 of resource usage per month.

--- a/content/docs/pricing/plans.md
+++ b/content/docs/pricing/plans.md
@@ -62,7 +62,9 @@ You are only charged for the resources you actually use, which helps prevent run
 
 To learn more about controlling your resource usage costs, read the FAQ on [How do I prevent spending more than I want to?](/pricing/faqs#how-do-i-prevent-spending-more-than-i-want-to)
 
-### VM pricing (Beta)
+<span id="vm-pricing-beta" />
+
+### VM pricing
 
 Workloads that run on Railway's virtual machine primitive, such as [sandboxes](/sandboxes), are billed at VM rates. You are only charged for the resources a VM consumes while it runs.
 
@@ -72,7 +74,7 @@ Workloads that run on Railway's virtual machine primitive, such as [sandboxes](/
 | **CPU**            | $50 / vCPU / month ($0.001157 / vCPU / minute) |
 | **Network Egress** | $0.05 / GB                                     |
 
-VMs are in beta and available through [Priority Boarding](/platform/priority-boarding).
+[Sandboxes](/sandboxes) are generally available. No Priority Boarding opt-in is required.
 
 ## Included usage
 

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -3,8 +3,6 @@ title: Sandboxes
 description: Provision ephemeral, isolated Linux environments on Railway. Create them from the dashboard, CLI, or TypeScript SDK, run commands in them, read and write their files, and tear them down when done.
 ---
 
-Sandboxes are generally available. No Priority Boarding opt-in is required.
-
 Sandboxes are short-lived Linux environments you can provision on demand, run commands in, and destroy.
 
 Each sandbox is scoped to a Railway [environment](/environments) and runs on Railway's virtual machine primitive, giving you isolated, on-demand compute for anything you'd run on a VM.

--- a/content/docs/sandboxes.md
+++ b/content/docs/sandboxes.md
@@ -3,7 +3,7 @@ title: Sandboxes
 description: Provision ephemeral, isolated Linux environments on Railway. Create them from the dashboard, CLI, or TypeScript SDK, run commands in them, read and write their files, and tear them down when done.
 ---
 
-<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
+Sandboxes are generally available. No Priority Boarding opt-in is required.
 
 Sandboxes are short-lived Linux environments you can provision on demand, run commands in, and destroy.
 
@@ -24,8 +24,6 @@ To add SSH keys to your account, go to [Account Settings -> SSH Keys](https://ra
 ## TypeScript SDK
 
 The SDK is the primary interface for working with sandboxes programmatically. It's <a href="https://github.com/railwayapp/railway-ts-sdk" target="_blank">open source on GitHub</a>.
-
-**Note:** The SDK is under active development while sandboxes are in Priority Boarding, and its API may change in breaking ways between releases.
 
 ### Installation
 

--- a/content/guides/agents-in-sandboxes.md
+++ b/content/guides/agents-in-sandboxes.md
@@ -10,8 +10,6 @@ tags:
 topic: ai
 ---
 
-<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
-
 A [sandbox](/sandboxes) is a short-lived, isolated Linux environment you provision on demand, run commands in, and destroy. This guide covers how to fold sandboxes into your development loop and let agents do real work inside them.
 
 Two layers of agents come together here. Your local agent, like Claude Code or Codex running on your laptop, drives sandboxes through the [Railway CLI](/cli) or the [TypeScript SDK](/sandboxes#typescript-sdk). Inside the sandbox, the same agent harnesses ship in the default image, so the environment can run untrusted code, test against your real infrastructure, and do the work without you bootstrapping a toolchain each time.
@@ -47,7 +45,7 @@ The point of the loop is that an agent doesn't rebuild the world every time. It 
 
 ## Prerequisites
 
-- A Railway account with [Sandboxes](/sandboxes) enabled through [Priority Boarding](/platform/priority-boarding).
+- A Railway account with access to the project and environment where you will create [sandboxes](/sandboxes).
 - The [Railway CLI](/cli) installed and logged in with `railway login`.
 - A project linked with `railway link`.
 - Node.js 22+ if you plan to use the [TypeScript SDK](/sandboxes#typescript-sdk).

--- a/content/guides/code-execution-sandboxes.md
+++ b/content/guides/code-execution-sandboxes.md
@@ -10,8 +10,6 @@ tags:
 topic: ai
 ---
 
-<Banner variant="primary">Sandboxes are available through <a href="/platform/priority-boarding" target="_blank">Priority Boarding</a>. Breaking changes may occur.</Banner>
-
 A code-execution sandbox is an isolated, short-lived environment where an AI agent can run code without putting anything else at risk. The agent writes code, the sandbox executes it, the results come back, and the environment is destroyed. Nothing the code does inside the sandbox touches your machine, your production services, or the next task's sandbox.
 
 In this guide we cover why agents need sandboxes, what a sandbox has to provide, and how to run one on Railway.


### PR DESCRIPTION
Remove sandbox beta and Priority Boarding access messaging from current documentation, without changing VM prices or SDK behavior. Rename the VM pricing section, preserve its old anchor, and update the Cloud Agents link.

- Update the sandbox overview, CLI reference, code execution guide, agents guide, and pricing page.
- Production docs build passes; both pricing anchors are present.
- Publish after https://github.com/railwayapp/mono/pull/39056 is deployed.
